### PR TITLE
Addressed Issue #210

### DIFF
--- a/tests/rules/test_open.py
+++ b/tests/rules/test_open.py
@@ -1,0 +1,25 @@
+import pytest
+from thefuck.rules.open import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.mark.parametrize('command', [
+	Command(script='open foo.com'), 
+	Command(script='open foo.ly'), 
+	Command(script='open foo.org'), 
+	Command(script='open foo.net'), 
+	Command(script='open foo.se'), 
+	Command(script='open foo.io')])
+def test_match(command):
+	assert match(command, None)
+
+
+@pytest.mark.parametrize('command, new_command', [
+	(Command('open foo.com'), 'open http://foo.com'),
+	(Command('open foo.ly'), 'open http://foo.ly'),
+	(Command('open foo.org'), 'open http://foo.org'),
+	(Command('open foo.net'), 'open http://foo.net'),
+	(Command('open foo.se'), 'open http://foo.se'),
+	(Command('open foo.io'), 'open http://foo.io')])
+def test_get_new_command(command, new_command):
+	assert get_new_command(command, None) == new_command

--- a/thefuck/rules/open.py
+++ b/thefuck/rules/open.py
@@ -1,0 +1,24 @@
+# Opens URL's in the default web browser
+# 
+# Example:
+# > open github.com
+# The file ~/github.com does not exist.
+# Perhaps you meant 'http://github.com'?
+#
+# 
+
+def match(command, settings):
+	return (command.script.startswith ('open')
+			and (
+			# Wanted to use this:
+			# 'http' in command.stderr
+			'.com' in command.script
+			or '.net' in command.script
+			or '.org' in command.script
+			or '.ly' in command.script
+			or '.io' in command.script
+			or '.se' in command.script
+			or '.edu' in command.script))
+
+def get_new_command(command, settings):
+	return 'open http://' + command.script[5:]


### PR DESCRIPTION
Hi, I wanted to address the issue regarding the `open` command for URL's not being recognised by fuck.
The code I provided works for the more popular domain extensions and the tests. However, I actually originally wanted to do something along these lines:
``` python
def match(command, settings):
	#Unpopular Extensions
	ext = ['.ly', '.se', '.io', '.edu']
	return (command.script.startswith ('open')
			and 'does not exist' in command.stderr
			and ('http' in command.stderr
			or any(e in command.script for e in ext)))
```
I couldn't get the `any` syntax or anything that involves `command.stderr` to work with my code while testing though. It'd be great if you could shed some light on this issue for me so I could edit the code :) Thanks!