### PR TITLE
Improved installation instructions - easy_install instead of pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ git branch
 Install `The Fuck`:
 
 ```bash
-sudo pip install thefuck
+sudo easy_install thefuck
 ```
 
 And add to `.bashrc` or `.zshrc`:


### PR DESCRIPTION
`sudo pip install` fucks everything up and depends on `pip`. You want `easy_install`. Trust me.