### PR TITLE
Change installation procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # The Fuck [![Build Status](https://travis-ci.org/nvbn/thefuck.svg)](https://travis-ci.org/nvbn/thefuck) 
 
-**Aliases changed in 1.34.**
-
 Magnificent app which corrects your previous console command,
 inspired by a [@liamosaur](https://twitter.com/liamosaur/)
 [tweet](https://twitter.com/liamosaur/status/506975850596536320).
@@ -106,29 +104,12 @@ sudo pip install thefuck
 
 [Or using an OS package manager (OS X, Ubuntu, Arch).](https://github.com/nvbn/thefuck/wiki/Installation)
 
-And add to the `.bashrc` or `.bash_profile`(for OSX):
+You should place this command in your `.bash_profile` or other startup script:
 
 ```bash
-alias fuck='eval $(thefuck $(fc -ln -1)); history -r'
+eval "$(thefuck-alias)"
 # You can use whatever you want as an alias, like for Mondays:
-alias FUCK='fuck'
-```
-
-Or in your `.zshrc`:
-
-```bash
-alias fuck='eval $(thefuck $(fc -ln -1 | tail -n 1)); fc -R'
-```
-
-If you are using `tcsh`:
-```tcsh
-alias fuck 'set fucked_cmd=`history -h 2 | head -n 1` && eval `thefuck ${fucked_cmd}`'
-```
-
-Alternatively, you can redirect the output of `thefuck-alias`:
-
-```bash
-thefuck-alias >> ~/.bashrc
+eval "$(thefuck-alias FUCK)"
 ```
 
 [Or in your shell config (Bash, Zsh, Fish, Powershell).](https://github.com/nvbn/thefuck/wiki/Shell-aliases)
@@ -142,6 +123,8 @@ To make them available immediately, run `source ~/.bashrc` (or your shell config
 ```bash
 sudo pip install thefuck --upgrade
 ```
+
+**Aliases changed in 1.34.**
 
 ## How it works
 

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -44,9 +44,10 @@ class TestGeneric(object):
         assert shell.get_aliases() == {}
 
     def test_app_alias(self, shell):
-        assert 'alias fuck' in shell.app_alias()
-        assert 'thefuck' in shell.app_alias()
-        assert 'TF_ALIAS' in shell.app_alias()
+        assert 'alias fuck' in shell.app_alias('fuck')
+        assert 'alias FUCK' in shell.app_alias('FUCK')
+        assert 'thefuck' in shell.app_alias('fuck')
+        assert 'TF_ALIAS' in shell.app_alias('fuck')
 
     def test_get_history(self, history_lines, shell):
         history_lines(['ls', 'rm'])
@@ -97,9 +98,10 @@ class TestBash(object):
                                        'll': 'ls -alF'}
 
     def test_app_alias(self, shell):
-        assert 'alias fuck' in shell.app_alias()
-        assert 'thefuck' in shell.app_alias()
-        assert 'TF_ALIAS' in shell.app_alias()
+        assert 'alias fuck' in shell.app_alias('fuck')
+        assert 'alias FUCK' in shell.app_alias('FUCK')
+        assert 'thefuck' in shell.app_alias('fuck')
+        assert 'TF_ALIAS' in shell.app_alias('fuck')
 
     def test_get_history(self, history_lines, shell):
         history_lines(['ls', 'rm'])
@@ -173,9 +175,10 @@ class TestFish(object):
                                        'ruby': 'ruby'}
 
     def test_app_alias(self, shell):
-        assert 'function fuck' in shell.app_alias()
-        assert 'thefuck' in shell.app_alias()
-        assert 'TF_ALIAS' in shell.app_alias()
+        assert 'function fuck' in shell.app_alias('fuck')
+        assert 'function FUCK' in shell.app_alias('FUCK')
+        assert 'thefuck' in shell.app_alias('fuck')
+        assert 'TF_ALIAS' in shell.app_alias('fuck')
 
 
 @pytest.mark.usefixtures('isfile')
@@ -222,9 +225,10 @@ class TestZsh(object):
             'll': 'ls -alF'}
 
     def test_app_alias(self, shell):
-        assert 'alias fuck' in shell.app_alias()
-        assert 'thefuck' in shell.app_alias()
-        assert 'TF_ALIAS' in shell.app_alias()
+        assert 'alias fuck' in shell.app_alias('fuck')
+        assert 'alias FUCK' in shell.app_alias('FUCK')
+        assert 'thefuck' in shell.app_alias('fuck')
+        assert 'TF_ALIAS' in shell.app_alias('fuck')
 
     def test_get_history(self, history_lines, shell):
         history_lines([': 1432613911:0;ls', ': 1432613916:0;rm'])


### PR DESCRIPTION
This makes the installation simpler for users, lighten a little the README and would allow to [change](https://github.com/nvbn/thefuck/commit/43ec39719020f2472f6baab005e57698cdf5e596) [the aliases](https://github.com/nvbn/thefuck/commit/c08d9125e4f57834a8a85eca3a2a8a83275cea90) in the future without the need for message likes "**Aliases changed in 1.34.**".

I'll update the wiki accordingly if the PR is merged.

Inspired from [GitHub's `hub` command](https://github.com/github/hub#aliasing).

Edit:
The PR has:
` coverage/coveralls — Coverage decreased (-0.1%) to 91.702% `
You can change the threshold for failure on coverall :)