### PR TITLE
Fix sudo rule

### DIFF
--- a/tests/rules/test_sudo.py
+++ b/tests/rules/test_sudo.py
@@ -8,6 +8,9 @@ from tests.utils import Command
     ('permission denied', ''),
     ("npm ERR! Error: EACCES, unlink", ''),
     ('requested operation requires superuser privilege', ''),
+    ('need to be root', ''),
+    ('need root', ''),
+    ('must be root', ''),
     ('', "error: [Errno 13] Permission denied: '/usr/local/lib/python2.7/dist-packages/ipaddr.py'")])
 def test_match(stderr, stdout):
     assert match(Command(stderr=stderr, stdout=stdout), None)

--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -11,6 +11,9 @@ patterns = ['permission denied',
             'requested operation requires superuser privilege',
             'must be run as root',
             'must be superuser',
+            'must be root',
+            # wow, case-sensitive
+            'need to be root',
             'Need to be root',
             'you must be root to run this program.',
             'only root can do that']

--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -14,6 +14,7 @@ patterns = ['permission denied',
             'must be root',
             # wow, case-sensitive
             'need to be root',
+            'need root',
             'Need to be root',
             'you must be root to run this program.',
             'only root can do that']


### PR DESCRIPTION
This fixes the sudo rule so when a command outputs something like `You need to be root to perform this command.` (like yum), it will detect it.

EDIT: doesn't work, hold on. adding more changes.

EDIT 2: committed the test, but not the rule lol