### PR TITLE
Add sudo rule for shutdown command.

### DIFF
--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -8,7 +8,8 @@ patterns = ['permission denied',
             'This command has to be run under the root user.',
             'This operation requires root.',
             'You need to be root to perform this command.',
-            'requested operation requires superuser privilege']
+            'requested operation requires superuser privilege',
+            'Need to be root']
 
 
 def match(command, settings):


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/8980971/7414822/be077eb4-ef72-11e4-97aa-6d65694e043c.png)

This rule adds the terminal output on running `shutdown` without `sudo`.
