### PR TITLE
Follow the XDG Base Directory Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Bundled, but not enabled by default:
 ## Creating your own rules
 
 For adding your own rule you should create `your-rule-name.py`
-in `~/.thefuck/rules`. The rule should contain two functions:
+in `~/.config/thefuck/rules`. The rule should contain two functions:
 
 ```python
 match(command: Command, settings: Settings) -> bool
@@ -221,7 +221,7 @@ and optional `enabled_by_default`, `requires_output` and `priority` variables.
 
 `Command` has three attributes: `script`, `stdout` and `stderr`.
 
-`Settings` is a special object filled with `~/.thefuck/settings.py` and values from env ([see more below](#settings)).
+`Settings` is a special object filled with `~/.config/thefuck/settings.py` and values from env ([see more below](#settings)).
 
 Simple example of the rule for running script with `sudo`:
 
@@ -250,7 +250,7 @@ requires_output = True
 
 ## Settings
 
-The Fuck has a few settings parameters which can be changed in `~/.thefuck/settings.py`:
+The Fuck has a few settings parameters which can be changed in `~/.config/thefuck/settings.py`:
 
 * `rules` &ndash; list of enabled rules, by default `thefuck.conf.DEFAULT_RULES`;
 * `require_confirmation` &ndash; requires confirmation before running new command, by default `True`;

--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -41,7 +41,7 @@ ENV_TO_ATTR = {'THEFUCK_RULES': 'rules',
                'THEFUCK_DEBUG': 'debug'}
 
 
-SETTINGS_HEADER = u"""# ~/.thefuck/settings.py: The Fuck settings file
+SETTINGS_HEADER = u"""# ~/.config/thefuck/settings.py: The Fuck settings file
 #
 # The rules are defined as in the example bellow:
 #

--- a/thefuck/main.py
+++ b/thefuck/main.py
@@ -13,8 +13,18 @@ from .ui import select_command
 
 
 def setup_user_dir():
-    """Returns user config dir, create it when it doesn't exist."""
+    """Returns user config dir, creates it when it doesn't exist.
+
+    Uses `~/.thefuck` if it exists, else `$XDG_CONFIG_HOME/thefuck` if it
+    exists else `~/.config/thefuck`, which is created if it does not exist.
+    """
     user_dir = Path(expanduser('~/.thefuck'))
+
+    if not user_dir.is_dir():
+        user_dir = Path(os.path.join(
+            expanduser(os.getenv("XDG_CONFIG_HOME", "~/.config")), 'thefuck'
+        ))
+
     rules_dir = user_dir.joinpath('rules')
     if not rules_dir.is_dir():
         rules_dir.mkdir(parents=True)


### PR DESCRIPTION
Namely, put configuration files in `~/.config`.

It should not break already existing configuration as `~/.thefuck` is used if it exists.