### PR TITLE
Adds example lines of settings.py in readme.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ The Fuck has a few settings parameters, they can be changed in `~/.thefuck/setti
 * `require_confirmation` &ndash; require confirmation before running new command, by default `False`;
 * `wait_command` &ndash; max amount of time in seconds for getting previous command output;
 * `no_colors` &ndash; disable colored output.
+ 
+These are entered into the file as seen in the following example:
+
+````
+require_confirmation='true'
+wait_command='true'
+````
+
 
 Or via environment variables:
 


### PR DESCRIPTION
To mitigate an empty settings file and as in the readme was no specification of the format, these are some sample lines on how to format the settings file