### PR TITLE
fixed dependency problem, on python 3.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 
 VERSION = '1.46'
 
-deps = ['psutil', 'colorama', 'six']
+install_requires = ['psutil', 'colorama', 'six']
 
 if sys.version_info < (3,4):
     deps.append('pathlib')
@@ -20,7 +20,7 @@ setup(name='thefuck',
                                       'tests', 'release']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=deps,
+      install_requires=install_requires,
       entry_points={'console_scripts': [
           'thefuck = thefuck.main:main',
           'thefuck-alias = thefuck.shells:app_alias']})

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ VERSION = '1.46'
 install_requires = ['psutil', 'colorama', 'six']
 
 if sys.version_info < (3,4):
-    deps.append('pathlib')
+    install_requires.append('pathlib')
 
 setup(name='thefuck',
       version=VERSION,

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,13 @@
 from setuptools import setup, find_packages
+import sys
 
 
 VERSION = '1.46'
 
+deps = ['psutil', 'colorama', 'six']
+
+if sys.version_info < (3,4):
+    deps.append('pathlib')
 
 setup(name='thefuck',
       version=VERSION,
@@ -15,7 +20,7 @@ setup(name='thefuck',
                                       'tests', 'release']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=['pathlib', 'psutil', 'colorama', 'six'],
+      install_requires=deps,
       entry_points={'console_scripts': [
           'thefuck = thefuck.main:main',
           'thefuck-alias = thefuck.shells:app_alias']})


### PR DESCRIPTION
Fixed dependency problem, on python 3.4.0 pathlib is included in the python distribution so it must not be included in the requirements for thefuck otherwise it wont run at startup.
This was necesary to make a package for Fedora
https://bugzilla.redhat.com/show_bug.cgi?id=1239148