### PR TITLE
Add support for coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+exclude_lines =
+    pragma: no cover ${COVERAGE_PYTHON_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,8 @@ python:
 install:
   - python setup.py develop
   - pip install -r requirements.txt
-script: py.test -v
+  - pip install coveralls
+script:
+    coverage run --source=thefuck,tests -m py.test -v
+after_success:
+    coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - pip install -r requirements.txt
   - pip install coveralls
 script:
-    coverage run --source=thefuck,tests -m py.test -v
+    - export COVERAGE_PYTHON_VERSION=python-${TRAVIS_PYTHON_VERSION:0:1}
+    - coverage run --source=thefuck,tests -m py.test -v
 after_success:
     coveralls

--- a/thefuck/main.py
+++ b/thefuck/main.py
@@ -71,9 +71,9 @@ def wait_output(settings, popen):
 
 def get_command(settings, args):
     """Creates command from `args` and executes it."""
-    if six.PY2:
+    if six.PY2:  # pragma: no cover python-3
         script = ' '.join(arg.decode('utf-8') for arg in args[1:])
-    else:
+    else:  # pragma: no cover python-2
         script = ' '.join(args[1:])
 
     if not script:

--- a/thefuck/main.py
+++ b/thefuck/main.py
@@ -11,7 +11,7 @@ import six
 from . import logs, conf, types, shells
 
 
-def setup_user_dir():
+def setup_user_dir():  # pragma: no cover
     """Returns user config dir, create it when it doesn't exist."""
     user_dir = Path(expanduser('~/.thefuck'))
     rules_dir = user_dir.joinpath('rules')

--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -8,10 +8,10 @@ from .types import Command
 
 DEVNULL = open(os.devnull, 'w')
 
-if six.PY2:
+if six.PY2:  # pragma: no cover python-3
     import pipes
     quote = pipes.quote
-else:
+else:  # pragma: no cover python-2
     import shlex
     quote = shlex.quote
 


### PR DESCRIPTION
This adds support for coverage tests using [coveralls.io](https://coveralls.io).
You can see an example [here](https://coveralls.io/builds/3016909).

Note: if you merge this PR you will need to create an account on [coveralls.io](https://coveralls.io).