### PR TITLE
Add systemd's kind of error for the sudo rule

### DIFF
--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -13,7 +13,8 @@ patterns = ['permission denied',
             'must be root',
             'need to be root',
             'need root',
-            'only root can do that']
+            'only root can do that',
+            'authentication is required']
 
 
 def match(command, settings):


### PR DESCRIPTION
A complete error would be:

```
% systemctl daemon-reload
==== AUTHENTICATING FOR org.freedesktop.systemd1.reload-daemon ===
Authentication is required to reload the systemd state.
Authenticating as: martin
Password:
```