### PR TITLE
main: enclose text with single quote in double quotes

### DIFF
--- a/thefuck/main.py
+++ b/thefuck/main.py
@@ -139,7 +139,7 @@ def main():
     command = get_command(settings, sys.argv)
     if command:
         if is_second_run(command):
-            print("echo Can't fuck twice")
+            print("echo \"Can't fuck twice\"")
             return
 
         rules = get_rules(user_dir, settings)


### PR DESCRIPTION
That single quote messes with Fish's eval:

```
$ fuck

$ fuck
fish: Could not locate end of block. The 'end' command is missing, misspelled or a ';' is missing.
/.../.config/fish/functions/fuck.fish (line 2): begin; echo Can't fuck twice
                                                               ^
in . (source) call of file '-',
	called on line 35 of file '/.../.config/fish/functions/fuck.fish',

in function 'fuck',
	called on standard input,


       begin − begin ‐ start a new block of code


begin ‐ start a new block of code
   Synopsis
# ...
```

Signed-off-by: Pablo Santiago Blum de Aguiar <scorphus@gmail.com>