### PR TITLE
refact(man): do not match if there's no argument to man

### DIFF
--- a/tests/rules/test_man.py
+++ b/tests/rules/test_man.py
@@ -2,6 +2,7 @@ import pytest
 from thefuck.rules.man import match, get_new_command
 from tests.utils import Command
 
+
 @pytest.mark.parametrize('command', [
     Command('man read'),
     Command('man 2 read'),
@@ -12,6 +13,13 @@ from tests.utils import Command
     Command('man -s 3 read')])
 def test_match(command):
     assert match(command, None)
+
+
+@pytest.mark.parametrize('command', [
+    Command('man'),
+    Command('man ')])
+def test_not_match(command):
+    assert not match(command, None)
 
 
 @pytest.mark.parametrize('command, new_command', [

--- a/thefuck/rules/man.py
+++ b/thefuck/rules/man.py
@@ -1,5 +1,5 @@
 def match(command, settings):
-    return command.script.startswith('man')
+    return command.script.strip().startswith('man ')
 
 
 def get_new_command(command, settings):


### PR DESCRIPTION
If there's no argument to man, a call to thefuck should just give no fuck, like the following:
```bash
~> man
What manual page do you want?
~> fuck
No fuck given
```