### PR TITLE
fix(shell::Fish): avoid looping when calling `fuck` twice

### DIFF
--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -81,12 +81,19 @@ class TestFish(object):
     @pytest.fixture(autouse=True)
     def Popen(self, mocker):
         mock = mocker.patch('thefuck.shells.Popen')
-        mock.return_value.stdout.read.return_value = (b'funced\nfuncsave\ngrep')
+        mock.return_value.stdout.read.return_value = (
+            b'fish_config\nfuck\nfunced\nfuncsave\ngrep\nhistory\nll\nmath')
         return mock
 
     @pytest.mark.parametrize('before, after', [
         ('pwd', 'pwd'),
-        ('ll', 'll')])  # Fish has no aliases but functions
+        ('fuck', 'fish -ic "fuck"'),
+        ('find', 'find'),
+        ('funced', 'fish -ic "funced"'),
+        ('awk', 'awk'),
+        ('math "2 + 2"', r'fish -ic "math \"2 + 2\""'),
+        ('vim', 'vim'),
+        ('ll', 'fish -ic "ll"')])  # Fish has no aliases but functions
     def test_from_shell(self, before, after, shell):
         assert shell.from_shell(before) == after
 
@@ -104,9 +111,14 @@ class TestFish(object):
         assert shell.and_('foo', 'bar') == 'foo; and bar'
 
     def test_get_aliases(self, shell):
-        assert shell.get_aliases() == {'funced': 'funced',
+        assert shell.get_aliases() == {'fish_config': 'fish_config',
+                                       'fuck': 'fuck',
+                                       'funced': 'funced',
                                        'funcsave': 'funcsave',
-                                       'grep': 'grep'}
+                                       'grep': 'grep',
+                                       'history': 'history',
+                                       'll': 'll',
+                                       'math': 'math'}
 
 
 @pytest.mark.usefixtures('isfile')

--- a/thefuck/shells.py
+++ b/thefuck/shells.py
@@ -101,6 +101,18 @@ class Fish(Generic):
         functions = proc.stdout.read().decode('utf-8').strip().split('\n')
         return {function: function for function in functions}
 
+    def _expand_aliases(self, command_script):
+        aliases = self.get_aliases()
+        binary = command_script.split(' ')[0]
+        if binary in aliases:
+            return 'fish -ic "{}"'.format(command_script.replace('"', r'\"'))
+        else:
+            return command_script
+
+    def from_shell(self, command_script):
+        """Prepares command before running in app."""
+        return self._expand_aliases(command_script)
+
     def _get_history_file_name(self):
         return os.path.expanduser('~/.config/fish/fish_history')
 


### PR DESCRIPTION
Or whatever the `thefuck` function name is.