### PR TITLE
mkdir -p

### DIFF
--- a/tests/rules/test_mkdir_p.py
+++ b/tests/rules/test_mkdir_p.py
@@ -1,0 +1,13 @@
+from thefuck.main import Command
+from thefuck.rules.mkdir_p import match, get_new_command
+
+
+def test_match():
+    assert match(Command('mkdir foo/bar/baz', '', 'mkdir: foo/bar: No such file or directory'), None)
+    assert not match(Command('mkdir foo/bar/baz', '', ''), None)
+    assert not match(Command('mkdir foo/bar/baz', '', 'foo bar baz'), None)
+    assert not match(Command('', '', ''), None)
+
+
+def test_get_new_command():
+    assert get_new_command(Command('mkdir foo/bar/baz', '', ''), None) == 'mkdir -p foo/bar/baz'

--- a/thefuck/rules/mkdir_p.py
+++ b/thefuck/rules/mkdir_p.py
@@ -1,0 +1,9 @@
+import re
+
+def match(command, settings):
+    return ('mkdir' in command.script
+            and 'No such file or directory' in command.stderr)
+
+
+def get_new_command(command, settings):
+    return re.sub('^mkdir (.*)', 'mkdir -p \\1', command.script)


### PR DESCRIPTION
When adding directories using `mkdir`, intermediate directories have to
exist, unless you specify the `-p` option:

    $ mkdir foo/bar/baz
    mkdir: foo/bar: No such file or directory
    $ fuck
    mkdir -p foo/bar/baz