### PR TITLE
Print out the fucking command before running it

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ E: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)
 E: Unable to lock the administration directory (/var/lib/dpkg/), are you root?
 
 ➜ fuck
-[sudo] password for nvbn: 
+sudo apt-get install vim
+[sudo] password for nvbn:
 Reading package lists... Done
 ...
 
@@ -24,6 +25,7 @@ To push the current branch and set the remote as upstream, use
 
 
 ➜ fuck
+git push --set-upstream origin master
 Counting objects: 9, done.
 ...
 
@@ -34,6 +36,7 @@ No command 'puthon' found, did you mean:
 zsh: command not found: puthon
 
 ➜ fuck
+python
 Python 3.4.2 (default, Oct  8 2014, 13:08:17)
 ...
 
@@ -44,6 +47,7 @@ Did you mean this?
 	branch
 
 ➜ fuck
+git branch
 * master
 ```
 

--- a/thefuck/main.py
+++ b/thefuck/main.py
@@ -71,6 +71,7 @@ def get_matched_rule(command, rules, settings):
 def run_rule(rule, command, settings):
     """Runs command from rule for passed command."""
     new_command = rule.get_new_command(command, settings)
+    sys.stderr.write(new_command + '\n')
     print(new_command)
 
 


### PR DESCRIPTION
This makes thefuck act similar to fixing commands with either `!!` or `fc`, and I think helps to remove some of the "magic". For example, I use `sudo !!` all day long when on I'm linux systems:

```
$ apt-get install something
E: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)
E: Unable to lock the administration directory (/var/lib/dpkg/), are you root?
$ sudo !!
sudo apt-get install something
[sudo] password for test:
```