### PR TITLE
Git branch list

### DIFF
--- a/tests/rules/test_git_branch_list.py
+++ b/tests/rules/test_git_branch_list.py
@@ -1,0 +1,18 @@
+from thefuck import shells
+from thefuck.rules.git_branch_list import match, get_new_command
+from tests.utils import Command
+
+def test_match():
+    assert match(Command('git branch list'), None)
+
+
+def test_not_match():
+    assert not match(Command(), None)
+    assert not match(Command('git commit'), None)
+    assert not match(Command('git branch'), None)
+    assert not match(Command('git stash list'), None)
+
+
+def test_get_new_command():
+    assert (get_new_command(Command('git branch list'), None) ==
+            shells.and_('git branch --delete list', 'git branch'))

--- a/thefuck/rules/git_branch_list.py
+++ b/thefuck/rules/git_branch_list.py
@@ -1,0 +1,10 @@
+from thefuck import shells
+
+
+def match(command, settings):
+    # catches "git branch list" in place of "git branch"
+    return command.script.split() == 'git branch list'.split()
+
+
+def get_new_command(command, settings):
+    return shells.and_('git branch --delete list', 'git branch')


### PR DESCRIPTION
Just catches `git branch list` in place of `git branch` - useful for those who are confused by `git stash` vs `git stash list`.