### PR TITLE
Force LC_ALL to C

### DIFF
--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -31,7 +31,7 @@ DEFAULT_SETTINGS = {'rules': DEFAULT_RULES,
                     'no_colors': False,
                     'debug': False,
                     'priority': {},
-                    'env': {'LANG': 'C', 'GIT_TRACE': '1'}}
+                    'env': {'LC_ALL': 'C', 'LANG': 'C', 'GIT_TRACE': '1'}}
 
 ENV_TO_ATTR = {'THEFUCK_RULES': 'rules',
                'THEFUCK_WAIT_COMMAND': 'wait_command',


### PR DESCRIPTION
`LC_ALL` overrides `LANG`
 
Bug:
```
$ export LC_ALL=ru_RU.utf8
$ apt-get install vim
E: Не удалось открыть файл блокировки /var/lib/dpkg/lock - open (13: Отказано в доступе)
E: Не удалось выполнить блокировку управляющего каталога (/var/lib/dpkg/); у вас есть права суперпользователя?
$ fuck
apt-get install ho [enter/ctrl+c]
```
should be `sudo apt-get install vim [enter/ctrl+c]`

```
$ unset LC_ALL
$ apt-get install vim
E: Не удалось открыть файл блокировки /var/lib/dpkg/lock - open (13: Отказано в доступе)
E: Не удалось выполнить блокировку управляющего каталога (/var/lib/dpkg/); у вас есть права суперпользователя?
$ fuck
sudo apt-get install vim [enter/ctrl+c]
```

See also: http://unix.stackexchange.com/a/87763/120177