### PR TITLE
Make a `sudo` pattern more general

### DIFF
--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -13,7 +13,7 @@ patterns = ['permission denied',
             'must be root',
             'need to be root',
             'need root',
-            'only root can do that',
+            'only root can ',
             'You don\'t have access to the history DB.',
             'authentication is required']
 


### PR DESCRIPTION
```
% mount -o uid=martin /dev/sdc1 mnt
mount: only root can use "--options" option
```