### PR TITLE
sudo rule: add support for mtr

### DIFF
--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -1,7 +1,8 @@
 patterns = ['permission denied',
             'EACCES',
             'pkg: Insufficient privileges',
-            'you cannot perform this operation unless you are root']
+            'you cannot perform this operation unless you are root',
+            'non-root users cannot']
 
 
 def match(command, settings):


### PR DESCRIPTION
The scenario is:

```
$ mtr -i0.5 8.8.8.8
non-root users cannot request an interval < 1.0 seconds
```