### PR TITLE
Add a don't repeat yourself rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ using matched rule and run it. Rules enabled by default:
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;
 * `cd_mkdir` &ndash; creates directories before cd'ing into them;
 * `cp_omitting_directory` &ndash; adds `-a` when you `cp` directory;
+* `dry` &ndash; fix repetitions like "git git push";
 * `fix_alt_space` &ndash; replaces Alt+Space with Space character;
 * `git_add` &ndash; fix *"Did you forget to 'git add'?"*;
 * `git_no_command` &ndash; fixes wrong git commands like `git brnch`;

--- a/tests/rules/test_dry.py
+++ b/tests/rules/test_dry.py
@@ -1,0 +1,17 @@
+import pytest
+from thefuck.rules.dry import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.mark.parametrize('command', [
+    Command(script='cd cd foo'),
+    Command(script='git git push origin/master')])
+def test_match(command):
+    assert match(command, None)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('cd cd foo'), 'cd foo'),
+    (Command('git git push origin/master'), 'git push origin/master')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command, None) == new_command

--- a/thefuck/rules/dry.py
+++ b/thefuck/rules/dry.py
@@ -5,7 +5,7 @@ def match(command, settings):
 
 
 def get_new_command(command, settings):
-    return command.script[command.script.find(' '):]
+    return command.script[command.script.find(' ')+1:]
 
 # it should be rare enough to actually have to type twice the same word, so
 # this rule can have a higher priority to come before things like "cd cd foo"

--- a/thefuck/rules/dry.py
+++ b/thefuck/rules/dry.py
@@ -1,0 +1,12 @@
+def match(command, settings):
+    split_command = command.script.split()
+
+    return len(split_command) >= 2 and split_command[0] == split_command[1]
+
+
+def get_new_command(command, settings):
+    return command.script[command.script.find(' '):]
+
+# it should be rare enough to actually have to type twice the same word, so
+# this rule can have a higher priority to come before things like "cd cd foo"
+priority = 900


### PR DESCRIPTION
How often did I start typing a command, though about what I actually wanted to do and wrote that command from the start, ending with commands like `git git commit …`?

No more! This rule removes the first word in case of such repetitions.