### PR TITLE
Added cd_mkdir rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ using matched rule and run it. Rules enabled by default:
 
 * `brew_unknown_command` &ndash; fixes wrong brew commands, for example `brew docto/brew doctor`;
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;
+* `cd_mkdir` &ndash; creates directories before cd'ing into them;
 * `cp_omitting_directory` &ndash; adds `-a` when you `cp` directory;
 * `fix_alt_space` &ndash; replaces Alt+Space with Space character;
 * `git_no_command` &ndash; fixes wrong git commands like `git brnch`;

--- a/tests/rules/test_cd_mkdir.py
+++ b/tests/rules/test_cd_mkdir.py
@@ -1,0 +1,19 @@
+from mock import Mock
+from thefuck.rules.cd_mkdir import match, get_new_command
+
+
+def test_match():
+    assert match(Mock(script='cd foo', stderr='cd: foo: No such file or directory'),
+                 None)
+    assert match(Mock(script='cd foo/bar/baz', stderr='cd: foo: No such file or directory'),
+                 None)
+    assert match(Mock(script='cd foo/bar/baz', stderr='cd: can\'t cd to foo/bar/baz'),
+                 None)
+    assert not match(Mock(script='cd foo',
+                          stderr=''), None)
+    assert not match(Mock(script='', stderr=''), None)
+
+
+def test_get_new_command():
+    assert get_new_command(Mock(script='cd foo'), None) == 'mkdir -p foo && cd foo'
+    assert get_new_command(Mock(script='cd foo/bar/baz'), None) == 'mkdir -p foo/bar/baz && cd foo/bar/baz'

--- a/thefuck/rules/cd_mkdir.py
+++ b/thefuck/rules/cd_mkdir.py
@@ -1,0 +1,14 @@
+import re
+from thefuck.utils import sudo_support
+
+
+@sudo_support
+def match(command, settings):
+    return (command.script.startswith('cd ')
+        and ('no such file or directory' in command.stderr.lower()
+            or 'cd: can\'t cd to' in command.stderr.lower()))
+
+
+@sudo_support
+def get_new_command(command, settings):
+    return re.sub(r'^cd (.*)', 'mkdir -p \\1 && cd \\1', command.script)


### PR DESCRIPTION
This fixes #50 and #98.

```bash
$ cd foo/bar/baz
cd: foo: No such file or directory
$ fuck
mkdir -p foo/bar/baz && cd foo/bar/baz
```

Added matchers for both Bash and sh error messages. Depending on your
default shell, the messages might be slightly different.