### PR TITLE
Create rm_root.py

### DIFF
--- a/thefuck/rules/rm_root.py
+++ b/thefuck/rules/rm_root.py
@@ -1,6 +1,6 @@
 def match(command, settings):
-    return ('rm' in command.script
-            and '--help' not in command.script
+    return ('/' in command.script
+            and '--no-preserve-root' not in command.script
             and '--no-preserve-root' in command.stderr)
 
 

--- a/thefuck/rules/rm_root.py
+++ b/thefuck/rules/rm_root.py
@@ -1,0 +1,8 @@
+def match(command, settings):
+    return ('rm' in command.script
+            and '--help' not in command.script
+            and '--no-preserve-root' in command.stderr)
+
+
+def get_new_command(command, settings):
+    return '{} --no-preserve-root'.format(command.script)

--- a/thefuck/rules/rm_root.py
+++ b/thefuck/rules/rm_root.py
@@ -1,5 +1,5 @@
 def match(command, settings):
-    return ('/' in command.script
+    return ('/' in command.script.split()
             and '--no-preserve-root' not in command.script
             and '--no-preserve-root' in command.stderr)
 


### PR DESCRIPTION
I think that it is a very useful rule.

spycheese@scc:~$ rm -r /
rm: it is dangerous to operate recursively on ‘/’
rm: use --no-preserve-root to override this failsafe
spycheese@scc:~$ fuck
rm -r / --no-preserve-root
rm: descend into write-protected directory ‘/’? 