### PR TITLE
Open

### DIFF
--- a/thefuck/rules/open.py
+++ b/thefuck/rules/open.py
@@ -8,7 +8,7 @@
 
 
 def match(command, settings):
-    return (command.script.startswith('open')
+    return (command.script.startswith(('open', 'xdg-open', 'gnome-open', 'kde-open'))
             and (
                 '.com' in command.script
                 or '.net' in command.script

--- a/thefuck/rules/open.py
+++ b/thefuck/rules/open.py
@@ -1,24 +1,23 @@
 # Opens URL's in the default web browser
-# 
+#
 # Example:
 # > open github.com
 # The file ~/github.com does not exist.
 # Perhaps you meant 'http://github.com'?
 #
-# 
+
 
 def match(command, settings):
-	return (command.script.startswith ('open')
-			and (
-			# Wanted to use this:
-			# 'http' in command.stderr
-			'.com' in command.script
-			or '.net' in command.script
-			or '.org' in command.script
-			or '.ly' in command.script
-			or '.io' in command.script
-			or '.se' in command.script
-			or '.edu' in command.script))
+    return (command.script.startswith('open')
+            and (
+                '.com' in command.script
+                or '.net' in command.script
+                or '.org' in command.script
+                or '.ly' in command.script
+                or '.io' in command.script
+                or '.se' in command.script
+                or '.edu' in command.script))
+
 
 def get_new_command(command, settings):
-	return 'open http://' + command.script[5:]
+    return 'open http://' + command.script[5:]

--- a/thefuck/rules/open.py
+++ b/thefuck/rules/open.py
@@ -16,7 +16,10 @@ def match(command, settings):
                 or '.ly' in command.script
                 or '.io' in command.script
                 or '.se' in command.script
-                or '.edu' in command.script))
+                or '.edu' in command.script
+                or '.info' in command.script
+                or '.me' in command.script
+                or 'www.' in command.script))
 
 
 def get_new_command(command, settings):


### PR DESCRIPTION
This is far from perfect but I can't think of a clean way to test if `foo.bar` can be a domain name, especially now that we allow things like `.paris` or `.diamonds`.
The complete list seems to [be available](https://www.iana.org/domains/root/db) so we could use that instead of the way too short list we currently have, but then we'd still have to differentiate the python file `foo.py` from a Paraguayan website.