### PR TITLE
Support brew unknown command

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ sudo pip install thefuck --upgrade
 The Fuck tries to match rule for the previous command, create new command
 using matched rule and run it. Rules enabled by default:
 
+* `brew_unknown_command` &ndash; fixes wrong brew commands, for example `brew docto/brew doctor`;
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;
 * `cp_omitting_directory` &ndash; adds `-a` when you `cp` directory;
 * `git_no_command` &ndash; fixes wrong git commands like `git brnch`;

--- a/tests/rules/test_brew_install.py
+++ b/tests/rules/test_brew_install.py
@@ -1,0 +1,49 @@
+import pytest
+from thefuck.types import Command
+from thefuck.rules.brew_install import match, get_new_command
+from thefuck.rules.brew_install import brew_formulas
+
+
+@pytest.fixture
+def brew_no_available_formula():
+    return '''Error: No available formula for elsticsearch '''
+
+
+@pytest.fixture
+def brew_install_no_argument():
+    return '''This command requires a formula argument'''
+
+
+@pytest.fixture
+def brew_already_installed():
+    return '''Warning: git-2.3.5 already installed'''
+
+
+def _is_not_okay_to_test():
+    if 'elasticsearch' not in brew_formulas:
+        return True
+    return False
+
+
+@pytest.mark.skipif(_is_not_okay_to_test(),
+                    reason='No need to run if there\'s no formula')
+def test_match(brew_no_available_formula, brew_already_installed,
+               brew_install_no_argument):
+    assert match(Command('brew install elsticsearch', '',
+                         brew_no_available_formula), None)
+    assert not match(Command('brew install git', '',
+                             brew_already_installed), None)
+    assert not match(Command('brew install', '', brew_install_no_argument),
+                     None)
+
+
+@pytest.mark.skipif(_is_not_okay_to_test(),
+                    reason='No need to run if there\'s no formula')
+def test_get_new_command(brew_no_available_formula):
+    assert get_new_command(Command('brew install elsticsearch', '',
+                                   brew_no_available_formula), None)\
+        == 'brew install elasticsearch'
+
+    assert get_new_command(Command('brew install aa', '',
+                                   brew_no_available_formula),
+                           None) != 'brew install aha'

--- a/tests/rules/test_brew_unknown_command.py
+++ b/tests/rules/test_brew_unknown_command.py
@@ -1,0 +1,28 @@
+import pytest
+from thefuck.types import Command
+from thefuck.rules.brew_unknown_command import match, get_new_command
+from thefuck.rules.brew_unknown_command import brew_commands
+
+
+@pytest.fixture
+def brew_unknown_cmd():
+    return '''Error: Unknown command: inst'''
+
+
+@pytest.fixture
+def brew_unknown_cmd_instaa():
+    return '''Error: Unknown command: instaa'''
+
+
+def test_match(brew_unknown_cmd):
+    assert match(Command('brew inst', '', brew_unknown_cmd), None)
+    for command in brew_commands:
+        assert not match(Command('brew ' + command, '', ''), None)
+
+
+def test_get_new_command(brew_unknown_cmd, brew_unknown_cmd_instaa):
+    assert get_new_command(Command('brew inst', '', brew_unknown_cmd), None)\
+        == 'brew list'
+
+    assert get_new_command(Command('brew instaa', '', brew_unknown_cmd_instaa),
+                           None) == 'brew install'

--- a/thefuck/rules/brew_install.py
+++ b/thefuck/rules/brew_install.py
@@ -1,0 +1,43 @@
+import difflib
+import os
+import re
+from subprocess import check_output
+
+import thefuck.logs
+
+# Formulars are base on each local system's status
+brew_formulas = []
+try:
+    brew_path_prefix = check_output(['brew', '--prefix']).strip()
+    brew_formula_path = brew_path_prefix + '/Library/Formula'
+
+    for file_name in os.listdir(brew_formula_path):
+        if file_name.endswith('.rb'):
+            brew_formulas.append(file_name.replace('.rb', ''))
+except:
+    pass
+
+
+def _get_similar_formulars(formula_name):
+    return difflib.get_close_matches(formula_name, brew_formulas, 1, 0.85)
+
+
+def match(command, settings):
+    is_proper_command = ('brew install' in command.script and
+                         'No available formula' in command.stderr)
+
+    has_possible_formulas = False
+    if is_proper_command:
+        formula = re.findall(r'Error: No available formula for ([a-z]+)',
+                             command.stderr)[0]
+        has_possible_formulas = len(_get_similar_formulars(formula)) > 0
+
+    return has_possible_formulas
+
+
+def get_new_command(command, settings):
+    not_exist_formula = re.findall(r'Error: No available formula for ([a-z]+)',
+                                   command.stderr)[0]
+    exist_formula = _get_similar_formulars(not_exist_formula)[0]
+
+    return command.script.replace(not_exist_formula, exist_formula, 1)

--- a/thefuck/rules/brew_unknown_command.py
+++ b/thefuck/rules/brew_unknown_command.py
@@ -1,0 +1,33 @@
+import difflib
+import re
+import thefuck.logs
+
+# This commands are based on Homebrew 0.9.5
+brew_commands = ['info', 'home', 'options', 'install', 'uninstall', 'search',
+                 'list', 'update', 'upgrade', 'pin', 'unpin', 'doctor',
+                 'create', 'edit']
+
+
+def _get_similar_commands(command):
+    return difflib.get_close_matches(command, brew_commands)
+
+
+def match(command, settings):
+    is_proper_command = ('brew' in command.script and
+                         'Unknown command' in command.stderr)
+
+    has_possible_commands = False
+    if is_proper_command:
+        broken_cmd = re.findall(r'Error: Unknown command: ([a-z]+)',
+                                command.stderr)[0]
+        has_possible_commands = len(_get_similar_commands(broken_cmd)) > 0
+
+    return has_possible_commands
+
+
+def get_new_command(command, settings):
+    broken_cmd = re.findall(r'Error: Unknown command: ([a-z]+)',
+                            command.stderr)[0]
+    new_cmd = _get_similar_commands(broken_cmd)[0]
+
+    return command.script.replace(broken_cmd, new_cmd, 1)


### PR DESCRIPTION
This also same as pip unknown command. ( issue #107 )

This patch has a command dictionary for HomeBrew 0.9.5 to recommend commands for unknown commands.