### PR TITLE
Add two cargo related rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ sudo pip install thefuck --upgrade
 The Fuck tries to match a rule for the previous command, creates a new command
 using the matched rule and runs it. Rules enabled by default are as follows:
 
+* `cargo` &ndash; run `cargo build` instead of `cargo`;
 * `cd_correction` &ndash; spellchecks and correct failed cd commands;
 * `cd_mkdir` &ndash; creates directories before cd'ing into them;
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ sudo pip install thefuck --upgrade
 The Fuck tries to match a rule for the previous command, creates a new command
 using the matched rule and runs it. Rules enabled by default are as follows:
 
-* `cargo` &ndash; run `cargo build` instead of `cargo`;
+* `cargo` &ndash; runs `cargo build` instead of `cargo`;
+* `cargo_no_command` &ndash; fixes wrongs commands like `cargo buid`;
 * `cd_correction` &ndash; spellchecks and correct failed cd commands;
 * `cd_mkdir` &ndash; creates directories before cd'ing into them;
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;

--- a/tests/rules/test_cargo_no_command.py
+++ b/tests/rules/test_cargo_no_command.py
@@ -1,0 +1,21 @@
+import pytest
+from thefuck.rules.cargo_no_command import match, get_new_command
+from tests.utils import Command
+
+
+no_such_subcommand = """No such subcommand
+
+        Did you mean `build`?
+"""
+
+
+@pytest.mark.parametrize('command', [
+    Command(script='cargo buid', stderr=no_such_subcommand)])
+def test_match(command):
+    assert match(command, None)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('cargo buid', stderr=no_such_subcommand), 'cargo build')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command, None) == new_command

--- a/thefuck/rules/cargo.py
+++ b/thefuck/rules/cargo.py
@@ -1,0 +1,6 @@
+def match(command, settings):
+    return command.script == 'cargo'
+
+
+def get_new_command(command, settings):
+    return 'cargo build'

--- a/thefuck/rules/cargo_no_command.py
+++ b/thefuck/rules/cargo_no_command.py
@@ -1,0 +1,14 @@
+import re
+
+
+def match(command, settings):
+    return ('cargo' in command.script
+            and 'No such subcommand' in command.stderr
+            and 'Did you mean' in command.stderr)
+
+
+def get_new_command(command, settings):
+    broken = command.script.split()[1]
+    fix = re.findall(r'Did you mean `([^`]*)`', command.stderr)[0]
+
+    return command.script.replace(broken, fix, 1)


### PR DESCRIPTION
Adds two rules for `cargo`:

- `cargo`: for those who are too used to simply type `make` and are fucked every time they want `cargo` to actually compile their project;
- `cargo_no_command`: fixes spelling mistakes, similar to the `git_not_command` rule.