### PR TITLE
fix(brew_unknown_command): make subprocess.check_output return str

### DIFF
--- a/thefuck/rules/brew_unknown_command.py
+++ b/thefuck/rules/brew_unknown_command.py
@@ -12,7 +12,8 @@ TAP_CMD_PATH = '/%s/%s/cmd'
 def _get_brew_path_prefix():
     """To get brew path"""
     try:
-        return subprocess.check_output(['brew', '--prefix']).strip()
+        return subprocess.check_output(['brew', '--prefix'],
+                                       universal_newlines=True).strip()
     except:
         return None
 


### PR DESCRIPTION
Fix `TypeError: can't concat bytes to str` error on Python 3.4.