### PR TITLE
Add tip on installing requirements on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Reading package lists... Done
 - python
 - python-dev
 
+You can install these requirements in Ubuntu with `apt-get`:
+
+```bash
+sudo apt-get install python-pip python-dev
+```
+
 ## Installation
 
 Install `The Fuck` with `pip`:


### PR DESCRIPTION
In trying to avoid that people leave the guide searching for how to install the requirements, I think it's useful to provide a simple command.

Perhaps we could add also commands for OS X and Fedora?