### PR TITLE
Add a `no_such_file` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `lein_not_task` &ndash; fixes wrong `lein` tasks like `lein rpl`;
 * `mkdir_p` &ndash; adds `-p` when you trying to create directory without parent;
 * `no_command` &ndash; fixes wrong console commands, for example `vom/vim`;
+* `no_such_file` &ndash; creates missing directories with `mv` and `cp` commands;
 * `man_no_space` &ndash; fixes man commands without spaces, for example `mandiff`;
 * `pacman` &ndash; installs app with `pacman` or `yaourt` if it is not installed;
 * `pip_unknown_command` &ndash; fixes wrong pip commands, for example `pip instatl/pip install`;

--- a/tests/rules/test_no_such_file.py
+++ b/tests/rules/test_no_such_file.py
@@ -1,0 +1,19 @@
+import pytest
+from thefuck.rules.no_such_file import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.mark.parametrize('command', [
+    Command(script='mv foo bar/foo', stderr="mv: cannot move 'foo' to 'bar/foo': No such file or directory"),
+    Command(script='mv foo bar/', stderr="mv: cannot move 'foo' to 'bar/': No such file or directory"),
+    ])
+def test_match(command):
+    assert match(command, None)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command(script='mv foo bar/foo', stderr="mv: cannot move 'foo' to 'bar/foo': No such file or directory"), 'mkdir -p bar && mv foo bar/foo'),
+    (Command(script='mv foo bar/', stderr="mv: cannot move 'foo' to 'bar/': No such file or directory"), 'mkdir -p bar && mv foo bar/'),
+    ])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command, None) == new_command

--- a/thefuck/rules/no_such_file.py
+++ b/thefuck/rules/no_such_file.py
@@ -3,7 +3,9 @@ import re
 
 patterns = (
     r"mv: cannot move '[^']*' to '([^']*)': No such file or directory",
+    r"mv: cannot move '[^']*' to '([^']*)': Not a directory",
     r"cp: cannot create regular file '([^']*)': No such file or directory",
+    r"cp: cannot create regular file '([^']*)': Not a directory",
 )
 
 

--- a/thefuck/rules/no_such_file.py
+++ b/thefuck/rules/no_such_file.py
@@ -1,0 +1,26 @@
+import re
+
+
+patterns = (
+    r"mv: cannot move '[^']*' to '([^']*)': No such file or directory",
+    r"cp: cannot create regular file '([^']*)': No such file or directory",
+)
+
+
+def match(command, settings):
+    for pattern in patterns:
+        if re.search(pattern, command.stderr):
+            return True
+
+    return False
+
+
+def get_new_command(command, settings):
+    for pattern in patterns:
+        file = re.findall(pattern, command.stderr)
+
+        if file:
+            file = file[0]
+            dir = file[0:file.rfind('/')]
+
+            return 'mkdir -p {} && {}'.format(dir, command.script)


### PR DESCRIPTION
Example:
```
% tree
.
└── foo

0 directories, 1 file
% mv foo bar/
mv: cannot move ‘foo’ to ‘bar/’: Not a directory
% fuck
mkdir -p bar && mv foo bar/ [enter/ctrl+c]
% tree
.
└── bar
    └── foo

1 directory, 1 file
% cp bar/foo baz/qux/fum
cp: cannot create regular file ‘baz/qux/fum’: No such file or directory
% fuck
mkdir -p baz/qux && cp bar/foo baz/qux/fum [enter/ctrl+c]
% tree
.
├── bar
│   └── foo
└── baz
    └── qux
        └── fum

3 directories, 2 files
```