### PR TITLE
Added javac rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `django_south_ghost` &ndash; adds `--delete-ghost-migrations` to failed because ghosts django south migration;
 * `django_south_merge` &ndash; adds `--merge` to inconsistent django south migration;
 * `fix_alt_space` &ndash; replaces Alt+Space with Space character;
+* `javac` &ndash; appends missing `.java` when compiling Java files
 * `git_add` &ndash; fix *"Did you forget to 'git add'?"*;
 * `git_checkout` &ndash; creates the branch before checking-out;
 * `git_no_command` &ndash; fixes wrong git commands like `git brnch`;

--- a/tests/rules/test_javac.py
+++ b/tests/rules/test_javac.py
@@ -1,0 +1,17 @@
+import pytest
+from thefuck.rules.javac import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.mark.parametrize('command', [
+	Command(script='javac foo'), 
+	Command(script='javac bar')])
+def test_match(command):
+	assert match(command, None)
+
+
+@pytest.mark.parametrize('command, new_command', [
+	(Command('javac foo'), 'javac foo.java'),
+	(Command('javac bar'), 'javac bar.java')])
+def test_get_new_command(command, new_command):
+	assert get_new_command(command, None) == new_command

--- a/thefuck/rules/javac.py
+++ b/thefuck/rules/javac.py
@@ -1,0 +1,15 @@
+# Appends .java when compiling java files
+# 
+# Example:
+# > javac foo
+# error: Class names, 'foo', are only accepted if annotation 
+# processing is explicitly requested
+#
+# 
+
+def match(command, settings):
+	return (command.script.startswith ('javac ')
+			and not command.script.endswith('.java'))
+
+def get_new_command(command, settings):
+	return command.script + '.java'


### PR DESCRIPTION
Fixes `javac` commands without `.java` file extensions
```
$ javac foo
error: Class names, 'foo', are only accepted if annotation processing is explicitly requested
```