### PR TITLE
add rule for having no spaces in man commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ using matched rule and run it. Rules enabled by default:
 * `lein_not_task` &ndash; fixes wrong `lein` tasks like `lein rpl`;
 * `mkdir_p` &ndash; adds `-p` when you trying to create directory without parent;
 * `no_command` &ndash; fixes wrong console commands, for example `vom/vim`;
+* `man_no_space` &ndash; fixes man commands without spaces, for example `mandiff`;
 * `pacman` &ndash; installs app with `pacman` or `yaourt` if it is not installed;
 * `pip_unknown_command` &ndash; fixes wrong pip commands, for example `pip instatl/pip install`;
 * `python_command` &ndash; prepends `python` when you trying to run not executable/without `./` python script;
@@ -193,13 +194,13 @@ def match(command, settings):
 
 def get_new_command(command, settings):
     return 'sudo {}'.format(command.script)
-    
+
 # Optional:
 enabled_by_default = True
 
 def side_effect(command, settings):
     subprocess.call('chmod 777 .', shell=True)
-    
+
 priority = 1000  # Lower first
 ```
 

--- a/tests/rules/test_man_no_space.py
+++ b/tests/rules/test_man_no_space.py
@@ -1,0 +1,12 @@
+from thefuck.rules.man_no_space import match, get_new_command
+from tests.utils import Command
+
+
+def test_match():
+    assert match(Command('mandiff', stderr='mandiff: command not found'), None)
+    assert not match(Command(), None)
+
+
+def test_get_new_command():
+    assert get_new_command(
+        Command('mandiff'), None) == 'man diff'

--- a/thefuck/rules/man_no_space.py
+++ b/thefuck/rules/man_no_space.py
@@ -1,0 +1,9 @@
+def match(command, settings):
+    return (command.script.startswith(u'man')
+            and u'command not found' in command.stderr.lower())
+
+
+def get_new_command(command, settings):
+    return u'man {}'.format(command.script[3:])
+
+priority = 2000


### PR DESCRIPTION
As reported in #168 