### PR TITLE
Fixing bug with /bin/sh not understanding other shells' keywords

### DIFF
--- a/thefuck/main.py
+++ b/thefuck/main.py
@@ -79,7 +79,8 @@ def get_command(settings, args):
         return
 
     script = shells.from_shell(script)
-    result = Popen(script, shell=True, stdout=PIPE, stderr=PIPE,
+    system_shell = os.environ.get("SHELL")
+    result = Popen(script, shell=True, executable=system_shell, stdout=PIPE, stderr=PIPE,
                    env=dict(os.environ, LANG='C'))
     if wait_output(settings, result):
         return types.Command(script, result.stdout.read().decode('utf-8'),


### PR DESCRIPTION
This is meant to fix the following issue:

https://github.com/nvbn/thefuck/issues/222

It reads the os.environ["SHELL"] to run the command to get the output.  If SHELL isn't defined, os.environ.get() should return None, which will run the default "/bin/sh" .