### PR TITLE
Added a string which could be thrown by Fedora's new dnf package manager.

### DIFF
--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -3,7 +3,8 @@ patterns = ['permission denied',
             'pkg: Insufficient privileges',
             'you cannot perform this operation unless you are root',
             'non-root users cannot',
-            'Operation not permitted']
+            'Operation not permitted',
+            'This command has to be run under the root user.']
 
 
 def match(command, settings):


### PR DESCRIPTION
"This command has to be run under the root user."