### PR TITLE
Added brew_upgrade rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Enabled by default only on specific platforms:
 * `apt_get` &ndash; installs app from apt if it not installed;
 * `brew_install` &ndash; fixes formula name for `brew install`;
 * `brew_unknown_command` &ndash; fixes wrong brew commands, for example `brew docto/brew doctor`;
+* `brew_upgrade` &ndash; appends `-all` to `brew upgrade` as per Homebrew's new behaviour
 * `pacman` &ndash; installs app with `pacman` or `yaourt` if it is not installed.
 
 Bundled, but not enabled by default:

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Enabled by default only on specific platforms:
 * `apt_get` &ndash; installs app from apt if it not installed;
 * `brew_install` &ndash; fixes formula name for `brew install`;
 * `brew_unknown_command` &ndash; fixes wrong brew commands, for example `brew docto/brew doctor`;
-* `brew_upgrade` &ndash; appends `-all` to `brew upgrade` as per Homebrew's new behaviour
+* `brew_upgrade` &ndash; appends `--all` to `brew upgrade` as per Homebrew's new behaviour
 * `pacman` &ndash; installs app with `pacman` or `yaourt` if it is not installed.
 
 Bundled, but not enabled by default:

--- a/tests/rules/test_brew_upgrade.py
+++ b/tests/rules/test_brew_upgrade.py
@@ -1,0 +1,15 @@
+import pytest
+from thefuck.rules.brew_upgrade import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.mark.parametrize('command', [
+	Command(script='brew upgrade')])
+def test_match(command):
+	assert match(command, None)
+
+
+@pytest.mark.parametrize('command, new_command', [
+	(Command('brew upgrade'), 'brew upgrade --all')])
+def test_get_new_command(command, new_command):
+	assert get_new_command(command, None) == new_command

--- a/thefuck/rules/brew_upgrade.py
+++ b/thefuck/rules/brew_upgrade.py
@@ -1,0 +1,14 @@
+# Appends --all to the brew upgrade command
+# 
+# Example:
+# > brew upgrade
+# Warning: brew upgrade with no arguments will change behaviour soon!
+# It currently upgrades all formula but this will soon change to require '--all'.
+#
+# 
+
+def match(command, settings):
+    return (command.script == 'brew upgrade')
+
+def get_new_command(command, settings):
+    return command.script + ' --all'


### PR DESCRIPTION
Appends `--all` to `brew upgrade`. Not relevant yet, but I've been getting errors that Homebrew will be disabling `brew upgrade` without flags eventually, so I thought I'd add it here for good measure.