### PR TITLE
Resolve git aliases

### DIFF
--- a/tests/rules/test_git_diff_staged.py
+++ b/tests/rules/test_git_diff_staged.py
@@ -3,15 +3,13 @@ from thefuck.rules.git_diff_staged import match, get_new_command
 from tests.utils import Command
 
 
-@pytest.mark.parametrize('command', [
-    Command(script='git diff'),
-    Command(script='git df'),
-    Command(script='git ds')])
+@pytest.mark.parametrize('command', [Command(script='git diff')])
 def test_match(command):
     assert match(command, None)
 
 
 @pytest.mark.parametrize('command', [
+    Command(script='git diff --staged'),
     Command(script='git tag'),
     Command(script='git branch'),
     Command(script='git log')])
@@ -20,8 +18,6 @@ def test_not_match(command):
 
 
 @pytest.mark.parametrize('command, new_command', [
-    (Command('git diff'), 'git diff --staged'),
-    (Command('git df'), 'git df --staged'),
-    (Command('git ds'), 'git ds --staged')])
+    (Command('git diff'), 'git diff --staged')])
 def test_get_new_command(command, new_command):
     assert get_new_command(command, None) == new_command

--- a/tests/rules/test_git_stash.py
+++ b/tests/rules/test_git_stash.py
@@ -3,22 +3,20 @@ from thefuck.rules.git_stash import match, get_new_command
 from tests.utils import Command
 
 
-@pytest.fixture
-def cherry_pick_error():
-    return ('error: Your local changes would be overwritten by cherry-pick.\n'
-            'hint: Commit your changes or stash them to proceed.\n'
-            'fatal: cherry-pick failed')
+cherry_pick_error = (
+        'error: Your local changes would be overwritten by cherry-pick.\n'
+        'hint: Commit your changes or stash them to proceed.\n'
+        'fatal: cherry-pick failed')
 
 
-@pytest.fixture
-def rebase_error():
-    return ('Cannot rebase: Your index contains uncommitted changes.\n'
-            'Please commit or stash them.')
+rebase_error = (
+        'Cannot rebase: Your index contains uncommitted changes.\n'
+        'Please commit or stash them.')
 
 
 @pytest.mark.parametrize('command', [
-    Command(script='git cherry-pick a1b2c3d', stderr=cherry_pick_error()),
-    Command(script='git rebase -i HEAD~7', stderr=rebase_error())])
+    Command(script='git cherry-pick a1b2c3d', stderr=cherry_pick_error),
+    Command(script='git rebase -i HEAD~7', stderr=rebase_error)])
 def test_match(command):
     assert match(command, None)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -84,7 +84,7 @@ class TestGetCommand(object):
                                       shell=True,
                                       stdout=PIPE,
                                       stderr=PIPE,
