### PR TITLE
New rule: sl -> ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ using matched rule and run it. Rules enabled by default:
 * `mkdir_p` &ndash; adds `-p` when you trying to create directory without parent;
 * `no_command` &ndash; fixes wrong console commands, for example `vom/vim`;
 * `python_command` &ndash; prepends `python` when you trying to run not executable/without `./` python script;
+* `sl_ls` &ndash; changes `sl` to `ls`;
 * `rm_dir` &ndash; adds `-rf` when you trying to remove directory;
 * `ssh_known_hosts` &ndash; removes host from `known_hosts` on warning;
 * `sudo` &ndash; prepends `sudo` to previous command if it failed because of permissions;

--- a/tests/rules/test_sl_ls.py
+++ b/tests/rules/test_sl_ls.py
@@ -1,0 +1,12 @@
+
+from thefuck.types import Command
+from thefuck.rules.sl_ls import match, get_new_command
+
+
+def test_match():
+    assert match(Command('sl', '', ''), None)
+    assert not match(Command('ls', '', ''), None)
+
+
+def test_get_new_command():
+    assert get_new_command(Command('sl', '', ''), None) == 'ls'

--- a/thefuck/rules/sl_ls.py
+++ b/thefuck/rules/sl_ls.py
@@ -1,0 +1,14 @@
+"""
+This happens way too often
+
+When typing really fast cause I'm a 1337 H4X0R,
+I often fuck up 'ls' and type 'sl'. No more!
+"""
+
+
+def match(command, settings):
+    return command.script == 'sl'
+
+
+def get_new_command(command, settings):
+    return 'ls'


### PR DESCRIPTION
When typing quickly, I make this mistake all the time. This addition allows you to unfuck sl, replacing it with ls.