### PR TITLE
Added rule:cp_omitting_directory

### DIFF
--- a/thefuck/rules/cp_omitting_directory.py
+++ b/thefuck/rules/cp_omitting_directory.py
@@ -1,0 +1,10 @@
+def match(command, settings):
+    if 'cp: omitting directory' in command.stderr.lower():
+        return True
+    return False
+
+
+def get_new_command(command, settings):
+    return command.script.replace('cp', 'cp -r') 
+
+


### PR DESCRIPTION
An Example:

➜ cp foo1/me/ foo2/
cp: omitting directory `foo1/me/'

➜ fuck
(would copy the directory by replacing 'cp' with 'cp -r' )