### PR TITLE
fix(main.wait_output): use Process’ children() instead of get_children()

### DIFF
--- a/thefuck/main.py
+++ b/thefuck/main.py
@@ -62,7 +62,7 @@ def wait_output(settings, popen):
         proc.wait(settings.wait_command)
         return True
     except TimeoutExpired:
-        for child in proc.get_children(recursive=True):
+        for child in proc.children(recursive=True):
             child.kill()
         proc.kill()
         return False


### PR DESCRIPTION
Since psutil 2.0.0 `get_children()` has become deprecated and the use of
`children()` instead of it has been encouraged. In version 3.0.0, just
released, `get_children()` has been dropped. Check:

https://github.com/giampaolo/psutil/blob/master/HISTORY.rst

Fix #255