### PR TITLE
improve(rules): add a rule to recursively copy a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `cd_mkdir` &ndash; creates directories before cd'ing into them;
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;
 * `composer_not_command` &ndash; fixes composer command name;
+* `cp_dir` &ndash; adds `-r` when you try to copy a directory;
 * `cp_omitting_directory` &ndash; adds `-a` when you `cp` directory;
 * `cpp11` &ndash; add missing `-std=c++11` to `g++` or `clang++`;
 * `django_south_ghost` &ndash; adds `--delete-ghost-migrations` to failed because ghosts django south migration;

--- a/tests/rules/test_cp_dir.py
+++ b/tests/rules/test_cp_dir.py
@@ -1,0 +1,22 @@
+import pytest
+from thefuck.rules.cp_dir import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.mark.parametrize('command', [
+    Command('cp foo foo_copy', stderr='cp: foo: is a directory'),
+    Command('cp bar bar_copy', stderr='cp: bar: Is a directory'),
+    Command('sudo cp qux qux_copy', stderr='cp: qux: is a directory')])
+def test_match(command):
+    assert match(command, None)
+
+
+@pytest.mark.parametrize('command', [
+    Command('cp foo foo_copy'), Command('cp foo foo_copy'), Command()])
+def test_not_match(command):
+    assert not match(command, None)
+
+
+def test_get_new_command():
+    assert get_new_command(
+        Command('cp foo foo_copy', '', ''), None) == 'cp -r foo foo_copy'

--- a/thefuck/rules/cp_dir.py
+++ b/thefuck/rules/cp_dir.py
@@ -1,0 +1,13 @@
+import re
+from thefuck.utils import sudo_support
+
+
+@sudo_support
+def match(command, settings):
+    return (command.script.startswith('cp ')
+            and 'is a directory' in command.stderr.lower())
+
+
+@sudo_support
+def get_new_command(command, settings):
+    return re.sub('^cp (.*)', 'cp -r \\1', command.script)


### PR DESCRIPTION
Add a new rule, `cp_dir`, that adds `-r` when you try to copy a directory:
```
» cp thefuck /tmp/
cp: thefuck is a directory (not copied).
» fuck
cp -r thefuck /tmp/ [enter/ctrl+c]
» ls /tmp/thefuck/
__init__.py
__init__.pyc
__pycache__
...
```