### PR TITLE
Fixing fish shell example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Or in `config.fish`:
 
 ```fish
 function fuck
-    eval (thefuck $history[1])
+    eval (thefuck $history[2])
 end
 ```
 


### PR DESCRIPTION
For me, at least, `$history[1]` is the currently running command, and the previous one is `$history[2]`.

Right now, the code given in the README outputs:
```
Can't fuck twice
```