### PR TITLE
Adding rule for forgotten '-r' when grepping folders

### DIFF
--- a/tests/rules/test_grep_recursive.py
+++ b/tests/rules/test_grep_recursive.py
@@ -1,0 +1,12 @@
+from thefuck.rules.grep_recursive import match, get_new_command
+from tests.utils import Command
+
+
+def test_match():
+    assert match(Command('grep blah .', stderr='grep: .: Is a directory'), None)
+    assert not match(Command(), None)
+
+
+def test_get_new_command():
+    assert get_new_command(
+        Command('grep blah .'), None) == 'grep -r blah .'

--- a/thefuck/rules/grep_recursive.py
+++ b/thefuck/rules/grep_recursive.py
@@ -1,0 +1,7 @@
+def match(command, settings):
+	return (command.script.startswith('grep')
+            and 'is a directory' in command.stderr.lower())
+
+
+def get_new_command(command, settings):
+    return 'grep -r {}'.format(command.script[5:])


### PR DESCRIPTION
I guess it's straightforward to understand what it does :)

```
igor:~$ grep "is a directory" .
grep: .: Is a directory
igor:~$ fuck
grep -r "is a directory" .
dev/thefuck/tests/rules/test_rm_dir.py:7:    Command('rm foo', stderr='rm: foo: is a directory'),
dev/thefuck/thefuck/rules/grep_recursive.py:3:            and 'is a directory' in command.stderr.lower())
dev/thefuck/thefuck/rules/rm_dir.py:8:            and 'is a directory' in command.stderr.lower())
```

