### PR TITLE
Add `dnf history` error for the sudo rule

### DIFF
--- a/tests/rules/test_sudo.py
+++ b/tests/rules/test_sudo.py
@@ -11,6 +11,7 @@ from tests.utils import Command
     ('need to be root', ''),
     ('need root', ''),
     ('must be root', ''),
+    ('You don\'t have access to the history DB.', ''),
     ('', "error: [Errno 13] Permission denied: '/usr/local/lib/python2.7/dist-packages/ipaddr.py'")])
 def test_match(stderr, stdout):
     assert match(Command(stderr=stderr, stdout=stdout), None)

--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -14,6 +14,7 @@ patterns = ['permission denied',
             'need to be root',
             'need root',
             'only root can do that',
+            'You don\'t have access to the history DB.',
             'authentication is required']
 
 


### PR DESCRIPTION
```
$ dnf history
You don't have access to the history DB.
```