### PR TITLE
Fixed a problem at whois.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = '1.40'
+VERSION = '1.41'
 
 
 setup(name='thefuck',

--- a/thefuck/rules/whois.py
+++ b/thefuck/rules/whois.py
@@ -1,4 +1,5 @@
-from urllib.parse import urlparse
+ # coding: utf-8
+from urlparse import urlparse
 
 
 def match(command, settings):


### PR DESCRIPTION
While the normal version of thefuck worked perfectly for me, the developer version did not. I had to add encoding line at rules/whois.py and also change the source of urlparse module. As a newbie i don't expect this solution to be perfect, it just worked for me and I wanted to bring this problem to your attention.


PS It's my first pull request ever so I would appreciate the feedback if something was terribly wrong