### PR TITLE
fix(whois): check if there's at least one argument to `whois`

### DIFF
--- a/tests/rules/test_whois.py
+++ b/tests/rules/test_whois.py
@@ -11,6 +11,10 @@ def test_match(command):
     assert match(command, None)
 
 
+def test_not_match():
+    assert not match(Command(script='whois'), None)
+
+
 @pytest.mark.parametrize('command, new_command', [
     (Command('whois https://en.wikipedia.org/wiki/Main_Page'), 'whois en.wikipedia.org'),
     (Command('whois https://en.wikipedia.org/'), 'whois en.wikipedia.org'),

--- a/thefuck/rules/whois.py
+++ b/thefuck/rules/whois.py
@@ -19,7 +19,7 @@ def match(command, settings):
         - www.google.fr → subdomain: www, domain: 'google.fr';
         - google.co.uk → subdomain: None, domain; 'google.co.uk'.
     """
-    return 'whois' in command.script
+    return 'whois' in command.script and len(command.script.split()) > 1
 
 
 def get_new_command(command, settings):


### PR DESCRIPTION
This avoids thefuck failing when there's no arguments. It fails with:

```
  ...
  File "thefuck/rules/whois.py", line 26, in get_new_command
    url = command.script.split()[1]
IndexError: list index out of range
```