### PR TITLE
Adds rule for cd.. and .gitignore for vim tmp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 
 .env
 .idea
+
+# vim temporary files
+.*.swp

--- a/thefuck/rules/cd_parent.py
+++ b/thefuck/rules/cd_parent.py
@@ -1,0 +1,14 @@
+# Adds the missing space between the cd command and the target directory
+# when trying to cd to the parent directory.
+#
+# Does not really save chars, but is fun :D
+#
+# Example:
+# > cd..
+# cd..: command not found
+
+def match(command, settings):
+    return command.script == 'cd..'
+
+def get_new_command(command, settings):
+    return 'cd ..'


### PR DESCRIPTION
I guess cd.. is a very common typo which can easily be handled using the attached fuck rule.