-                                      env={'LANG': 'C'})
+                                      env={'LANG': 'C', 'GIT_TRACE': 1})
 
     @pytest.mark.parametrize('args, result', [
         (['thefuck', 'ls', '-la'], 'ls -la'),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -77,23 +77,23 @@ class TestGetCommand(object):
         monkeypatch.setattr('thefuck.shells.to_shell', lambda x: x)
 
     def test_get_command_calls(self, Popen):
-        assert main.get_command(Mock(),
+        assert main.get_command(Mock(env={}),
             ['thefuck', 'apt-get', 'search', 'vim']) \
                == Command('apt-get search vim', 'stdout', 'stderr')
         Popen.assert_called_once_with('apt-get search vim',
                                       shell=True,
                                       stdout=PIPE,
                                       stderr=PIPE,
-                                      env={'LANG': 'C', 'GIT_TRACE': 1})
+                                      env={})
 
     @pytest.mark.parametrize('args, result', [
         (['thefuck', 'ls', '-la'], 'ls -la'),
         (['thefuck', 'ls'], 'ls')])
     def test_get_command_script(self, args, result):
         if result:
-            assert main.get_command(Mock(), args).script == result
+            assert main.get_command(Mock(env={}), args).script == result
         else:
-            assert main.get_command(Mock(), args) is None
+            assert main.get_command(Mock(env={}), args) is None
 
 
 class TestGetMatchedRule(object):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 from mock import Mock
-from thefuck.utils import sudo_support, wrap_settings, memoize, get_closest
+from thefuck.utils import git_support, sudo_support, wrap_settings, memoize, get_closest
 from thefuck.types import Settings
 from tests.utils import Command
 
@@ -24,6 +24,15 @@ def test_sudo_support(return_value, command, called, result):
     fn = Mock(return_value=return_value, __name__='')
     assert sudo_support(fn)(Command(command), None) == result
     fn.assert_called_once_with(Command(called), None)
+
+
+@pytest.mark.parametrize('called, command, stderr', [
+    ('git co', "git 'checkout'", "19:22:36.299340 git.c:282   trace: alias expansion: co => 'checkout'"),
+    ('git com file', "git 'commit' '--verbose' file", "19:23:25.470911 git.c:282   trace: alias expansion: com => 'commit' '--verbose'")])
+def test_git_support(called, command, stderr):
+    @git_support
+    def fn(command, settings): return command.script
+    assert fn(Command(script=called, stderr=stderr), None) == command
 
 
 def test_memoize():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,8 +27,8 @@ def test_sudo_support(return_value, command, called, result):
 
 
 @pytest.mark.parametrize('called, command, stderr', [
-    ('git co', "git 'checkout'", "19:22:36.299340 git.c:282   trace: alias expansion: co => 'checkout'"),
-    ('git com file', "git 'commit' '--verbose' file", "19:23:25.470911 git.c:282   trace: alias expansion: com => 'commit' '--verbose'")])
+    ('git co', 'git checkout', "19:22:36.299340 git.c:282   trace: alias expansion: co => 'checkout'"),
+    ('git com file', 'git commit --verbose file', "19:23:25.470911 git.c:282   trace: alias expansion: com => 'commit' '--verbose'")])
 def test_git_support(called, command, stderr):
     @git_support
     def fn(command, settings): return command.script

--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -30,7 +30,8 @@ DEFAULT_SETTINGS = {'rules': DEFAULT_RULES,
                     'require_confirmation': False,
                     'no_colors': False,
                     'debug': False,
-                    'priority': {}}
+                    'priority': {},
+                    'env': {'LANG': 'C', 'GIT_TRACE': '1'}}
 
 ENV_TO_ATTR = {'THEFUCK_RULES': 'rules',
                'THEFUCK_WAIT_COMMAND': 'wait_command',

--- a/thefuck/main.py
+++ b/thefuck/main.py
@@ -82,7 +82,7 @@ def get_command(settings, args):
     script = shells.from_shell(script)
     logs.debug('Call: {}'.format(script), settings)
     result = Popen(script, shell=True, stdout=PIPE, stderr=PIPE,
-                   env=dict(os.environ, LANG='C'))
+                   env=dict(os.environ, LANG='C', GIT_TRACE=1))
     if wait_output(settings, result):
         return types.Command(script, result.stdout.read().decode('utf-8'),
                              result.stderr.read().decode('utf-8'))

--- a/thefuck/main.py
+++ b/thefuck/main.py
@@ -81,8 +81,12 @@ def get_command(settings, args):
 
     script = shells.from_shell(script)
     logs.debug('Call: {}'.format(script), settings)
-    result = Popen(script, shell=True, stdout=PIPE, stderr=PIPE,
-                   env=dict(os.environ, LANG='C', GIT_TRACE=1))
+
+    env = dict(os.environ)
+    env.update(settings.env)
+    logs.debug('Executing with env: {}'.format(env), settings)
+
+    result = Popen(script, shell=True, stdout=PIPE, stderr=PIPE, env=env)
     if wait_output(settings, result):
         return types.Command(script, result.stdout.read().decode('utf-8'),
                              result.stderr.read().decode('utf-8'))

--- a/thefuck/rules/git_add.py
+++ b/thefuck/rules/git_add.py
@@ -1,13 +1,15 @@
 import re
-from thefuck import shells
+from thefuck import utils, shells
 
 
+@utils.git_support
 def match(command, settings):
     return ('git' in command.script
             and 'did not match any file(s) known to git.' in command.stderr
             and "Did you forget to 'git add'?" in command.stderr)
 
 
