### PR TITLE
Add a rule for pacman

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ using matched rule and run it. Rules enabled by default:
 * `lein_not_task` &ndash; fixes wrong `lein` tasks like `lein rpl`;
 * `mkdir_p` &ndash; adds `-p` when you trying to create directory without parent;
 * `no_command` &ndash; fixes wrong console commands, for example `vom/vim`;
+* `pacman` &ndash; installs app with `pacman` or `yaourt` if it is not installed;
 * `pip_unknown_command` &ndash; fixes wrong pip commands, for example `pip instatl/pip install`;
 * `python_command` &ndash; prepends `python` when you trying to run not executable/without `./` python script;
 * `sl_ls` &ndash; changes `sl` to `ls`;

--- a/thefuck/rules/pacman.py
+++ b/thefuck/rules/pacman.py
@@ -1,0 +1,42 @@
+import subprocess
+
+
+def __command_available(command):
+    try:
+        subprocess.check_output([command], stderr=subprocess.DEVNULL)
+        return True
+    except subprocess.CalledProcessError:
+        # command exists but is not happy to be called without any argument
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def __get_pkgfile(command):
+    try:
+        return subprocess.check_output(
+            ['pkgfile', '-b', '-v', command.script.split(" ")[0]],
+            universal_newlines=True, stderr=subprocess.DEVNULL
+        ).split()
+    except subprocess.CalledProcessError:
+        return None
+
+
+def match(command, settings):
+    return 'not found' in command.stderr and __get_pkgfile(command)
+
+
+def get_new_command(command, settings):
+    package = __get_pkgfile(command)[0]
+
+    return '{} -S {} && {}'.format(pacman, package, command.script)
+
+
+if not __command_available('pkgfile'):
+    enabled_by_default = False
+elif __command_available('yaourt'):
+    pacman = 'yaourt'
+elif __command_available('pacman'):
+    pacman = 'sudo pacman'
+else:
+    enabled_by_default = False


### PR DESCRIPTION
This adds a rule for `pacman`, Arch Linux's package manager.

It is similar to the *apt-get* rule. It is enabled by default only if `pkgfile` is available and prefers `yaourt` (a wrapper for `pacman`) over `pacman` itself if available.