### PR TITLE
Wrap apt-get rule in sudo_support

### DIFF
--- a/thefuck/rules/apt_get.py
+++ b/thefuck/rules/apt_get.py
@@ -1,11 +1,12 @@
 from thefuck import shells
+from thefuck.utils import sudo_support
 
 try:
     import CommandNotFound
 except ImportError:
     enabled_by_default = False
 
-
+@sudo_support
 def match(command, settings):
     if 'not found' in command.stderr:
         try:
@@ -17,7 +18,7 @@ def match(command, settings):
             # IndexError is thrown when no matching package is found
             return False
 
-
+@sudo_support
 def get_new_command(command, settings):
     c = CommandNotFound.CommandNotFound()
     pkgs = c.getPackages(command.script.split(" ")[0])


### PR DESCRIPTION
Fixes `sudo_support` not working for `no_command` rule.

Example:

```
$ sudo apt0get update
sudo: apt0get: command not found
$ fuck
```

would try to do `sudo apt-get install sudo && sudo apt0get update` and `no_command` rule wouldn't be executed at all.

By the way, there are some other rules that are not wrapped in `sudo_support` (ex. git rules). Would it make sense to wrap them too?