### PR TITLE
hdfs -rm -r /directory and hdfs -mkdir -p /directory/sub support

### DIFF
--- a/tests/rules/test_mkdir_p.py
+++ b/tests/rules/test_mkdir_p.py
@@ -3,20 +3,29 @@ from thefuck.rules.mkdir_p import match, get_new_command
 from tests.utils import Command
 
 
-def test_match():
-    assert match(Command('mkdir foo/bar/baz',
-                         stderr='mkdir: foo/bar: No such file or directory'),
-                 None)
+@pytest.mark.parametrize('command', [
+    Command('mkdir foo/bar/baz', stderr='mkdir: foo/bar: No such file or directory'),
+    Command('./bin/hdfs dfs -mkdir foo/bar/baz', stderr='mkdir: `foo/bar/baz\': No such file or directory'),
+    Command('hdfs dfs -mkdir foo/bar/baz', stderr='mkdir: `foo/bar/baz\': No such file or directory')
+    ])
+def test_match(command):
+    assert match(command, None)
 
 
 @pytest.mark.parametrize('command', [
     Command('mkdir foo/bar/baz'),
     Command('mkdir foo/bar/baz', stderr='foo bar baz'),
+    Command('hdfs dfs -mkdir foo/bar/baz'),
+    Command('./bin/hdfs dfs -mkdir foo/bar/baz'),
     Command()])
 def test_not_match(command):
     assert not match(command, None)
 
 
-def test_get_new_command():
-    assert get_new_command(Command('mkdir foo/bar/baz'), None)\
-           == 'mkdir -p foo/bar/baz'
+@pytest.mark.parametrize('command, new_command', [
+    (Command('mkdir foo/bar/baz'), 'mkdir -p foo/bar/baz'),
+    (Command('hdfs dfs -mkdir foo/bar/baz'), 'hdfs dfs -mkdir -p foo/bar/baz'),
+    (Command('./bin/hdfs dfs -mkdir foo/bar/baz'), './bin/hdfs dfs -mkdir -p foo/bar/baz')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command, None) == new_command
+

--- a/tests/rules/test_rm_dir.py
+++ b/tests/rules/test_rm_dir.py
@@ -5,17 +5,28 @@ from tests.utils import Command
 
 @pytest.mark.parametrize('command', [
     Command('rm foo', stderr='rm: foo: is a directory'),
-    Command('rm foo', stderr='rm: foo: Is a directory')])
+    Command('rm foo', stderr='rm: foo: Is a directory'),
+    Command('hdfs dfs -rm foo', stderr='rm: `foo`: Is a directory'),
+    Command('./bin/hdfs dfs -rm foo', stderr='rm: `foo`: Is a directory')
+    ])
 def test_match(command):
     assert match(command, None)
     assert match(command, None)
 
 
 @pytest.mark.parametrize('command', [
-    Command('rm foo'), Command('rm foo'), Command()])
+    Command('rm foo'), 
+    Command('hdfs dfs -rm foo'),
+    Command('./bin/hdfs dfs -rm foo'),  
+    Command()])
 def test_not_match(command):
     assert not match(command, None)
 
 
-def test_get_new_command():
-    assert get_new_command(Command('rm foo', '', ''), None) == 'rm -rf foo'
+@pytest.mark.parametrize('command, new_command', [
+    (Command('rm foo'), 'rm -rf foo'),
+    (Command('hdfs dfs -rm foo'), 'hdfs dfs -rm -r foo')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command, None) == new_command
+
+

--- a/tests/rules/test_rm_dir.py
+++ b/tests/rules/test_rm_dir.py
@@ -11,7 +11,6 @@ from tests.utils import Command
     ])
 def test_match(command):
     assert match(command, None)
-    assert match(command, None)
 
 
 @pytest.mark.parametrize('command', [

--- a/thefuck/rules/mkdir_p.py
+++ b/thefuck/rules/mkdir_p.py
@@ -10,4 +10,4 @@ def match(command, settings):
 
 @sudo_support
 def get_new_command(command, settings):
-    return re.sub('^mkdir (.*)', 'mkdir -p \\1', command.script)
+    return re.sub('\\bmkdir (.*)', 'mkdir -p \\1', command.script)

--- a/thefuck/rules/rm_dir.py
+++ b/thefuck/rules/rm_dir.py
@@ -10,4 +10,7 @@ def match(command, settings):
 
 @sudo_support
 def get_new_command(command, settings):
-    return re.sub('^rm (.*)', 'rm -rf \\1', command.script)
+    arguments = '-rf'
+    if 'hdfs' in command.script:
+        arguments = '-r'
+    return re.sub('\\brm (.*)', 'rm ' + arguments + ' \\1', command.script)


### PR DESCRIPTION
This expands the rm_dir and mkdir_p rules to also work with hdfs commands. 