### PR TITLE
Added rm -rf support

### DIFF
--- a/tests/rules/test_rm_dir.py
+++ b/tests/rules/test_rm_dir.py
@@ -1,0 +1,13 @@
+from thefuck.main import Command
+from thefuck.rules.rm_dir import match, get_new_command
+
+
+def test_match():
+    assert match(Command('rm foo', '', 'rm: foo: is a directory'), None)
+    assert not match(Command('rm foo', '', ''), None)
+    assert not match(Command('rm foo', '', 'foo bar baz'), None)
+    assert not match(Command('', '', ''), None)
+
+
+def test_get_new_command():
+    assert get_new_command(Command('rm foo', '', ''), None) == 'rm -rf foo'

--- a/thefuck/rules/rm_dir.py
+++ b/thefuck/rules/rm_dir.py
@@ -1,0 +1,9 @@
+import re
+
+def match(command, settings):
+    return ('rm' in command.script
+            and 'is a directory' in command.stderr)
+
+
+def get_new_command(command, settings):
+    return re.sub('^rm (.*)', 'rm -rf \\1', command.script)


### PR DESCRIPTION
When someone tries to remove a directory without specifying `-rf`, e.g.

    $ mkdir foo
    $ rm foo

the shell refuses to remove the directory with an error:

    rm: foo: is a directory

Instead, you need to use

    $ rm -rf foo

This rule adds fuck support for this:

    $ mkdir foo
    $ rm foo
    rm: foo: is a directory
    $ fuck
    rm -rf foo