### PR TITLE
Fix brew_install rule on Python 3

### DIFF
--- a/thefuck/rules/brew_install.py
+++ b/thefuck/rules/brew_install.py
@@ -6,7 +6,8 @@ from subprocess import check_output
 # Formulars are base on each local system's status
 brew_formulas = []
 try:
-    brew_path_prefix = check_output(['brew', '--prefix']).strip()
+    brew_path_prefix = check_output(['brew', '--prefix'],
+                                    universal_newlines=True).strip()
     brew_formula_path = brew_path_prefix + '/Library/Formula'
 
     for file_name in os.listdir(brew_formula_path):

--- a/thefuck/rules/brew_install.py
+++ b/thefuck/rules/brew_install.py
@@ -3,8 +3,6 @@ import os
 import re
 from subprocess import check_output
 
-import thefuck.logs
-
 # Formulars are base on each local system's status
 brew_formulas = []
 try:


### PR DESCRIPTION
With this change, the `brew_install` rule works on Python 3. Also, there are no more tests being ignored – there were two of them.