### PR TITLE
Added rule for fixing Alt+Space character

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ using matched rule and run it. Rules enabled by default:
 * `brew_unknown_command` &ndash; fixes wrong brew commands, for example `brew docto/brew doctor`;
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;
 * `cp_omitting_directory` &ndash; adds `-a` when you `cp` directory;
+* `fix_alt_space` &ndash; replaces Alt+Space with Space character;
 * `git_no_command` &ndash; fixes wrong git commands like `git brnch`;
 * `git_push` &ndash; adds `--set-upstream origin $branch` to previous failed `git push`;
 * `has_exists_script` &ndash; prepends `./` when script/binary exists;

--- a/tests/rules/test_fix_alt_space.py
+++ b/tests/rules/test_fix_alt_space.py
@@ -1,0 +1,18 @@
+# -*- encoding: utf-8 -*-
+
+
+from thefuck.types import Command
+from thefuck.rules.fix_alt_space import match, get_new_command
+
+
+def test_match():
+    """ The character before 'grep' is Alt+Space, which happens frequently on the Mac when typing
+        the pipe character (Alt+7), and holding the Alt key pressed for longer than necessary. """
+    assert match(Command(u'ps -ef | grep foo', '', u'-bash:  grep: command not found'), None)
+    assert not match(Command('ps -ef | grep foo', '', ''), None)
+    assert not match(Command('', '', ''), None)
+
+
+def test_get_new_command():
+    """ Replace the Alt+Space character by a simple space """
+    assert get_new_command(Command(u'ps -ef | grep foo', '', ''), None) == 'ps -ef | grep foo'

--- a/thefuck/rules/fix_alt_space.py
+++ b/thefuck/rules/fix_alt_space.py
@@ -1,0 +1,15 @@
+# -*- encoding: utf-8 -*-
+
+import re
+from thefuck.utils import sudo_support
+
+
+@sudo_support
+def match(command, settings):
+    return ('command not found' in command.stderr.lower()
+            and u' ' in command.script)
+
+
+@sudo_support
+def get_new_command(command, settings):
+    return re.sub(u' ', ' ', command.script)


### PR DESCRIPTION
Happens on the Mac a lot when typing a pipe character (Alt+7), and keeping the Alt key pressed down for a bit too long, so instead of Space, you're typing Alt+Space. This rule replaces the Alt+Space with a
simple Space character.

```bash
$ ps -ef | grep foo
-bash:  grep: command not found
$ fuck
ps -ef | grep foo
    502 29003  6587   0  3:18pm ttys007    0:00.00 grep --color=auto foo
```