+@utils.git_support
 def get_new_command(command, settings):
     missing_file = re.findall(
             r"error: pathspec '([^']*)' "

--- a/thefuck/rules/git_branch_list.py
+++ b/thefuck/rules/git_branch_list.py
@@ -1,10 +1,12 @@
-from thefuck import shells
+from thefuck import utils, shells
 
 
+@utils.git_support
 def match(command, settings):
     # catches "git branch list" in place of "git branch"
     return command.script.split() == 'git branch list'.split()
 
 
+@utils.git_support
 def get_new_command(command, settings):
     return shells.and_('git branch --delete list', 'git branch')

--- a/thefuck/rules/git_checkout.py
+++ b/thefuck/rules/git_checkout.py
@@ -1,13 +1,15 @@
 import re
-from thefuck import shells
+from thefuck import shells, utils
 
 
+@utils.git_support
 def match(command, settings):
     return ('git' in command.script
             and 'did not match any file(s) known to git.' in command.stderr
             and "Did you forget to 'git add'?" not in command.stderr)
 
 
+@utils.git_support
 def get_new_command(command, settings):
     missing_file = re.findall(
             r"error: pathspec '([^']*)' "

--- a/thefuck/rules/git_diff_staged.py
+++ b/thefuck/rules/git_diff_staged.py
@@ -1,6 +1,13 @@
+from thefuck import utils
+
+
+@utils.git_support
 def match(command, settings):
-    return command.script.startswith('git d')
+    return ('git' in command.script and
+            'diff' in command.script and
+            '--staged' not in command.script)
 
 
+@utils.git_support
 def get_new_command(command, settings):
     return '{} --staged'.format(command.script)

--- a/thefuck/rules/git_not_command.py
+++ b/thefuck/rules/git_not_command.py
@@ -1,8 +1,8 @@
-from difflib import get_close_matches
 import re
-from thefuck.utils import get_closest
+from thefuck.utils import get_closest, git_support
 
 
+@git_support
 def match(command, settings):
     return ('git' in command.script
             and " is not a git command. See 'git --help'." in command.stderr
@@ -18,6 +18,7 @@ def _get_all_git_matched_commands(stderr):
             yield line.strip()
 
 
+@git_support
 def get_new_command(command, settings):
     broken_cmd = re.findall(r"git: '([^']*)' is not a git command",
                             command.stderr)[0]

--- a/thefuck/rules/git_pull.py
+++ b/thefuck/rules/git_pull.py
@@ -1,12 +1,14 @@
-from thefuck import shells
+from thefuck import shells, utils
 
 
+@utils.git_support
 def match(command, settings):
     return ('git' in command.script
             and 'pull' in command.script
             and 'set-upstream' in command.stderr)
 
 
+@utils.git_support
 def get_new_command(command, settings):
     line = command.stderr.split('\n')[-3].strip()
     branch = line.split(' ')[-1]

--- a/thefuck/rules/git_push.py
+++ b/thefuck/rules/git_push.py
@@ -1,8 +1,13 @@
+from thefuck import utils
+
+
+@utils.git_support
 def match(command, settings):
     return ('git' in command.script
             and 'push' in command.script
             and 'set-upstream' in command.stderr)
 
 
+@utils.git_support
 def get_new_command(command, settings):
     return command.stderr.split('\n')[-3].strip()

--- a/thefuck/rules/git_stash.py
+++ b/thefuck/rules/git_stash.py
@@ -1,12 +1,14 @@
-from thefuck import shells
+from thefuck import shells, utils
 
 
+@utils.git_support
 def match(command, settings):
     # catches "Please commit or stash them" and "Please, commit your changes or
     # stash them before you can switch branches."
     return 'git' in command.script and 'or stash them' in command.stderr
 
 
+@utils.git_support
 def get_new_command(command, settings):
     formatme = shells.and_('git stash', '{}')
     return formatme.format(command.script)


### PR DESCRIPTION
This PR adds a new utility function to resolve git aliases for `git_*` rules.
It does not require to find, read or parse the `gitconfig` user file as it uses logging from `git` itself with the `GIT_TRACE` env variable.

It was inspired by the `git_diff_staged` rule by @scorphus which uses [some](https://github.com/nvbn/thefuck/blob/15e13d7c1a3b5733c84139e89b09d105bb70de93/tests/rules/test_git_diff_staged.py#L8-9) of [his aliases](https://github.com/scorphus/dotfilesetal/blob/26cea37aad58aed760547c7d578de4b82f9d1708/.gitconfig#L33-34).