### PR TITLE
adding a rule to run "sudo apt-get install"

### DIFF
--- a/thefuck/rules/apt_get.py
+++ b/thefuck/rules/apt_get.py
@@ -1,0 +1,28 @@
+import sys
+
+def match(command, settings):
+    try:
+        import CommandNotFound
+        if 'not found' in command.stderr:
+            try:
+                c = CommandNotFound.CommandNotFound()
+                pkgs = c.getPackages(command.script.split(" ")[0])
+                name,_ = pkgs[0]
+                return True
+            except IndexError:
+                # IndexError is thrown when no matching package is found
+                return False
+    except:
+        return False
+
+def get_new_command(command, settings):
+    try:
+        import CommandNotFound
+        c = CommandNotFound.CommandNotFound()
+        if 'not found' in command.stderr:
+            pkgs = c.getPackages(command.script.split(" ")[0])
+            name,_ = pkgs[0]
+            return "sudo apt-get install %s" % name
+    except:
+        sys.stderr.write("Can't apt fuck\n")
+        return ""


### PR DESCRIPTION
A straight-forward rule; 

Catching all exceptions not to cause problems on systems without apt-get (or without CommandNotFound package)