### PR TITLE
add a rule to run the script you enter by add './' in command's prefix

### DIFF
--- a/thefuck/rules/has_exists_script.py
+++ b/thefuck/rules/has_exists_script.py
@@ -1,0 +1,9 @@
+import os
+
+def match(command, settings):
+	exist = os.path.exists(command.script)
+	return exist
+
+def get_new_command(command, settings):
+    return './{}'.format(command.script)
+


### PR DESCRIPTION
add a rule to run your command by add './' in command's prefix if the command is a file exists in your path.