### PR TITLE
A special case for 'Permission denied' error msg when trying to execute ...

### DIFF
--- a/tests/rules/test_python_command.py
+++ b/tests/rules/test_python_command.py
@@ -1,0 +1,9 @@
+from thefuck.main import Command
+from thefuck.rules.sudo import match, get_new_command
+
+def test_match():
+    assert match(Command('', '', 'Permission denied'), None)
+    assert not match(Command('', '', ''), None)
+
+def test_get_new_command():
+    assert get_new_command(Command('./test_sudo.py', '', ''), None) == 'python ./test_sudo.py'

--- a/tests/rules/test_python_command.py
+++ b/tests/rules/test_python_command.py
@@ -2,7 +2,7 @@ from thefuck.main import Command
 from thefuck.rules.python_command import match, get_new_command
 
 def test_match():
-    assert match(Command('', '', 'Permission denied'), None)
+    assert match(Command('temp.py', '', 'Permission denied'), None)
     assert not match(Command('', '', ''), None)
 
 def test_get_new_command():

--- a/tests/rules/test_python_command.py
+++ b/tests/rules/test_python_command.py
@@ -1,5 +1,5 @@
 from thefuck.main import Command
-from thefuck.rules.sudo import match, get_new_command
+from thefuck.rules.python_command import match, get_new_command
 
 def test_match():
     assert match(Command('', '', 'Permission denied'), None)

--- a/thefuck/main.py
+++ b/thefuck/main.py
@@ -51,7 +51,7 @@ def get_rules(user_dir, settings):
                             .joinpath('rules')\
                             .glob('*.py')
     user = user_dir.joinpath('rules').glob('*.py')
-    return [load_rule(rule) for rule in list(bundled) + list(user)
+    return [load_rule(rule) for rule in sorted(list(bundled)) + list(user)
             if rule.name != '__init__.py' and is_rule_enabled(settings, rule)]
 
 

--- a/thefuck/rules/python_command.py
+++ b/thefuck/rules/python_command.py
@@ -1,0 +1,12 @@
+# add 'python' suffix to the command if
+#  1) The script does not have execute permission or
+#  2) is interpreted as shell script
+
+def match(command, settings):
+  toks = command.script.split()
+  return (toks[0].endswith('.py')
+          and ('Permission denied' in command.stderr or
+               'command not found' in command.stderr))
+
+def get_new_command(command, settings):
+  return 'python ' + command.script

--- a/thefuck/rules/python_command.py
+++ b/thefuck/rules/python_command.py
@@ -4,7 +4,8 @@
 
 def match(command, settings):
   toks = command.script.split()
-  return (toks[0].endswith('.py')
+  return (len(toks) > 0
+          and toks[0].endswith('.py')
           and ('Permission denied' in command.stderr or
                'command not found' in command.stderr))
 


### PR DESCRIPTION
...a

python scripy.

The script does not have execute permission and/or does not start with !#/usr/...
In that case, pre-pend the command with 'python' keyword.

Change-Id: Idf73ee9cf0a523f51c78672188a457b2fcedc1e6