### PR TITLE
Added java rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `django_south_ghost` &ndash; adds `--delete-ghost-migrations` to failed because ghosts django south migration;
 * `django_south_merge` &ndash; adds `--merge` to inconsistent django south migration;
 * `fix_alt_space` &ndash; replaces Alt+Space with Space character;
+* `java` &ndash; removes `.java` extension when running Java programs
 * `git_add` &ndash; fix *"Did you forget to 'git add'?"*;
 * `git_checkout` &ndash; creates the branch before checking-out;
 * `git_no_command` &ndash; fixes wrong git commands like `git brnch`;

--- a/tests/rules/test_java.py
+++ b/tests/rules/test_java.py
@@ -1,0 +1,17 @@
+import pytest
+from thefuck.rules.java import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.mark.parametrize('command', [
+	Command(script='java foo.java'),
+	Command(script='java bar.java')])
+def test_match(command):
+	assert match(command, None)
+
+
+@pytest.mark.parametrize('command, new_command', [
+	(Command('java foo.java'), 'java foo'),
+	(Command('java bar.java'), 'java bar')])
+def test_get_new_command(command, new_command):
+	assert get_new_command(command, None) == new_command

--- a/thefuck/rules/java.py
+++ b/thefuck/rules/java.py
@@ -1,0 +1,13 @@
+# Fixes common java command mistake
+# 
+# Example:
+# > java foo.java
+# Error: Could not find or load main class foo.java
+# 
+
+def match(command, settings):
+	return (command.script.startswith ('java ')
+		and command.script.endswith ('.java'))
+
+def get_new_command(command, settings):
+	return command.script[:-5]


### PR DESCRIPTION
Removes `.java` extension when running Java programs
```
$ java foo.java
Error: Could not find or load main class foo.java
```