### PR TITLE
Improve no_command

### DIFF
--- a/tests/rules/test_no_command.py
+++ b/tests/rules/test_no_command.py
@@ -50,8 +50,7 @@ def bin_might_exist(request):
 @pytest.fixture
 def patch_history(request):
     def side_effect(name):
-        print("history('{}')".format(name))
-        count = 2 if name == 'not-really-used' else 12
+        return 2 if name == 'not-really-used' else 12
     p = patch('thefuck.rules.no_command._count_history_uses',
               side_effect = side_effect)
     p.start()

--- a/tests/rules/test_no_command.py
+++ b/tests/rules/test_no_command.py
@@ -9,7 +9,19 @@ from thefuck.main import Command
 def command_found():
     return b'''No command 'aptget' found, did you mean:
  Command 'apt-get' from package 'apt' (main)
+ Command 'not-installed' from package 'derp' (main)
+ Command 'not-really-used' from package 'whatever' (main)
 aptget: command not found
+'''
+
+@pytest.fixture
+def uninstalled_command_found():
+    return b'''No command 'pish' found, did you mean:
+ Command 'vish' from package 'vish' (universe)
+ Command 'wish' from package 'tk' (main)
+ Command 'fish' from package 'fish' (universe)
+ Command 'pdsh' from package 'pdsh' (universe)
+pish: command not found
 '''
 
 @pytest.fixture
@@ -18,13 +30,33 @@ def command_not_found():
 vom: command not found
 '''
 
-
 @pytest.fixture
 def bins_exists(request):
     p = patch('thefuck.rules.no_command.which',
               return_value=True)
     p.start()
     request.addfinalizer(p.stop)
+
+@pytest.fixture
+def bin_might_exist(request):
+    def side_effect(name):
+        return name in ['not-really-used', 'apt-get', '/usr/lib/command-not-found', 'test']
+    p = patch('thefuck.rules.no_command.which',
+              side_effect = side_effect)
+    p.start()
+    request.addfinalizer(p.stop)
+            
+
+@pytest.fixture
+def patch_history(request):
+    def side_effect(name):
+        print("history('{}')".format(name))
+        count = 2 if name == 'not-really-used' else 12
+    p = patch('thefuck.rules.no_command._count_history_uses',
+              side_effect = side_effect)
+    p.start()
+    request.addfinalizer(p.stop)
+    
 
 
 @pytest.fixture
@@ -34,8 +66,8 @@ def settings():
     return _Settings
 
 
-@pytest.mark.usefixtures('bins_exists')
-def test_match(command_found, command_not_found, settings):
+@pytest.mark.usefixtures('bin_might_exist', 'patch_history')
+def test_match(command_found, command_not_found, uninstalled_command_found, settings):
     with patch('thefuck.rules.no_command.Popen') as Popen:
         Popen.return_value.stderr.read.return_value = command_found
         assert match(Command('aptget install vim', '', ''), settings)
@@ -51,8 +83,11 @@ def test_match(command_found, command_not_found, settings):
         Popen.assert_called_with('test aptget',
                                       shell=True, stderr=PIPE)
 
+    with patch('thefuck.rules.no_command.Popen') as Popen:
+        Popen.return_value.stderr.read.return_value = uninstalled_command_found
+        assert not match(Command('pish bla blah', '', ''), settings)
 
-@pytest.mark.usefixtures('bins_exists')
+@pytest.mark.usefixtures('bin_might_exist', 'patch_history')
 def test_get_new_command(command_found):
     with patch('thefuck.rules.no_command._get_output',
                return_value=command_found.decode()):

--- a/tests/rules/test_no_command.py
+++ b/tests/rules/test_no_command.py
@@ -39,7 +39,7 @@ def test_match(command_found, command_not_found, settings):
     with patch('thefuck.rules.no_command.Popen') as Popen:
         Popen.return_value.stderr.read.return_value = command_found
         assert match(Command('aptget install vim', '', ''), settings)
-        Popen.assert_called_once_with('/usr/lib/command-not-found aptget',
+        Popen.assert_called_with('/usr/lib/command-not-found aptget',
                                       shell=True, stderr=PIPE)
         Popen.return_value.stderr.read.return_value = command_not_found
         assert not match(Command('ls', '', ''), settings)
@@ -48,7 +48,7 @@ def test_match(command_found, command_not_found, settings):
         Popen.return_value.stderr.read.return_value = command_found
         assert match(Command('sudo aptget install vim', '', ''),
                      Mock(command_not_found='test'))
-        Popen.assert_called_once_with('test aptget',
+        Popen.assert_called_with('test aptget',
                                       shell=True, stderr=PIPE)
 
 

--- a/thefuck/rules/no_command.py
+++ b/thefuck/rules/no_command.py
@@ -12,9 +12,10 @@ def _get_output(command, settings):
     return result.stderr.read().decode()
 
 def _count_history_uses(name):
-    script = 'history | grep {}'.format(name)
-    result = Popen(script, shell=True, stdout=PIPE)
-    return len(list(result.stdout))
+    script = "history | egrep '\\b{}\\b' | wc -l".format(name)
+    result = Popen(script, shell=True,
+                   stdout=PIPE)
+    return int(result.stdout.read())
 
 def _get_candidate_commands(command, settings):
     output = _get_output(command, settings)
@@ -40,6 +41,6 @@ def get_new_command(command, settings):
     broken_name = re.findall(r"No command '([^']*)' found",
                              output)[0]
     candidates = _get_candidate_commands(command, settings)
-    fixed_name = sorted(candidates, key=_count_history_uses)[0]
+    fixed_name = sorted(candidates, key=_count_history_uses, reverse=True)[0]
     return command.script.replace(broken_name, fixed_name)
      

--- a/thefuck/rules/no_command.py
+++ b/thefuck/rules/no_command.py
@@ -22,7 +22,7 @@ def _get_candidate_commands(command, settings):
     if "No command" in output and "from package" in output:
         fixed_names = re.findall(r"Command '([^']*)' from package",
                             output)
-        return filter(which, fixed_names)
+        return [name for name in fixed_names if which(name)]
     return []
         
 


### PR DESCRIPTION
This PR fixes a couple of limitations of the no_command rule:

`/usr/lib/command-not-found` suggests commands from uninstalled packages, so we filter out commands that aren't installed. 

In many cases taking the first installed suggestion is inappropriate -- for example, if the broken command is `bish`, on my system two of the suggestions are installed: `wish` and `bash`.  Which one did I mean?  We can guess by counting the number of occurrences in my shell history:
```sh
➜  thefuck git:(improve-no-command) history | egrep '\bbash\b' | wc -l
35
➜  thefuck git:(improve-no-command) history | egrep '\bwish\b' | wc -l
3
```
which tells us that I probably want `bash` (I don't even know what `wish` is, it's just in my history because I `which`ed it and `grep`ed for it a couple of times).

I've updated the tests to check these cases and continue to work with the original cases.

   