### PR TITLE
better way to get shell

### DIFF
--- a/thefuck/shells.py
+++ b/thefuck/shells.py
@@ -153,16 +153,16 @@ shells = defaultdict(lambda: Generic(), {
     'bash': Bash(),
     'fish': Fish(),
     'zsh': Zsh(),
-    '-csh': Tcsh(),
+    'csh': Tcsh(),
     'tcsh': Tcsh()})
 
 
 def _get_shell():
     try:
-        shell = Process(os.getpid()).parent().cmdline()[0]
+        shell = Process(os.getpid()).parent().name()
     except TypeError:
-        shell = Process(os.getpid()).parent.cmdline[0]
-    return shells[os.path.basename(shell)]
+        shell = Process(os.getpid()).parent.name()
+    return shells[shell]
 
 
 def from_shell(command):


### PR DESCRIPTION
Hi,

I'm using `zsh` on `OS X 10.10.3` and I got this:
```
$ git push
fatal: The current branch master has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin master


$ fuck
gpt
```
The `gpt` at last which `thefuck` invoked for me is an aliase of `git push --tags`.
Obviously this is not an expected behaviour.

This PR solves the problem for me that `shell` can not be determined correctly.

In my situation the `shell` variable equals to `-zsh` however the matching target is sadly `zsh`.

Hope this can help, thanks for the great work! :smile: 