### PR TITLE
Fix slowness problems

### DIFF
--- a/tests/rules/test_mercurial.py
+++ b/tests/rules/test_mercurial.py
@@ -2,7 +2,7 @@ import pytest
 
 from tests.utils import Command
 from thefuck.rules.mercurial import (
-    extract_possisiblities, match, get_new_command
+    extract_possibilities, match, get_new_command
 )
 
 
@@ -96,8 +96,8 @@ def test_not_match(command):
         '\n    rebase recover remove rename resolve revert'
     )), ['rebase', 'recover', 'remove', 'rename', 'resolve', 'revert']),
 ])
-def test_extract_possisiblities(command, possibilities):
-    assert extract_possisiblities(command) == possibilities
+def test_extract_possibilities(command, possibilities):
+    assert extract_possibilities(command) == possibilities
 
 
 @pytest.mark.parametrize('command, new_command', [

--- a/thefuck/rules/dirty_untar.py
+++ b/thefuck/rules/dirty_untar.py
@@ -13,12 +13,12 @@ def _is_tar_extract(cmd):
 
 
 def _tar_file(cmd):
-    tar_extentions = ('.tar', '.tar.Z', '.tar.bz2', '.tar.gz', '.tar.lz',
+    tar_extensions = ('.tar', '.tar.Z', '.tar.bz2', '.tar.gz', '.tar.lz',
                       '.tar.lzma', '.tar.xz', '.taz', '.tb2', '.tbz', '.tbz2',
                       '.tgz', '.tlz', '.txz', '.tz')
 
     for c in cmd.split():
-        for ext in tar_extentions:
+        for ext in tar_extensions:
             if c.endswith(ext):
                 return (c, c[0:len(c)-len(ext)])
 

--- a/thefuck/rules/mercurial.py
+++ b/thefuck/rules/mercurial.py
@@ -2,7 +2,7 @@ import re
 from thefuck.utils import get_closest
 
 
-def extract_possisiblities(command):
+def extract_possibilities(command):
     possib = re.findall(r'\n\(did you mean one of ([^\?]+)\?\)', command.stderr)
     if possib:
         return possib[0].split(', ')
@@ -24,6 +24,6 @@ def match(command, settings):
 
 def get_new_command(command, settings):
     script = command.script.split(' ')
-    possisiblities = extract_possisiblities(command)
-    script[1] = get_closest(script[1], possisiblities)
+    possibilities = extract_possibilities(command)
+    script[1] = get_closest(script[1], possibilities)
     return ' '.join(script)

--- a/thefuck/shells.py
+++ b/thefuck/shells.py
@@ -84,6 +84,7 @@ class Bash(Generic):
             value = value[1:-1]
         return name, value
 
+    @memoize
     def get_aliases(self):
         proc = Popen('bash -ic alias', stdout=PIPE, stderr=DEVNULL,
                      shell=True)
@@ -118,15 +119,16 @@ class Fish(Generic):
                 "    set -l exit_code $status\n"
                 "    set -l eval_script"
                 " (mktemp 2>/dev/null ; or mktemp -t 'thefuck')\n"
-                "    set -l fucked_up_commandd $history[1]\n"
-                "    thefuck $fucked_up_commandd > $eval_script\n"
+                "    set -l fucked_up_command $history[1]\n"
+                "    thefuck $fucked_up_command > $eval_script\n"
                 "    . $eval_script\n"
                 "    rm $eval_script\n"
                 "    if test $exit_code -ne 0\n"
-                "        history --delete $fucked_up_commandd\n"
+                "        history --delete $fucked_up_command\n"
                 "    end\n"
                 "end").format(fuck)
 
+    @memoize
     def get_aliases(self):
         overridden = self._get_overridden_aliases()
         proc = Popen('fish -ic functions', stdout=PIPE, stderr=DEVNULL,
@@ -168,6 +170,7 @@ class Zsh(Generic):
             value = value[1:-1]
         return name, value
 
+    @memoize
     def get_aliases(self):
         proc = Popen('zsh -ic alias', stdout=PIPE, stderr=DEVNULL,
                      shell=True)
@@ -200,6 +203,7 @@ class Tcsh(Generic):
         name, value = alias.split("\t", 1)
         return name, value
 
+    @memoize
     def get_aliases(self):
         proc = Popen('tcsh -ic alias', stdout=PIPE, stderr=DEVNULL,
                      shell=True)
@@ -257,7 +261,6 @@ def and_(*commands):
     return _get_shell().and_(*commands)
 
 
-@memoize
 def get_aliases():
     return list(_get_shell().get_aliases().keys())
 


### PR DESCRIPTION
While searching for a solution for #334 I discovered that the `@memoize` annotation is not applied to the right place and so the shell was always executed twice to get the aliases list.
On my system with zsh:
```shell
# before:
% time thefuck test
No fucks given
thefuck test  0.87s user 0.10s system 96% cpu 1.003 total
# after:
% time thefuck test           
No fucks given
thefuck test  0.50s user 0.07s system 96% cpu 0.588 total
```

Now that this is fixed, the `history` rule is still the longest one, but this has become reasonable (~40ms with a 10k lines history file on my system).