### PR TITLE
fix rm dir rule to make it case insensitive

### DIFF
--- a/tests/rules/test_rm_dir.py
+++ b/tests/rules/test_rm_dir.py
@@ -4,6 +4,7 @@ from thefuck.rules.rm_dir import match, get_new_command
 
 def test_match():
     assert match(Command('rm foo', '', 'rm: foo: is a directory'), None)
+    assert match(Command('rm foo', '', 'rm: foo: Is a directory'), None)
     assert not match(Command('rm foo', '', ''), None)
     assert not match(Command('rm foo', '', 'foo bar baz'), None)
     assert not match(Command('', '', ''), None)

--- a/thefuck/rules/rm_dir.py
+++ b/thefuck/rules/rm_dir.py
@@ -5,7 +5,7 @@ from thefuck.utils import sudo_support
 @sudo_support
 def match(command, settings):
     return ('rm' in command.script
-            and 'is a directory' in command.stderr)
+            and 'is a directory' in command.stderr.lower())
 
 
 @sudo_support


### PR DESCRIPTION
In bash the output for the command `rm -f foo/` is:

    rm: cannot remove ‘foo/’: Is a directory

And not:

    rm: cannot remove ‘foo/’: is a directory