### PR TITLE
MacOSX specific message

### DIFF
--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -6,6 +6,7 @@ patterns = ['permission denied',
             'Operation not permitted',
             'root privilege',
             'This command has to be run under the root user.',
+            'This operation requires root.',
             'You need to be root to perform this command.']
 
 


### PR DESCRIPTION
Patch for understanding macosx message.
Example case:
```
[10:24:48][bethrezen@bethrezen-mac ~]$ apachectl graceful
This operation requires root.
[10:24:54][bethrezen@bethrezen-mac ~]$ fuck
No fuck given
```