### PR TITLE
sudo rule: add support for "Operation not permitted" errors

### DIFF
--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -2,7 +2,8 @@ patterns = ['permission denied',
             'EACCES',
             'pkg: Insufficient privileges',
             'you cannot perform this operation unless you are root',
-            'non-root users cannot']
+            'non-root users cannot',
+            'Operation not permitted']
 
 
 def match(command, settings):


### PR DESCRIPTION
`Operation not permitted` is also a commonly seen error that could be fixed by sudo in many cases. A few examples that this PR could fix:

```
$ hping -S -p 80 127.0.0.1
[open_sockraw] socket(): Operation not permitted
[main] can't open raw socket
```

```
$ sudo touch /tmp/tmp
$ chown nobody /tmp/tmp
chown: changing ownership of ‘/tmp/tmp’: Operation not permitted
```

```
$ umount /tmp
umount: /tmp: umount failed: Operation not permitted
```