### PR TITLE
Don't pass `settings` explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,20 +226,21 @@ For adding your own rule you should create `your-rule-name.py`
 in `~/.thefuck/rules`. The rule should contain two functions:
 
 ```python
-match(command: Command, settings: Settings) -> bool
-get_new_command(command: Command, settings: Settings) -> str | list[str]
+match(command: Command) -> bool
+get_new_command(command: Command) -> str | list[str]
 ```
 
 Also the rule can contain an optional function
 
 ```python
-side_effect(old_command: Command, fixed_command: str, settings: Settings) -> None
+side_effect(old_command: Command, fixed_command: str) -> None
 ```
 and optional `enabled_by_default`, `requires_output` and `priority` variables.
 
 `Command` has three attributes: `script`, `stdout` and `stderr`.
 
-`Settings` is a special object filled with `~/.thefuck/settings.py` and values from env ([see more below](#settings)).
+*Rules api changed in 3.0:* For accessing settings in rule you need to import it with `from thefuck.conf import settings`.
+`settings` is a special object filled with `~/.thefuck/settings.py` and values from env ([see more below](#settings)).
 
 Simple example of the rule for running script with `sudo`:
 
@@ -264,7 +265,8 @@ requires_output = True
 ```
 
 [More examples of rules](https://github.com/nvbn/thefuck/tree/master/thefuck/rules),
-[utility functions for rules](https://github.com/nvbn/thefuck/tree/master/thefuck/utils.py).
+[utility functions for rules](https://github.com/nvbn/thefuck/tree/master/thefuck/utils.py),
+[app/os-specific helpers](https://github.com/nvbn/thefuck/tree/master/thefuck/specific/).
 
 ## Settings
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import Mock
+from thefuck import conf
 
 
 def pytest_addoption(parser):
@@ -14,9 +14,15 @@ def no_memoize(monkeypatch):
     monkeypatch.setattr('thefuck.utils.memoize.disabled', True)
 
 
+@pytest.fixture(autouse=True)
+def settings(request):
+    request.addfinalizer(lambda: conf.settings.update(conf.DEFAULT_SETTINGS))
+    return conf.settings
+
+
 @pytest.fixture
-def settings():
-    return Mock(debug=False, no_colors=True)
+def no_colors(settings):
+    settings.no_colors = True
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import pytest
 from thefuck import conf
 
@@ -16,7 +17,12 @@ def no_memoize(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def settings(request):
-    request.addfinalizer(lambda: conf.settings.update(conf.DEFAULT_SETTINGS))
+    def _reset_settings():
+        conf.settings.clear()
+        conf.settings.update(conf.DEFAULT_SETTINGS)
+
+    request.addfinalizer(_reset_settings)
+    conf.settings.user_dir = Path('~/.thefuck')
     return conf.settings
 
 

--- a/tests/rules/test_apt_get.py
+++ b/tests/rules/test_apt_get.py
@@ -11,7 +11,7 @@ from tests.utils import Command
 @pytest.mark.parametrize('command', [
     Command(script='vim', stderr='vim: command not found')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command, return_value', [
@@ -24,7 +24,7 @@ def test_match(command):
 def test_match_mocked(cmdnf_mock, command, return_value):
     get_packages = Mock(return_value=return_value)
     cmdnf_mock.CommandNotFound.return_value = Mock(getPackages=get_packages)
-    assert match(command, None)
+    assert match(command)
     assert cmdnf_mock.CommandNotFound.called
     assert get_packages.called
 
@@ -32,7 +32,7 @@ def test_match_mocked(cmdnf_mock, command, return_value):
 @pytest.mark.parametrize('command', [
     Command(script='vim', stderr=''), Command()])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 # python-commandnotfound is available in ubuntu 14.04+
@@ -44,7 +44,7 @@ def test_not_match(command):
     (Command('sudo vim'), 'sudo apt-get install vim && sudo vim'),
     (Command('sudo convert'), 'sudo apt-get install imagemagick && sudo convert')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command
 
 
 @pytest.mark.parametrize('command, new_command, return_value', [
@@ -63,4 +63,4 @@ def test_get_new_command(command, new_command):
 def test_get_new_command_mocked(cmdnf_mock, command, new_command, return_value):
     get_packages = Mock(return_value=return_value)
     cmdnf_mock.CommandNotFound.return_value = Mock(getPackages=get_packages)
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_apt_get_search.py
+++ b/tests/rules/test_apt_get_search.py
@@ -4,7 +4,7 @@ from tests.utils import Command
 
 
 def test_match():
-    assert match(Command('apt-get search foo'), None)
+    assert match(Command('apt-get search foo'))
 
 
 @pytest.mark.parametrize('command', [
@@ -18,8 +18,8 @@ def test_match():
     Command('apt-get update')
 ])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 def test_get_new_command():
-    assert get_new_command(Command('apt-get search foo'), None) == 'apt-cache search foo'
+    assert get_new_command(Command('apt-get search foo')) == 'apt-cache search foo'

--- a/tests/rules/test_brew_install.py
+++ b/tests/rules/test_brew_install.py
@@ -28,9 +28,9 @@ def _is_not_okay_to_test():
 def test_match(brew_no_available_formula, brew_already_installed,
                brew_install_no_argument):
     assert match(Command('brew install elsticsearch',
-                         stderr=brew_no_available_formula), None)
+                         stderr=brew_no_available_formula))
     assert not match(Command('brew install git',
-                             stderr=brew_already_installed), None)
+                             stderr=brew_already_installed))
     assert not match(Command('brew install', stderr=brew_install_no_argument),
                      None)
 
@@ -39,7 +39,7 @@ def test_match(brew_no_available_formula, brew_already_installed,
                     reason='No need to run if there\'s no formula')
 def test_get_new_command(brew_no_available_formula):
     assert get_new_command(Command('brew install elsticsearch',
-                                   stderr=brew_no_available_formula), None)\
+                                   stderr=brew_no_available_formula))\
         == 'brew install elasticsearch'
 
     assert get_new_command(Command('brew install aa',

--- a/tests/rules/test_brew_unknown_command.py
+++ b/tests/rules/test_brew_unknown_command.py
@@ -15,15 +15,15 @@ def brew_unknown_cmd2():
 
 
 def test_match(brew_unknown_cmd):
-    assert match(Command('brew inst', stderr=brew_unknown_cmd), None)
+    assert match(Command('brew inst', stderr=brew_unknown_cmd))
     for command in _brew_commands():
-        assert not match(Command('brew ' + command), None)
+        assert not match(Command('brew ' + command))
 
 
 def test_get_new_command(brew_unknown_cmd, brew_unknown_cmd2):
-    assert get_new_command(Command('brew inst', stderr=brew_unknown_cmd),
-                           None) == ['brew list', 'brew install', 'brew uninstall']
+    assert get_new_command(Command('brew inst', stderr=brew_unknown_cmd)) \
+           == ['brew list', 'brew install', 'brew uninstall']
 
-    cmds = get_new_command(Command('brew instaa', stderr=brew_unknown_cmd2), None)
+    cmds = get_new_command(Command('brew instaa', stderr=brew_unknown_cmd2))
     assert 'brew install' in cmds
     assert 'brew uninstall' in cmds

--- a/tests/rules/test_brew_upgrade.py
+++ b/tests/rules/test_brew_upgrade.py
@@ -6,10 +6,10 @@ from tests.utils import Command
 @pytest.mark.parametrize('command', [
     Command(script='brew upgrade')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
     (Command('brew upgrade'), 'brew upgrade --all')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_cargo_no_command.py
+++ b/tests/rules/test_cargo_no_command.py
@@ -12,10 +12,10 @@ no_such_subcommand = """No such subcommand
 @pytest.mark.parametrize('command', [
     Command(script='cargo buid', stderr=no_such_subcommand)])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
     (Command('cargo buid', stderr=no_such_subcommand), 'cargo build')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_cd_mkdir.py
+++ b/tests/rules/test_cd_mkdir.py
@@ -9,17 +9,17 @@ from tests.utils import Command
             stderr='cd: foo: No such file or directory'),
     Command(script='cd foo/bar/baz', stderr='cd: can\'t cd to foo/bar/baz')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
     Command(script='cd foo', stderr=''), Command()])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
     (Command('cd foo'), 'mkdir -p foo && cd foo'),
     (Command('cd foo/bar/baz'), 'mkdir -p foo/bar/baz && cd foo/bar/baz')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_cd_parent.py
+++ b/tests/rules/test_cd_parent.py
@@ -3,10 +3,10 @@ from tests.utils import Command
 
 
 def test_match():
-    assert match(Command('cd..', stderr='cd..: command not found'), None)
-    assert not match(Command(), None)
+    assert match(Command('cd..', stderr='cd..: command not found'))
+    assert not match(Command())
 
 
 def test_get_new_command():
     assert get_new_command(
-        Command('cd..'), None) == 'cd ..'
+        Command('cd..')) == 'cd ..'

--- a/tests/rules/test_composer_not_command.py
+++ b/tests/rules/test_composer_not_command.py
@@ -41,17 +41,16 @@ def composer_not_command_one_of_this():
 
 def test_match(composer_not_command, composer_not_command_one_of_this):
     assert match(Command('composer udpate',
-                         stderr=composer_not_command), None)
+                         stderr=composer_not_command))
     assert match(Command('composer pdate',
-                         stderr=composer_not_command_one_of_this), None)
-    assert not match(Command('ls update', stderr=composer_not_command),
-                     None)
+                         stderr=composer_not_command_one_of_this))
+    assert not match(Command('ls update', stderr=composer_not_command))
 
 
 def test_get_new_command(composer_not_command, composer_not_command_one_of_this):
     assert get_new_command(Command('composer udpate',
-                                   stderr=composer_not_command), None) \
+                                   stderr=composer_not_command)) \
            == 'composer update'
     assert get_new_command(
-        Command('composer pdate', stderr=composer_not_command_one_of_this),
-        None) == 'composer selfupdate'
+        Command('composer pdate', stderr=composer_not_command_one_of_this)) \
+           == 'composer selfupdate'

--- a/tests/rules/test_cp_omitting_directory.py
+++ b/tests/rules/test_cp_omitting_directory.py
@@ -7,7 +7,7 @@ from tests.utils import Command
     ('cp dir', 'cp: dor: is a directory'),
     ('cp dir', "cp: omitting directory 'dir'")])
 def test_match(script, stderr):
-    assert match(Command(script, stderr=stderr), None)
+    assert match(Command(script, stderr=stderr))
 
 
 @pytest.mark.parametrize('script, stderr', [
@@ -15,8 +15,8 @@ def test_match(script, stderr):
     ('some dir', "cp: omitting directory 'dir'"),
     ('cp dir', '')])
 def test_not_match(script, stderr):
-    assert not match(Command(script, stderr=stderr), None)
+    assert not match(Command(script, stderr=stderr))
 
 
 def test_get_new_command():
-    assert get_new_command(Command(script='cp dir'), None) == 'cp -a dir'
+    assert get_new_command(Command(script='cp dir')) == 'cp -a dir'

--- a/tests/rules/test_dirty_untar.py
+++ b/tests/rules/test_dirty_untar.py
@@ -45,14 +45,14 @@ parametrize_script = pytest.mark.parametrize('script, fixed', [
 @parametrize_script
 def test_match(tar_error, filename, script, fixed):
     tar_error(filename)
-    assert match(Command(script=script.format(filename)), None)
+    assert match(Command(script=script.format(filename)))
 
 
 @parametrize_filename
 @parametrize_script
 def test_side_effect(tar_error, filename, script, fixed):
     tar_error(filename)
-    side_effect(Command(script=script.format(filename)), None, None)
+    side_effect(Command(script=script.format(filename)), None)
     assert(os.listdir('.') == [filename])
 
 
@@ -60,4 +60,4 @@ def test_side_effect(tar_error, filename, script, fixed):
 @parametrize_script
 def test_get_new_command(tar_error, filename, script, fixed):
     tar_error(filename)
-    assert get_new_command(Command(script=script.format(filename)), None) == fixed.format(filename)
+    assert get_new_command(Command(script=script.format(filename))) == fixed.format(filename)

--- a/tests/rules/test_dirty_unzip.py
+++ b/tests/rules/test_dirty_unzip.py
@@ -27,14 +27,14 @@ def zip_error(tmpdir):
     'unzip foo',
     'unzip foo.zip'])
 def test_match(zip_error, script):
-    assert match(Command(script=script), None)
+    assert match(Command(script=script))
 
 
 @pytest.mark.parametrize('script', [
     'unzip foo',
     'unzip foo.zip'])
 def test_side_effect(zip_error, script):
-    side_effect(Command(script=script), None, None)
+    side_effect(Command(script=script), None)
     assert(os.listdir('.') == ['foo.zip'])
 
 
@@ -42,4 +42,4 @@ def test_side_effect(zip_error, script):
     ('unzip foo', 'unzip foo -d foo'),
     ('unzip foo.zip', 'unzip foo.zip -d foo')])
 def test_get_new_command(zip_error, script, fixed):
-    assert get_new_command(Command(script=script), None) == fixed
+    assert get_new_command(Command(script=script)) == fixed

--- a/tests/rules/test_django_south_ghost.py
+++ b/tests/rules/test_django_south_ghost.py
@@ -41,13 +41,13 @@ south.exceptions.GhostMigrations:
 
 
 def test_match(stderr):
-    assert match(Command('./manage.py migrate', stderr=stderr), None)
-    assert match(Command('python manage.py migrate', stderr=stderr), None)
-    assert not match(Command('./manage.py migrate'), None)
-    assert not match(Command('app migrate', stderr=stderr), None)
-    assert not match(Command('./manage.py test', stderr=stderr), None)
+    assert match(Command('./manage.py migrate', stderr=stderr))
+    assert match(Command('python manage.py migrate', stderr=stderr))
+    assert not match(Command('./manage.py migrate'))
+    assert not match(Command('app migrate', stderr=stderr))
+    assert not match(Command('./manage.py test', stderr=stderr))
 
 
 def test_get_new_command():
-    assert get_new_command(Command('./manage.py migrate auth'), None)\
+    assert get_new_command(Command('./manage.py migrate auth'))\
         == './manage.py migrate auth --delete-ghost-migrations'

--- a/tests/rules/test_django_south_merge.py
+++ b/tests/rules/test_django_south_merge.py
@@ -31,13 +31,13 @@ The following options are available:
 
 
 def test_match(stderr):
-    assert match(Command('./manage.py migrate', stderr=stderr), None)
-    assert match(Command('python manage.py migrate', stderr=stderr), None)
-    assert not match(Command('./manage.py migrate'), None)
-    assert not match(Command('app migrate', stderr=stderr), None)
-    assert not match(Command('./manage.py test', stderr=stderr), None)
+    assert match(Command('./manage.py migrate', stderr=stderr))
+    assert match(Command('python manage.py migrate', stderr=stderr))
+    assert not match(Command('./manage.py migrate'))
+    assert not match(Command('app migrate', stderr=stderr))
+    assert not match(Command('./manage.py test', stderr=stderr))
 
 
 def test_get_new_command():
-    assert get_new_command(Command('./manage.py migrate auth'), None) \
+    assert get_new_command(Command('./manage.py migrate auth')) \
            == './manage.py migrate auth --merge'

--- a/tests/rules/test_docker_not_command.py
+++ b/tests/rules/test_docker_not_command.py
@@ -110,14 +110,14 @@ def stderr(cmd):
 
 
 def test_match():
-    assert match(Command('docker pes', stderr=stderr('pes')), None)
+    assert match(Command('docker pes', stderr=stderr('pes')))
 
 
 @pytest.mark.parametrize('script, stderr', [
     ('docker ps', ''),
     ('cat pes', stderr('pes'))])
 def test_not_match(script, stderr):
-    assert not match(Command(script, stderr=stderr), None)
+    assert not match(Command(script, stderr=stderr))
 
 
 @pytest.mark.usefixtures('docker_help')
@@ -126,4 +126,4 @@ def test_not_match(script, stderr):
     ('tags', ['tag', 'stats', 'images'])])
 def test_get_new_command(wrong, fixed):
     command = Command('docker {}'.format(wrong), stderr=stderr(wrong))
-    assert get_new_command(command, None) == ['docker {}'.format(x) for x in fixed]
+    assert get_new_command(command) == ['docker {}'.format(x) for x in fixed]

--- a/tests/rules/test_dry.py
+++ b/tests/rules/test_dry.py
@@ -7,11 +7,11 @@ from tests.utils import Command
     Command(script='cd cd foo'),
     Command(script='git git push origin/master')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
     (Command('cd cd foo'), 'cd foo'),
     (Command('git git push origin/master'), 'git push origin/master')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_fix_alt_space.py
+++ b/tests/rules/test_fix_alt_space.py
@@ -11,12 +11,12 @@ def test_match():
 
     """
     assert match(Command(u'ps -ef | grep foo',
-                         stderr=u'-bash:  grep: command not found'), None)
-    assert not match(Command('ps -ef | grep foo'), None)
-    assert not match(Command(), None)
+                         stderr=u'-bash:  grep: command not found'))
+    assert not match(Command('ps -ef | grep foo'))
+    assert not match(Command())
 
 
 def test_get_new_command():
     """ Replace the Alt+Space character by a simple space """
-    assert get_new_command(Command(u'ps -ef | grep foo'), None)\
+    assert get_new_command(Command(u'ps -ef | grep foo'))\
            == 'ps -ef | grep foo'

--- a/tests/rules/test_fix_file.py
+++ b/tests/rules/test_fix_file.py
@@ -184,7 +184,7 @@ E       NameError: name 'mocker' is not defined
 def test_match(mocker, monkeypatch, test):
     mocker.patch('os.path.isfile', return_value=True)
     monkeypatch.setenv('EDITOR', 'dummy_editor')
-    assert match(Command(stdout=test[4], stderr=test[5]), None)
+    assert match(Command(stdout=test[4], stderr=test[5]))
 
 
 @pytest.mark.parametrize('test', tests)
@@ -194,7 +194,7 @@ def test_no_editor(mocker, monkeypatch, test):
     if 'EDITOR' in os.environ:
         monkeypatch.delenv('EDITOR')
 
-    assert not match(Command(stdout=test[4], stderr=test[5]), None)
+    assert not match(Command(stdout=test[4], stderr=test[5]))
 
 
 @pytest.mark.parametrize('test', tests)
@@ -203,7 +203,7 @@ def test_not_file(mocker, monkeypatch, test):
     mocker.patch('os.path.isfile', return_value=False)
     monkeypatch.setenv('EDITOR', 'dummy_editor')
 
-    assert not match(Command(stdout=test[4], stderr=test[5]), None)
+    assert not match(Command(stdout=test[4], stderr=test[5]))
 
 
 @pytest.mark.parametrize('test', tests)
@@ -219,16 +219,16 @@ def test_get_new_command(mocker, monkeypatch, test):
 
 @pytest.mark.parametrize('test', tests)
 @pytest.mark.usefixtures('no_memoize')
-def test_get_new_command_with_settings(mocker, monkeypatch, test):
+def test_get_new_command_with_settings(mocker, monkeypatch, test, settings):
     mocker.patch('os.path.isfile', return_value=True)
     monkeypatch.setenv('EDITOR', 'dummy_editor')
 
     cmd = Command(script=test[0], stdout=test[4], stderr=test[5])
-    settings = Settings({'fixcolcmd': '{editor} {file} +{line}:{col}'})
+    settings.fixcolcmd = '{editor} {file} +{line}:{col}'
 
     if test[3]:
-        assert (get_new_command(cmd, settings) ==
+        assert (get_new_command(cmd) ==
             'dummy_editor {} +{}:{} && {}'.format(test[1], test[2], test[3], test[0]))
     else:
-        assert (get_new_command(cmd, settings) ==
+        assert (get_new_command(cmd) ==
             'dummy_editor {} +{} && {}'.format(test[1], test[2], test[0]))

--- a/tests/rules/test_git_add.py
+++ b/tests/rules/test_git_add.py
@@ -18,7 +18,7 @@ def did_not_match(target, did_you_forget=True):
     Command(script='git commit unknown',
             stderr=did_not_match('unknown'))])  # Older versions of Git
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -27,7 +27,7 @@ def test_match(command):
     Command(script='git commit unknown',  # Newer versions of Git
             stderr=did_not_match('unknown', False))])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
@@ -36,4 +36,4 @@ def test_not_match(command):
     (Command('git commit unknown', stderr=did_not_match('unknown')),  # Old Git
      'git add -- unknown && git commit unknown')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_git_branch_delete.py
+++ b/tests/rules/test_git_branch_delete.py
@@ -12,11 +12,11 @@ If you are sure you want to delete it, run 'git branch -D branch'.
 
 
 def test_match(stderr):
-    assert match(Command('git branch -d branch', stderr=stderr), None)
-    assert not match(Command('git branch -d branch'), None)
-    assert not match(Command('ls', stderr=stderr), None)
+    assert match(Command('git branch -d branch', stderr=stderr))
+    assert not match(Command('git branch -d branch'))
+    assert not match(Command('ls', stderr=stderr))
 
 
 def test_get_new_command(stderr):
-    assert get_new_command(Command('git branch -d branch', stderr=stderr), None)\
+    assert get_new_command(Command('git branch -d branch', stderr=stderr))\
         == "git branch -D branch"

--- a/tests/rules/test_git_branch_list.py
+++ b/tests/rules/test_git_branch_list.py
@@ -4,16 +4,16 @@ from tests.utils import Command
 
 
 def test_match():
-    assert match(Command('git branch list'), None)
+    assert match(Command('git branch list'))
 
 
 def test_not_match():
-    assert not match(Command(), None)
-    assert not match(Command('git commit'), None)
-    assert not match(Command('git branch'), None)
-    assert not match(Command('git stash list'), None)
+    assert not match(Command())
+    assert not match(Command('git commit'))
+    assert not match(Command('git branch'))
+    assert not match(Command('git stash list'))
 
 
 def test_get_new_command():
-    assert (get_new_command(Command('git branch list'), None) ==
+    assert (get_new_command(Command('git branch list')) ==
             shells.and_('git branch --delete list', 'git branch'))

--- a/tests/rules/test_git_checkout.py
+++ b/tests/rules/test_git_checkout.py
@@ -21,7 +21,7 @@ def get_branches(mocker):
     Command(script='git checkout unknown', stderr=did_not_match('unknown')),
     Command(script='git commit unknown', stderr=did_not_match('unknown'))])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -30,7 +30,7 @@ def test_match(command):
     Command(script='git checkout known', stderr=('')),
     Command(script='git commit known', stderr=(''))])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('branches, command, new_command', [
@@ -50,4 +50,4 @@ def test_not_match(command):
      'git commit test-random-branch-123')])
 def test_get_new_command(branches, command, new_command, get_branches):
     get_branches.return_value = branches
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_git_diff_staged.py
+++ b/tests/rules/test_git_diff_staged.py
@@ -7,7 +7,7 @@ from tests.utils import Command
     Command(script='git diff foo'),
     Command(script='git diff')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -16,11 +16,11 @@ def test_match(command):
     Command(script='git branch'),
     Command(script='git log')])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
     (Command('git diff'), 'git diff --staged'),
     (Command('git diff foo'), 'git diff --staged foo')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_git_fix_stash.py
+++ b/tests/rules/test_git_fix_stash.py
@@ -20,7 +20,7 @@ usage: git stash list [<options>]
     'git stash Some message',
     'git stash saev Some message'])
 def test_match(wrong):
-    assert match(Command(wrong, stderr=git_stash_err), None)
+    assert match(Command(wrong, stderr=git_stash_err))
 
 
 @pytest.mark.parametrize('wrong,fixed', [
@@ -28,4 +28,4 @@ def test_match(wrong):
     ('git stash Some message', 'git stash save Some message'),
     ('git stash saev Some message', 'git stash save Some message')])
 def test_get_new_command(wrong, fixed):
-    assert get_new_command(Command(wrong, stderr=git_stash_err), None) == fixed
+    assert get_new_command(Command(wrong, stderr=git_stash_err)) == fixed

--- a/tests/rules/test_git_not_command.py
+++ b/tests/rules/test_git_not_command.py
@@ -41,17 +41,17 @@ def git_command():
 
 
 def test_match(git_not_command, git_command, git_not_command_one_of_this):
-    assert match(Command('git brnch', stderr=git_not_command), None)
-    assert match(Command('git st', stderr=git_not_command_one_of_this), None)
-    assert not match(Command('ls brnch', stderr=git_not_command), None)
-    assert not match(Command('git branch', stderr=git_command), None)
+    assert match(Command('git brnch', stderr=git_not_command))
+    assert match(Command('git st', stderr=git_not_command_one_of_this))
+    assert not match(Command('ls brnch', stderr=git_not_command))
+    assert not match(Command('git branch', stderr=git_command))
 
 
 def test_get_new_command(git_not_command, git_not_command_one_of_this,
                          git_not_command_closest):
-    assert get_new_command(Command('git brnch', stderr=git_not_command), None) \
+    assert get_new_command(Command('git brnch', stderr=git_not_command)) \
            == ['git branch']
-    assert get_new_command(Command('git st', stderr=git_not_command_one_of_this),
-                           None) == ['git stats', 'git stash', 'git stage']
-    assert get_new_command(Command('git tags', stderr=git_not_command_closest),
-                           None) == ['git tag', 'git stage']
+    assert get_new_command(Command('git st', stderr=git_not_command_one_of_this)) \
+           == ['git stats', 'git stash', 'git stage']
+    assert get_new_command(Command('git tags', stderr=git_not_command_closest)) \
+           == ['git tag', 'git stage']

--- a/tests/rules/test_git_pull.py
+++ b/tests/rules/test_git_pull.py
@@ -19,11 +19,11 @@ If you wish to set tracking information for this branch you can do so with:
 
 
 def test_match(stderr):
-    assert match(Command('git pull', stderr=stderr), None)
-    assert not match(Command('git pull'), None)
-    assert not match(Command('ls', stderr=stderr), None)
+    assert match(Command('git pull', stderr=stderr))
+    assert not match(Command('git pull'))
+    assert not match(Command('ls', stderr=stderr))
 
 
 def test_get_new_command(stderr):
-    assert get_new_command(Command('git pull', stderr=stderr), None) \
+    assert get_new_command(Command('git pull', stderr=stderr)) \
            == "git branch --set-upstream-to=origin/master master && git pull"

--- a/tests/rules/test_git_pull_clone.py
+++ b/tests/rules/test_git_pull_clone.py
@@ -12,10 +12,10 @@ Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
 @pytest.mark.parametrize('command', [
     Command(script='git pull git@github.com:mcarton/thefuck.git', stderr=git_err)])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command, output', [
     (Command(script='git pull git@github.com:mcarton/thefuck.git', stderr=git_err), 'git clone git@github.com:mcarton/thefuck.git')])
 def test_get_new_command(command, output):
-    assert get_new_command(command, None) == output
+    assert get_new_command(command) == output

--- a/tests/rules/test_git_push.py
+++ b/tests/rules/test_git_push.py
@@ -14,11 +14,11 @@ To push the current branch and set the remote as upstream, use
 
 
 def test_match(stderr):
-    assert match(Command('git push master', stderr=stderr), None)
-    assert not match(Command('git push master'), None)
-    assert not match(Command('ls', stderr=stderr), None)
+    assert match(Command('git push master', stderr=stderr))
+    assert not match(Command('git push master'))
+    assert not match(Command('ls', stderr=stderr))
 
 
 def test_get_new_command(stderr):
-    assert get_new_command(Command('git push', stderr=stderr), None)\
+    assert get_new_command(Command('git push', stderr=stderr))\
         == "git push --set-upstream origin master"

--- a/tests/rules/test_git_push_force.py
+++ b/tests/rules/test_git_push_force.py
@@ -30,7 +30,7 @@ To /tmp/bar
     Command(script='git push nvbn', stderr=git_err),
     Command(script='git push nvbn master', stderr=git_err)])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -41,7 +41,7 @@ def test_match(command):
     Command(script='git push nvbn', stderr=git_ok),
     Command(script='git push nvbn master', stderr=git_uptodate)])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, output', [
@@ -49,4 +49,4 @@ def test_not_match(command):
     (Command(script='git push nvbn', stderr=git_err), 'git push --force nvbn'),
     (Command(script='git push nvbn master', stderr=git_err), 'git push --force nvbn master')])
 def test_get_new_command(command, output):
-    assert get_new_command(command, None) == output
+    assert get_new_command(command) == output

--- a/tests/rules/test_git_push_pull.py
+++ b/tests/rules/test_git_push_pull.py
@@ -30,7 +30,7 @@ To /tmp/bar
     Command(script='git push nvbn', stderr=git_err),
     Command(script='git push nvbn master', stderr=git_err)])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -41,7 +41,7 @@ def test_match(command):
     Command(script='git push nvbn', stderr=git_ok),
     Command(script='git push nvbn master', stderr=git_uptodate)])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, output', [
@@ -51,4 +51,4 @@ def test_not_match(command):
     (Command(script='git push nvbn master', stderr=git_err),
      'git pull nvbn master && git push nvbn master')])
 def test_get_new_command(command, output):
-    assert get_new_command(command, None) == output
+    assert get_new_command(command) == output

--- a/tests/rules/test_git_stash.py
+++ b/tests/rules/test_git_stash.py
@@ -18,14 +18,14 @@ rebase_error = (
     Command(script='git cherry-pick a1b2c3d', stderr=cherry_pick_error),
     Command(script='git rebase -i HEAD~7', stderr=rebase_error)])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
     Command(script='git cherry-pick a1b2c3d', stderr=('')),
     Command(script='git rebase -i HEAD~7', stderr=(''))])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
@@ -34,4 +34,4 @@ def test_not_match(command):
     (Command('git rebase -i HEAD~7', stderr=rebase_error),
      'git stash && git rebase -i HEAD~7')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_go_run.py
+++ b/tests/rules/test_go_run.py
@@ -7,11 +7,11 @@ from tests.utils import Command
     Command(script='go run foo'),
     Command(script='go run bar')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
     (Command('go run foo'), 'go run foo.go'),
     (Command('go run bar'), 'go run bar.go')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_grep_recursive.py
+++ b/tests/rules/test_grep_recursive.py
@@ -3,10 +3,10 @@ from tests.utils import Command
 
 
 def test_match():
-    assert match(Command('grep blah .', stderr='grep: .: Is a directory'), None)
-    assert not match(Command(), None)
+    assert match(Command('grep blah .', stderr='grep: .: Is a directory'))
+    assert not match(Command())
 
 
 def test_get_new_command():
     assert get_new_command(
-        Command('grep blah .'), None) == 'grep -r blah .'
+        Command('grep blah .')) == 'grep -r blah .'

--- a/tests/rules/test_gulp_not_task.py
+++ b/tests/rules/test_gulp_not_task.py
@@ -11,18 +11,18 @@ def stdout(task):
 
 
 def test_match():
-    assert match(Command('gulp srve', stdout('srve')), None)
+    assert match(Command('gulp srve', stdout('srve')))
 
 
 @pytest.mark.parametrize('script, stdout', [
     ('gulp serve', ''),
     ('cat srve', stdout('srve'))])
 def test_not_march(script, stdout):
-    assert not match(Command(script, stdout), None)
+    assert not match(Command(script, stdout))
 
 
 def test_get_new_command(mocker):
     mocker.patch('thefuck.rules.gulp_not_task.get_gulp_tasks', return_value=[
         'serve', 'build', 'default'])
     command = Command('gulp srve', stdout('srve'))
-    assert get_new_command(command, None) == ['gulp serve', 'gulp default']
+    assert get_new_command(command) == ['gulp serve', 'gulp default']

--- a/tests/rules/test_has_exists_script.py
+++ b/tests/rules/test_has_exists_script.py
@@ -4,17 +4,14 @@ from thefuck.rules.has_exists_script import match, get_new_command
 
 def test_match():
     with patch('os.path.exists', return_value=True):
-        assert match(Mock(script='main', stderr='main: command not found'),
-                     None)
+        assert match(Mock(script='main', stderr='main: command not found'))
         assert match(Mock(script='main --help',
-                          stderr='main: command not found'),
-                     None)
-        assert not match(Mock(script='main', stderr=''), None)
+                          stderr='main: command not found'))
+        assert not match(Mock(script='main', stderr=''))
 
     with patch('os.path.exists', return_value=False):
-        assert not match(Mock(script='main', stderr='main: command not found'),
-                         None)
+        assert not match(Mock(script='main', stderr='main: command not found'))
 
 
 def test_get_new_command():
-    assert get_new_command(Mock(script='main --help'), None) == './main --help'
+    assert get_new_command(Mock(script='main --help')) == './main --help'

--- a/tests/rules/test_heroku_not_command.py
+++ b/tests/rules/test_heroku_not_command.py
@@ -16,14 +16,14 @@ no_suggest_stderr = ''' !    `aaaaa` is not a heroku command.
 @pytest.mark.parametrize('cmd', ['log', 'pge'])
 def test_match(cmd):
     assert match(
-        Command('heroku {}'.format(cmd), stderr=suggest_stderr(cmd)), None)
+        Command('heroku {}'.format(cmd), stderr=suggest_stderr(cmd)))
 
 
 @pytest.mark.parametrize('script, stderr', [
     ('cat log', suggest_stderr('log')),
     ('heroku aaa', no_suggest_stderr)])
 def test_not_match(script, stderr):
-    assert not match(Command(script, stderr=stderr), None)
+    assert not match(Command(script, stderr=stderr))
 
 
 @pytest.mark.parametrize('cmd, result', [
@@ -31,4 +31,4 @@ def test_not_match(script, stderr):
     ('pge', ['heroku pg', 'heroku logs'])])
 def test_get_new_command(cmd, result):
     command = Command('heroku {}'.format(cmd), stderr=suggest_stderr(cmd))
-    assert get_new_command(command, None) == result
+    assert get_new_command(command) == result

--- a/tests/rules/test_history.py
+++ b/tests/rules/test_history.py
@@ -25,13 +25,13 @@ def callables(mocker):
 @pytest.mark.usefixtures('history', 'callables', 'no_memoize', 'alias')
 @pytest.mark.parametrize('script', ['ls cet', 'daff x'])
 def test_match(script):
-    assert match(Command(script=script), None)
+    assert match(Command(script=script))
 
 
 @pytest.mark.usefixtures('history', 'callables', 'no_memoize', 'alias')
 @pytest.mark.parametrize('script', ['apt-get', 'nocommand y'])
 def test_not_match(script):
-    assert not match(Command(script=script), None)
+    assert not match(Command(script=script))
 
 
 @pytest.mark.usefixtures('history', 'callables', 'no_memoize', 'alias')
@@ -39,4 +39,4 @@ def test_not_match(script):
     ('ls cet', 'ls cat'),
     ('daff x', 'diff x')])
 def test_get_new_command(script, result):
-    assert get_new_command(Command(script), None) == result
+    assert get_new_command(Command(script)) == result

--- a/tests/rules/test_java.py
+++ b/tests/rules/test_java.py
@@ -7,11 +7,11 @@ from tests.utils import Command
     Command(script='java foo.java'),
     Command(script='java bar.java')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
     (Command('java foo.java'), 'java foo'),
     (Command('java bar.java'), 'java bar')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_javac.py
+++ b/tests/rules/test_javac.py
@@ -7,11 +7,11 @@ from tests.utils import Command
     Command(script='javac foo'),
     Command(script='javac bar')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
     (Command('javac foo'), 'javac foo.java'),
     (Command('javac bar'), 'javac bar.java')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_lein_not_task.py
+++ b/tests/rules/test_lein_not_task.py
@@ -14,10 +14,10 @@ Did you mean this?
 
 
 def test_match(is_not_task):
-    assert match(Command(script='lein rpl', stderr=is_not_task), None)
-    assert not match(Command(script='ls', stderr=is_not_task), None)
+    assert match(Command(script='lein rpl', stderr=is_not_task))
+    assert not match(Command(script='ls', stderr=is_not_task))
 
 
 def test_get_new_command(is_not_task):
-    assert get_new_command(Command(script='lein rpl --help', stderr=is_not_task),
-                           None) == ['lein repl --help', 'lein jar --help']
+    assert get_new_command(Command(script='lein rpl --help', stderr=is_not_task)) \
+           == ['lein repl --help', 'lein jar --help']

--- a/tests/rules/test_ls_lah.py
+++ b/tests/rules/test_ls_lah.py
@@ -3,14 +3,14 @@ from tests.utils import Command
 
 
 def test_match():
-    assert match(Command(script='ls'), None)
-    assert match(Command(script='ls file.py'), None)
-    assert match(Command(script='ls /opt'), None)
-    assert not match(Command(script='ls -lah /opt'), None)
-    assert not match(Command(script='pacman -S binutils'), None)
-    assert not match(Command(script='lsof'), None)
+    assert match(Command(script='ls'))
+    assert match(Command(script='ls file.py'))
+    assert match(Command(script='ls /opt'))
+    assert not match(Command(script='ls -lah /opt'))
+    assert not match(Command(script='pacman -S binutils'))
+    assert not match(Command(script='lsof'))
 
 
 def test_get_new_command():
-    assert get_new_command(Command(script='ls file.py'), None) == 'ls -lah file.py'
-    assert get_new_command(Command(script='ls'), None) == 'ls -lah'
+    assert get_new_command(Command(script='ls file.py')) == 'ls -lah file.py'
+    assert get_new_command(Command(script='ls')) == 'ls -lah'

--- a/tests/rules/test_man.py
+++ b/tests/rules/test_man.py
@@ -12,14 +12,14 @@ from tests.utils import Command
     Command('man -s 2 read'),
     Command('man -s 3 read')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
     Command('man'),
     Command('man ')])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
@@ -31,4 +31,4 @@ def test_not_match(command):
     (Command('man -s 2 read'), 'man -s 3 read'),
     (Command('man -s 3 read'), 'man -s 2 read')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_man_no_space.py
+++ b/tests/rules/test_man_no_space.py
@@ -3,10 +3,10 @@ from tests.utils import Command
 
 
 def test_match():
-    assert match(Command('mandiff', stderr='mandiff: command not found'), None)
-    assert not match(Command(), None)
+    assert match(Command('mandiff', stderr='mandiff: command not found'))
+    assert not match(Command())
 
 
 def test_get_new_command():
     assert get_new_command(
-        Command('mandiff'), None) == 'man diff'
+        Command('mandiff')) == 'man diff'

--- a/tests/rules/test_mercurial.py
+++ b/tests/rules/test_mercurial.py
@@ -37,7 +37,7 @@ from thefuck.rules.mercurial import (
     )),
 ])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -63,7 +63,7 @@ def test_match(command):
     )),
 ])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, possibilities', [
@@ -131,4 +131,4 @@ def test_extract_possibilities(command, possibilities):
     )), 'hg rebase re'),
 ])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_mkdir_p.py
+++ b/tests/rules/test_mkdir_p.py
@@ -9,7 +9,7 @@ from tests.utils import Command
     Command('hdfs dfs -mkdir foo/bar/baz', stderr='mkdir: `foo/bar/baz\': No such file or directory')
     ])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -19,7 +19,7 @@ def test_match(command):
     Command('./bin/hdfs dfs -mkdir foo/bar/baz'),
     Command()])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
@@ -27,5 +27,5 @@ def test_not_match(command):
     (Command('hdfs dfs -mkdir foo/bar/baz'), 'hdfs dfs -mkdir -p foo/bar/baz'),
     (Command('./bin/hdfs dfs -mkdir foo/bar/baz'), './bin/hdfs dfs -mkdir -p foo/bar/baz')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command
 

--- a/tests/rules/test_mvn_no_command.py
+++ b/tests/rules/test_mvn_no_command.py
@@ -6,7 +6,7 @@ from tests.utils import Command
 @pytest.mark.parametrize('command', [
     Command(script='mvn', stdout='[ERROR] No goals have been specified for this build. You must specify a valid lifecycle phase or a goal in the format <plugin-prefix>:<goal> or <plugin-group-id>:<plugin-artifact-id>[:<plugin-version>]:<goal>. Available lifecycle phases are: validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy, pre-clean, clean, post-clean, pre-site, site, post-site, site-deploy. -> [Help 1]')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -30,11 +30,11 @@ def test_match(command):
     Command(script='mvn -v')
 ])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 @pytest.mark.parametrize('command, new_command', [
     (Command(script='mvn', stdout='[ERROR] No goals have been specified for this build. You must specify a valid lifecycle phase or a goal in the format <plugin-prefix>:<goal> or <plugin-group-id>:<plugin-artifact-id>[:<plugin-version>]:<goal>. Available lifecycle phases are: validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy, pre-clean, clean, post-clean, pre-site, site, post-site, site-deploy. -> [Help 1]'), ['mvn clean package', 'mvn clean install']),
     (Command(script='mvn -N', stdout='[ERROR] No goals have been specified for this build. You must specify a valid lifecycle phase or a goal in the format <plugin-prefix>:<goal> or <plugin-group-id>:<plugin-artifact-id>[:<plugin-version>]:<goal>. Available lifecycle phases are: validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy, pre-clean, clean, post-clean, pre-site, site, post-site, site-deploy. -> [Help 1]'), ['mvn -N clean package', 'mvn -N clean install'])])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command
 

--- a/tests/rules/test_mvn_unknown_lifecycle_phase.py
+++ b/tests/rules/test_mvn_unknown_lifecycle_phase.py
@@ -6,7 +6,7 @@ from tests.utils import Command
 @pytest.mark.parametrize('command', [
     Command(script='mvn cle', stdout='[ERROR] Unknown lifecycle phase "cle". You must specify a valid lifecycle phase or a goal in the format <plugin-prefix>:<goal> or <plugin-group-id>:<plugin-artifact-id>[:<plugin-version>]:<goal>. Available lifecycle phases are: validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy, pre-clean, clean, post-clean, pre-site, site, post-site, site-deploy. -> [Help 1]')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -30,11 +30,11 @@ def test_match(command):
     Command(script='mvn -v')
 ])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 @pytest.mark.parametrize('command, new_command', [
     (Command(script='mvn cle', stdout='[ERROR] Unknown lifecycle phase "cle". You must specify a valid lifecycle phase or a goal in the format <plugin-prefix>:<goal> or <plugin-group-id>:<plugin-artifact-id>[:<plugin-version>]:<goal>. Available lifecycle phases are: validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy, pre-clean, clean, post-clean, pre-site, site, post-site, site-deploy. -> [Help 1]'), ['mvn clean', 'mvn compile']),
     (Command(script='mvn claen package', stdout='[ERROR] Unknown lifecycle phase "claen". You must specify a valid lifecycle phase or a goal in the format <plugin-prefix>:<goal> or <plugin-group-id>:<plugin-artifact-id>[:<plugin-version>]:<goal>. Available lifecycle phases are: validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy, pre-clean, clean, post-clean, pre-site, site, post-site, site-deploy. -> [Help 1]'), ['mvn clean package'])])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command
 

--- a/tests/rules/test_no_command.py
+++ b/tests/rules/test_no_command.py
@@ -11,19 +11,17 @@ def get_all_executables(mocker):
 
 @pytest.mark.usefixtures('no_memoize')
 def test_match():
-    assert match(Command(stderr='vom: not found', script='vom file.py'), None)
-    assert match(Command(stderr='fucck: not found', script='fucck'), None)
-    assert not match(Command(stderr='qweqwe: not found', script='qweqwe'), None)
-    assert not match(Command(stderr='some text', script='vom file.py'), None)
+    assert match(Command(stderr='vom: not found', script='vom file.py'))
+    assert match(Command(stderr='fucck: not found', script='fucck'))
+    assert not match(Command(stderr='qweqwe: not found', script='qweqwe'))
+    assert not match(Command(stderr='some text', script='vom file.py'))
 
 
 @pytest.mark.usefixtures('no_memoize')
 def test_get_new_command():
     assert get_new_command(
         Command(stderr='vom: not found',
-                script='vom file.py'),
-        None) == ['vim file.py']
+                script='vom file.py')) == ['vim file.py']
     assert get_new_command(
         Command(stderr='fucck: not found',
-                script='fucck'),
-        Command) == ['fsck']
+                script='fucck')) == ['fsck']

--- a/tests/rules/test_no_such_file.py
+++ b/tests/rules/test_no_such_file.py
@@ -8,7 +8,7 @@ from tests.utils import Command
     Command(script='mv foo bar/', stderr="mv: cannot move 'foo' to 'bar/': No such file or directory"),
     ])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -16,7 +16,7 @@ def test_match(command):
     Command(script='mv foo bar/foo', stderr="mv: permission denied"),
     ])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
@@ -24,4 +24,4 @@ def test_not_match(command):
     (Command(script='mv foo bar/', stderr="mv: cannot move 'foo' to 'bar/': No such file or directory"), 'mkdir -p bar && mv foo bar/'),
     ])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_open.py
+++ b/tests/rules/test_open.py
@@ -14,7 +14,7 @@ from tests.utils import Command
     Command(script='gnome-open foo.com'),
     Command(script='kde-open foo.com')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
@@ -28,4 +28,4 @@ def test_match(command):
     (Command('gnome-open foo.io'), 'gnome-open http://foo.io'),
     (Command('kde-open foo.io'), 'kde-open http://foo.io')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_pacman.py
+++ b/tests/rules/test_pacman.py
@@ -23,7 +23,7 @@ extra/vim-python3 7.4.712-1 \t/usr/bin/vim'''
     Command(script='vim', stderr='vim: command not found'),
     Command(script='sudo vim', stderr='sudo: vim: command not found')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command, return_value', [
@@ -33,14 +33,14 @@ def test_match(command):
 @patch.multiple(pacman, create=True, pacman=pacman_cmd)
 def test_match_mocked(subp_mock, command, return_value):
     subp_mock.check_output.return_value = return_value
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
     Command(script='vim', stderr=''), Command(),
     Command(script='sudo vim', stderr=''), Command()])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 sudo_vim_possibilities = ['{} -S extra/gvim && sudo vim',
@@ -66,7 +66,7 @@ vim_possibilities = [s.format(pacman_cmd) for s in vim_possibilities]
     (Command('convert'), ['{} -S extra/imagemagick && convert'.format(pacman_cmd)]),
     (Command('sudo convert'), ['{} -S extra/imagemagick && sudo convert'.format(pacman_cmd)])])
 def test_get_new_command(command, new_command, mocker):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command
 
 
 @pytest.mark.parametrize('command, new_command, return_value', [
@@ -79,4 +79,4 @@ def test_get_new_command(command, new_command, mocker):
 @patch.multiple(pacman, create=True, pacman=pacman_cmd)
 def test_get_new_command_mocked(subp_mock, command, new_command, return_value):
     subp_mock.check_output.return_value = return_value
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_pacman_not_found.py
+++ b/tests/rules/test_pacman_not_found.py
@@ -15,7 +15,7 @@ extra/llvm35 3.5.2-13/usr/bin/llc'''
     Command(script='pacman llc', stderr='error: target not found: llc'),
     Command(script='sudo pacman llc', stderr='error: target not found: llc')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -25,7 +25,7 @@ def test_match(command):
 @patch('thefuck.specific.archlinux.subprocess')
 def test_match_mocked(subp_mock, command):
     subp_mock.check_output.return_value = PKGFILE_OUTPUT_LLC
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.skipif(not getattr(pacman_not_found, 'enabled_by_default', True),
@@ -35,7 +35,7 @@ def test_match_mocked(subp_mock, command):
     (Command(script='pacman -S llc', stderr='error: target not found: llc'), ['pacman -S extra/llvm', 'pacman -S extra/llvm35']),
     (Command(script='sudo pacman -S llc', stderr='error: target not found: llc'), ['sudo pacman -S extra/llvm', 'sudo pacman -S extra/llvm35'])])
 def test_get_new_command(command, fixed):
-    assert get_new_command(command, None) == fixed
+    assert get_new_command(command) == fixed
 
 
 @pytest.mark.parametrize('command, fixed', [
@@ -45,4 +45,4 @@ def test_get_new_command(command, fixed):
 @patch('thefuck.specific.archlinux.subprocess')
 def test_get_new_command_mocked(subp_mock, command, fixed):
     subp_mock.check_output.return_value = PKGFILE_OUTPUT_LLC
-    assert get_new_command(command, None) == fixed
+    assert get_new_command(command) == fixed

--- a/tests/rules/test_pip_unknown_command.py
+++ b/tests/rules/test_pip_unknown_command.py
@@ -14,12 +14,11 @@ def pip_unknown_cmd_without_recommend():
 
 
 def test_match(pip_unknown_cmd, pip_unknown_cmd_without_recommend):
-    assert match(Command('pip instatl', stderr=pip_unknown_cmd), None)
+    assert match(Command('pip instatl', stderr=pip_unknown_cmd))
     assert not match(Command('pip i',
-                             stderr=pip_unknown_cmd_without_recommend),
-                     None)
+                             stderr=pip_unknown_cmd_without_recommend))
 
 
 def test_get_new_command(pip_unknown_cmd):
-    assert get_new_command(Command('pip instatl', stderr=pip_unknown_cmd),
-                           None) == 'pip install'
+    assert get_new_command(Command('pip instatl',
+                                   stderr=pip_unknown_cmd)) == 'pip install'

--- a/tests/rules/test_python_command.py
+++ b/tests/rules/test_python_command.py
@@ -3,10 +3,10 @@ from tests.utils import Command
 
 
 def test_match():
-    assert match(Command('temp.py', stderr='Permission denied'), None)
-    assert not match(Command(), None)
+    assert match(Command('temp.py', stderr='Permission denied'))
+    assert not match(Command())
 
 
 def test_get_new_command():
-    assert get_new_command(Command('./test_sudo.py'), None)\
+    assert get_new_command(Command('./test_sudo.py'))\
            == 'python ./test_sudo.py'

--- a/tests/rules/test_python_execute.py
+++ b/tests/rules/test_python_execute.py
@@ -7,11 +7,11 @@ from tests.utils import Command
     Command(script='python foo'),
     Command(script='python bar')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
     (Command('python foo'), 'python foo.py'),
     (Command('python bar'), 'python bar.py')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_quotation_marks.py
+++ b/tests/rules/test_quotation_marks.py
@@ -8,7 +8,7 @@ from tests.utils import Command
     Command(script="git commit -am \"Mismatched Quotation Marks\'"),
     Command(script="echo \"hello\'")])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
@@ -16,4 +16,4 @@ def test_match(command):
     (Command("git commit -am \"Mismatched Quotation Marks\'"), "git commit -am \"Mismatched Quotation Marks\""),
     (Command("echo \"hello\'"), "echo \"hello\"")])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_rm_dir.py
+++ b/tests/rules/test_rm_dir.py
@@ -10,7 +10,7 @@ from tests.utils import Command
     Command('./bin/hdfs dfs -rm foo', stderr='rm: `foo`: Is a directory')
     ])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -19,13 +19,13 @@ def test_match(command):
     Command('./bin/hdfs dfs -rm foo'),  
     Command()])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
     (Command('rm foo'), 'rm -rf foo'),
     (Command('hdfs dfs -rm foo'), 'hdfs dfs -rm -r foo')])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command
 
 

--- a/tests/rules/test_rm_root.py
+++ b/tests/rules/test_rm_root.py
@@ -5,7 +5,7 @@ from tests.utils import Command
 
 def test_match():
     assert match(Command(script='rm -rf /',
-                         stderr='add --no-preserve-root'), None)
+                         stderr='add --no-preserve-root'))
 
 
 @pytest.mark.parametrize('command', [
@@ -13,9 +13,9 @@ def test_match():
     Command(script='rm --no-preserve-root /', stderr='add --no-preserve-root'),
     Command(script='rm -rf /', stderr='')])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 def test_get_new_command():
-    assert get_new_command(Command(script='rm -rf /'), None) \
+    assert get_new_command(Command(script='rm -rf /')) \
            == 'rm -rf / --no-preserve-root'

--- a/tests/rules/test_sed_unterminated_s.py
+++ b/tests/rules/test_sed_unterminated_s.py
@@ -9,20 +9,20 @@ def sed_unterminated_s():
 
 
 def test_match(sed_unterminated_s):
-    assert match(Command('sed -e s/foo/bar', stderr=sed_unterminated_s), None)
-    assert match(Command('sed -es/foo/bar', stderr=sed_unterminated_s), None)
-    assert match(Command('sed -e s/foo/bar -e s/baz/quz', stderr=sed_unterminated_s), None)
-    assert not match(Command('sed -e s/foo/bar'), None)
-    assert not match(Command('sed -es/foo/bar'), None)
-    assert not match(Command('sed -e s/foo/bar -e s/baz/quz'), None)
+    assert match(Command('sed -e s/foo/bar', stderr=sed_unterminated_s))
+    assert match(Command('sed -es/foo/bar', stderr=sed_unterminated_s))
+    assert match(Command('sed -e s/foo/bar -e s/baz/quz', stderr=sed_unterminated_s))
+    assert not match(Command('sed -e s/foo/bar'))
+    assert not match(Command('sed -es/foo/bar'))
+    assert not match(Command('sed -e s/foo/bar -e s/baz/quz'))
 
 
 def test_get_new_command(sed_unterminated_s):
-    assert get_new_command(Command('sed -e s/foo/bar', stderr=sed_unterminated_s), None) \
+    assert get_new_command(Command('sed -e s/foo/bar', stderr=sed_unterminated_s)) \
             == 'sed -e s/foo/bar/'
-    assert get_new_command(Command('sed -es/foo/bar', stderr=sed_unterminated_s), None) \
+    assert get_new_command(Command('sed -es/foo/bar', stderr=sed_unterminated_s)) \
             == 'sed -es/foo/bar/'
-    assert get_new_command(Command(r"sed -e 's/\/foo/bar'", stderr=sed_unterminated_s), None) \
+    assert get_new_command(Command(r"sed -e 's/\/foo/bar'", stderr=sed_unterminated_s)) \
             == r"sed -e 's/\/foo/bar/'"
-    assert get_new_command(Command(r"sed -e s/foo/bar -es/baz/quz", stderr=sed_unterminated_s), None) \
+    assert get_new_command(Command(r"sed -e s/foo/bar -es/baz/quz", stderr=sed_unterminated_s)) \
             == r"sed -e s/foo/bar/ -es/baz/quz/"

--- a/tests/rules/test_sl_ls.py
+++ b/tests/rules/test_sl_ls.py
@@ -4,9 +4,9 @@ from tests.utils import Command
 
 
 def test_match():
-    assert match(Command('sl'), None)
-    assert not match(Command('ls'), None)
+    assert match(Command('sl'))
+    assert not match(Command('ls'))
 
 
 def test_get_new_command():
-    assert get_new_command(Command('sl'), None) == 'ls'
+    assert get_new_command(Command('sl')) == 'ls'

--- a/tests/rules/test_ssh_known_host.py
+++ b/tests/rules/test_ssh_known_host.py
@@ -44,23 +44,23 @@ Host key verification failed.""".format(path, '98.765.432.321')
 
 def test_match(ssh_error):
     errormsg, _, _, _ = ssh_error
-    assert match(Command('ssh', stderr=errormsg), None)
-    assert match(Command('ssh', stderr=errormsg), None)
-    assert match(Command('scp something something', stderr=errormsg), None)
-    assert match(Command('scp something something', stderr=errormsg), None)
-    assert not match(Command(stderr=errormsg), None)
-    assert not match(Command('notssh', stderr=errormsg), None)
-    assert not match(Command('ssh'), None)
+    assert match(Command('ssh', stderr=errormsg))
+    assert match(Command('ssh', stderr=errormsg))
+    assert match(Command('scp something something', stderr=errormsg))
+    assert match(Command('scp something something', stderr=errormsg))
+    assert not match(Command(stderr=errormsg))
+    assert not match(Command('notssh', stderr=errormsg))
+    assert not match(Command('ssh'))
 
 
 def test_side_effect(ssh_error):
     errormsg, path, reset, known_hosts = ssh_error
     command = Command('ssh user@host', stderr=errormsg)
-    side_effect(command, None, None)
+    side_effect(command, None)
     expected = ['123.234.567.890 asdjkasjdakjsd\n', '111.222.333.444 qwepoiwqepoiss\n']
     assert known_hosts(path) == expected
 
 
 def test_get_new_command(ssh_error, monkeypatch):
     errormsg, _, _, _ = ssh_error
-    assert get_new_command(Command('ssh user@host', stderr=errormsg), None) == 'ssh user@host'
+    assert get_new_command(Command('ssh user@host', stderr=errormsg)) == 'ssh user@host'

--- a/tests/rules/test_sudo.py
+++ b/tests/rules/test_sudo.py
@@ -14,11 +14,11 @@ from tests.utils import Command
     ('You don\'t have access to the history DB.', ''),
     ('', "error: [Errno 13] Permission denied: '/usr/local/lib/python2.7/dist-packages/ipaddr.py'")])
 def test_match(stderr, stdout):
-    assert match(Command(stderr=stderr, stdout=stdout), None)
+    assert match(Command(stderr=stderr, stdout=stdout))
 
 
 def test_not_match():
-    assert not match(Command(), None)
+    assert not match(Command())
 
 
 @pytest.mark.parametrize('before, after', [
@@ -26,4 +26,4 @@ def test_not_match():
     ('echo a > b', 'sudo sh -c "echo a > b"'),
     ('echo "a" >> b', 'sudo sh -c "echo \\"a\\" >> b"')])
 def test_get_new_command(before, after):
-    assert get_new_command(Command(before), None) == after
+    assert get_new_command(Command(before)) == after

--- a/tests/rules/test_switch_lang.py
+++ b/tests/rules/test_switch_lang.py
@@ -9,7 +9,7 @@ from tests.utils import Command
     Command(stderr='command not found: фзе-пуе', script=u'фзе-пуе'),
     Command(stderr='command not found: λσ', script=u'λσ')])
 def test_match(command):
-    assert switch_lang.match(command, None)
+    assert switch_lang.match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -18,11 +18,11 @@ def test_match(command):
     Command(stderr='command not found: агсл', script=u'агсл'),
     Command(stderr='some info', script=u'фзе-пуе')])
 def test_not_match(command):
-    assert not switch_lang.match(command, None)
+    assert not switch_lang.match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
     (Command(u'фзе-пуе штыефдд мшь'), 'apt-get install vim'),
     (Command(u'λσ -λα'), 'ls -la')])
 def test_get_new_command(command, new_command):
-    assert switch_lang.get_new_command(command, None) == new_command
+    assert switch_lang.get_new_command(command) == new_command

--- a/tests/rules/test_systemctl.py
+++ b/tests/rules/test_systemctl.py
@@ -4,15 +4,15 @@ from tests.utils import Command
 
 
 def test_match():
-    assert match(Command('systemctl nginx start', stderr='Unknown operation \'nginx\'.'), None)
-    assert match(Command('sudo systemctl nginx start', stderr='Unknown operation \'nginx\'.'), None)
-    assert not match(Command('systemctl start nginx'), None)
-    assert not match(Command('systemctl start nginx'), None)
-    assert not match(Command('sudo systemctl nginx', stderr='Unknown operation \'nginx\'.'), None)
-    assert not match(Command('systemctl nginx', stderr='Unknown operation \'nginx\'.'), None)
-    assert not match(Command('systemctl start wtf', stderr='Failed to start wtf.service: Unit wtf.service failed to load: No such file or directory.'), None)
+    assert match(Command('systemctl nginx start', stderr='Unknown operation \'nginx\'.'))
+    assert match(Command('sudo systemctl nginx start', stderr='Unknown operation \'nginx\'.'))
+    assert not match(Command('systemctl start nginx'))
+    assert not match(Command('systemctl start nginx'))
+    assert not match(Command('sudo systemctl nginx', stderr='Unknown operation \'nginx\'.'))
+    assert not match(Command('systemctl nginx', stderr='Unknown operation \'nginx\'.'))
+    assert not match(Command('systemctl start wtf', stderr='Failed to start wtf.service: Unit wtf.service failed to load: No such file or directory.'))
 
 
 def test_get_new_command():
-    assert get_new_command(Command('systemctl nginx start'), None) == "systemctl start nginx"
-    assert get_new_command(Command('sudo systemctl nginx start'), None) == "sudo systemctl start nginx"
+    assert get_new_command(Command('systemctl nginx start')) == "systemctl start nginx"
+    assert get_new_command(Command('sudo systemctl nginx start')) == "sudo systemctl start nginx"

--- a/tests/rules/test_tmux.py
+++ b/tests/rules/test_tmux.py
@@ -11,9 +11,9 @@ def tmux_ambiguous():
 
 
 def test_match(tmux_ambiguous):
-    assert match(Command('tmux list', stderr=tmux_ambiguous), None)
+    assert match(Command('tmux list', stderr=tmux_ambiguous))
 
 
 def test_get_new_command(tmux_ambiguous):
-    assert get_new_command(Command('tmux list', stderr=tmux_ambiguous), None)\
+    assert get_new_command(Command('tmux list', stderr=tmux_ambiguous))\
         == ['tmux list-keys', 'tmux list-panes', 'tmux list-windows']

--- a/tests/rules/test_tsuru_login.py
+++ b/tests/rules/test_tsuru_login.py
@@ -15,7 +15,7 @@ error_msg = (
     Command(script='tsuru app-log -f', stderr=error_msg[1]),
 ])
 def test_match(command):
-    assert match(command, {})
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -24,7 +24,7 @@ def test_match(command):
     Command(script='tsuru app-log -f', stderr=('Error: unparseable data')),
 ])
 def test_not_match(command):
-    assert not match(command, {})
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
@@ -34,4 +34,4 @@ def test_not_match(command):
      'tsuru login && tsuru app-log -f'),
 ])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, {}) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_tsuru_not_command.py
+++ b/tests/rules/test_tsuru_not_command.py
@@ -30,7 +30,7 @@ from thefuck.rules.tsuru_not_command import match, get_new_command
     )),
 ])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -58,7 +58,7 @@ def test_match(command):
     Command('tsuru env-get', stderr='Error: App thefuck not found.'),
 ])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_commands', [
@@ -87,4 +87,4 @@ def test_not_match(command):
     )), ['tsuru target-list']),
 ])
 def test_get_new_command(command, new_commands):
-    assert get_new_command(command, None) == new_commands
+    assert get_new_command(command) == new_commands

--- a/tests/rules/test_unknown_command.py
+++ b/tests/rules/test_unknown_command.py
@@ -9,7 +9,7 @@ from tests.utils import Command
             stderr='ls: Unknown command\nDid you mean -ls?  This command begins with a dash.'),
     Command(script='hdfs dfs ls /foo/bar', stderr='ls: Unknown command\nDid you mean -ls?  This command begins with a dash.')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -18,7 +18,7 @@ def test_match(command):
     Command(script='hdfs dfs -ls -R /foo/bar', stderr=''),  
     Command()])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
@@ -31,5 +31,5 @@ def test_not_match(command):
     (Command('./bin/hdfs dfs -Dtest=fred ls -R /foo/bar',
         stderr='ls: Unknown command\nDid you mean -ls?  This command begins with a dash.'), ['./bin/hdfs dfs -Dtest=fred -ls -R /foo/bar'])])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command
 

--- a/tests/rules/test_vagrant_up.py
+++ b/tests/rules/test_vagrant_up.py
@@ -11,7 +11,7 @@ from tests.utils import Command
     Command(script='vagrant rdp devbox',
             stderr='VM must be created before running this command. Run `vagrant up` first.')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -20,7 +20,7 @@ def test_match(command):
     Command(script='vagrant ssh', stderr='A Vagrant environment or target machine is required to run this command. Run `vagrant init` to create a new Vagrant environment. Or, get an ID of a target machine from `vagrant global-status` to run this command on. A final option is to change to a directory with a Vagrantfile and to try again.'),  
     Command()])
 def test_not_match(command):
-    assert not match(command, None)
+    assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
@@ -31,5 +31,5 @@ def test_not_match(command):
     (Command(script='vagrant rdp devbox',
             stderr='VM must be created before running this command. Run `vagrant up` first.'), ['vagrant up devbox && vagrant rdp devbox', 'vagrant up && vagrant rdp devbox'])])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command
 

--- a/tests/rules/test_whois.py
+++ b/tests/rules/test_whois.py
@@ -8,11 +8,11 @@ from tests.utils import Command
     Command(script='whois https://en.wikipedia.org/'),
     Command(script='whois meta.unix.stackexchange.com')])
 def test_match(command):
-    assert match(command, None)
+    assert match(command)
 
 
 def test_not_match():
-    assert not match(Command(script='whois'), None)
+    assert not match(Command(script='whois'))
 
 
 # `whois com` actually makes sense
@@ -23,4 +23,4 @@ def test_not_match():
                                                     'whois stackexchange.com',
                                                     'whois com'])])
 def test_get_new_command(command, new_command):
-    assert get_new_command(command, None) == new_command
+    assert get_new_command(command) == new_command

--- a/tests/specific/test_git.py
+++ b/tests/specific/test_git.py
@@ -9,9 +9,10 @@ from tests.utils import Command
      "19:23:25.470911 git.c:282   trace: alias expansion: com => 'commit' '--verbose'")])
 def test_git_support(called, command, stderr):
     @git_support
-    def fn(command, settings): return command.script
+    def fn(command):
+        return command.script
 
-    assert fn(Command(script=called, stderr=stderr), None) == command
+    assert fn(Command(script=called, stderr=stderr)) == command
 
 
 @pytest.mark.parametrize('command, is_git', [
@@ -24,6 +25,7 @@ def test_git_support(called, command, stderr):
     ('cat hub', False)])
 def test_git_support_match(command, is_git):
     @git_support
-    def fn(command, settings): return True
+    def fn(command):
+        return True
 
-    assert fn(Command(script=command), None) == is_git
+    assert fn(Command(script=command)) == is_git

--- a/tests/specific/test_sudo.py
+++ b/tests/specific/test_sudo.py
@@ -13,8 +13,8 @@ from tests.utils import Command
     (False, 'sudo ls', 'ls', False),
     (False, 'ls', 'ls', False)])
 def test_sudo_support(return_value, command, called, result):
-    def fn(command, settings):
+    def fn(command):
         assert command == Command(called)
         return return_value
 
-    assert sudo_support(fn)(Command(command), None) == result
+    assert sudo_support(fn)(Command(command)) == result

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -29,7 +29,7 @@ def environ(monkeypatch):
 def test_settings_defaults(load_source):
     load_source.return_value = object()
     for key, val in conf.DEFAULT_SETTINGS.items():
-        assert getattr(conf.get_settings(Mock()), key) == val
+        assert getattr(conf.init_settings(Mock()), key) == val
 
 
 @pytest.mark.usefixture('environ')
@@ -41,7 +41,7 @@ class TestSettingsFromFile(object):
                                         no_colors=True,
                                         priority={'vim': 100},
                                         exclude_rules=['git'])
-        settings = conf.get_settings(Mock())
+        settings = conf.init_settings(Mock())
         assert settings.rules == ['test']
         assert settings.wait_command == 10
         assert settings.require_confirmation is True
@@ -55,7 +55,7 @@ class TestSettingsFromFile(object):
                                         exclude_rules=[],
                                         require_confirmation=True,
                                         no_colors=True)
-        settings = conf.get_settings(Mock())
+        settings = conf.init_settings(Mock())
         assert settings.rules == conf.DEFAULT_RULES + ['test']
 
 
@@ -68,7 +68,7 @@ class TestSettingsFromEnv(object):
                         'THEFUCK_REQUIRE_CONFIRMATION': 'true',
                         'THEFUCK_NO_COLORS': 'false',
                         'THEFUCK_PRIORITY': 'bash=10:lisp=wrong:vim=15'})
-        settings = conf.get_settings(Mock())
+        settings = conf.init_settings(Mock())
         assert settings.rules == ['bash', 'lisp']
         assert settings.exclude_rules == ['git', 'vim']
         assert settings.wait_command == 55
@@ -78,7 +78,7 @@ class TestSettingsFromEnv(object):
 
     def test_from_env_with_DEFAULT(self, environ):
         environ.update({'THEFUCK_RULES': 'DEFAULT_RULES:bash:lisp'})
-        settings = conf.get_settings(Mock())
+        settings = conf.init_settings(Mock())
         assert settings.rules == conf.DEFAULT_RULES + ['bash', 'lisp']
 
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -26,22 +26,23 @@ def environ(monkeypatch):
 
 
 @pytest.mark.usefixture('environ')
-def test_settings_defaults(load_source):
+def test_settings_defaults(load_source, settings):
     load_source.return_value = object()
+    conf.init_settings(Mock())
     for key, val in conf.DEFAULT_SETTINGS.items():
-        assert getattr(conf.init_settings(Mock()), key) == val
+        assert getattr(settings, key) == val
 
 
 @pytest.mark.usefixture('environ')
 class TestSettingsFromFile(object):
-    def test_from_file(self, load_source):
+    def test_from_file(self, load_source, settings):
         load_source.return_value = Mock(rules=['test'],
                                         wait_command=10,
                                         require_confirmation=True,
                                         no_colors=True,
                                         priority={'vim': 100},
                                         exclude_rules=['git'])
-        settings = conf.init_settings(Mock())
+        conf.init_settings(Mock())
         assert settings.rules == ['test']
         assert settings.wait_command == 10
         assert settings.require_confirmation is True
@@ -49,26 +50,26 @@ class TestSettingsFromFile(object):
         assert settings.priority == {'vim': 100}
         assert settings.exclude_rules == ['git']
 
-    def test_from_file_with_DEFAULT(self, load_source):
+    def test_from_file_with_DEFAULT(self, load_source, settings):
         load_source.return_value = Mock(rules=conf.DEFAULT_RULES + ['test'],
                                         wait_command=10,
                                         exclude_rules=[],
                                         require_confirmation=True,
                                         no_colors=True)
-        settings = conf.init_settings(Mock())
+        conf.init_settings(Mock())
         assert settings.rules == conf.DEFAULT_RULES + ['test']
 
 
 @pytest.mark.usefixture('load_source')
 class TestSettingsFromEnv(object):
-    def test_from_env(self, environ):
+    def test_from_env(self, environ, settings):
         environ.update({'THEFUCK_RULES': 'bash:lisp',
                         'THEFUCK_EXCLUDE_RULES': 'git:vim',
                         'THEFUCK_WAIT_COMMAND': '55',
                         'THEFUCK_REQUIRE_CONFIRMATION': 'true',
                         'THEFUCK_NO_COLORS': 'false',
                         'THEFUCK_PRIORITY': 'bash=10:lisp=wrong:vim=15'})
-        settings = conf.init_settings(Mock())
+        conf.init_settings(Mock())
         assert settings.rules == ['bash', 'lisp']
         assert settings.exclude_rules == ['git', 'vim']
         assert settings.wait_command == 55
@@ -76,9 +77,9 @@ class TestSettingsFromEnv(object):
         assert settings.no_colors is False
         assert settings.priority == {'bash': 10, 'vim': 15}
 
-    def test_from_env_with_DEFAULT(self, environ):
+    def test_from_env_with_DEFAULT(self, environ, settings):
         environ.update({'THEFUCK_RULES': 'DEFAULT_RULES:bash:lisp'})
-        settings = conf.init_settings(Mock())
+        conf.init_settings(Mock())
         assert settings.rules == conf.DEFAULT_RULES + ['bash', 'lisp']
 
 

--- a/tests/test_corrector.py
+++ b/tests/test_corrector.py
@@ -25,7 +25,7 @@ class TestGetRules(object):
     @pytest.fixture
     def glob(self, mocker):
         results = {}
-        mocker.patch('thefuck.corrector.Path.glob',
+        mocker.patch('pathlib.Path.glob',
                      new_callable=lambda: lambda *_: results.pop('value', []))
         return lambda value: results.update({'value': value})
 
@@ -54,7 +54,7 @@ class TestGetRules(object):
         settings.update(rules=self._prepare_rules(conf_rules),
                         priority={},
                         exclude_rules=self._prepare_rules(exclude_rules))
-        rules = corrector.get_rules(Path('~'))
+        rules = corrector.get_rules()
         self._compare_names(rules, loaded_rules)
 
 
@@ -98,5 +98,5 @@ def test_get_corrected_commands(mocker):
                   get_new_command=lambda x: [x.script + '@', x.script + ';'],
                   priority=60)]
     mocker.patch('thefuck.corrector.get_rules', return_value=rules)
-    assert [cmd.script for cmd in get_corrected_commands(command, None)] \
+    assert [cmd.script for cmd in get_corrected_commands(command)] \
            == ['test!', 'test@', 'test;']

--- a/tests/test_corrector.py
+++ b/tests/test_corrector.py
@@ -61,10 +61,10 @@ class TestGetRules(object):
 class TestIsRuleMatch(object):
     def test_no_match(self):
         assert not corrector.is_rule_match(
-            Command('ls'), Rule('', lambda *_: False))
+            Command('ls'), Rule('', lambda _: False))
 
     def test_match(self):
-        rule = Rule('', lambda x, _: x.script == 'cd ..')
+        rule = Rule('', lambda x: x.script == 'cd ..')
         assert corrector.is_rule_match(Command('cd ..'), rule)
 
     @pytest.mark.usefixtures('no_colors')
@@ -77,25 +77,25 @@ class TestIsRuleMatch(object):
 
 class TestMakeCorrectedCommands(object):
     def test_with_rule_returns_list(self):
-        rule = Rule(get_new_command=lambda x, _: [x.script + '!', x.script + '@'],
+        rule = Rule(get_new_command=lambda x: [x.script + '!', x.script + '@'],
                     priority=100)
         assert list(make_corrected_commands(Command(script='test'), rule)) \
                == [CorrectedCommand(script='test!', priority=100),
                    CorrectedCommand(script='test@', priority=200)]
 
     def test_with_rule_returns_command(self):
-        rule = Rule(get_new_command=lambda x, _: x.script + '!',
+        rule = Rule(get_new_command=lambda x: x.script + '!',
                     priority=100)
         assert list(make_corrected_commands(Command(script='test'), rule)) \
                == [CorrectedCommand(script='test!', priority=100)]
 
 def test_get_corrected_commands(mocker):
     command = Command('test', 'test', 'test')
-    rules = [Rule(match=lambda *_: False),
-             Rule(match=lambda *_: True,
-                  get_new_command=lambda x, _: x.script + '!', priority=100),
-             Rule(match=lambda *_: True,
-                  get_new_command=lambda x, _: [x.script + '@', x.script + ';'],
+    rules = [Rule(match=lambda _: False),
+             Rule(match=lambda _: True,
+                  get_new_command=lambda x: x.script + '!', priority=100),
+             Rule(match=lambda _: True,
+                  get_new_command=lambda x: [x.script + '@', x.script + ';'],
                   priority=60)]
     mocker.patch('thefuck.corrector.get_rules', return_value=rules)
     assert [cmd.script for cmd in get_corrected_commands(command, None)] \

--- a/tests/test_corrector.py
+++ b/tests/test_corrector.py
@@ -16,7 +16,7 @@ def test_load_rule(mocker):
                           enabled_by_default=True,
                           priority=900,
                           requires_output=True))
-    assert corrector.load_rule(Path('/rules/bash.py'), settings=Mock(priority={})) \
+    assert corrector.load_rule(Path('/rules/bash.py')) \
            == Rule('bash', match, get_new_command, priority=900)
     load_source.assert_called_once_with('bash', '/rules/bash.py')
 
@@ -48,29 +48,30 @@ class TestGetRules(object):
         (['git.py', 'bash.py'], ['git'], [], ['git']),
         (['git.py', 'bash.py'], conf.DEFAULT_RULES, ['git'], ['bash']),
         (['git.py', 'bash.py'], ['git'], ['git'], [])])
-    def test_get_rules(self, glob, paths, conf_rules, exclude_rules, loaded_rules):
+    def test_get_rules(self, glob, settings, paths, conf_rules, exclude_rules,
+                       loaded_rules):
         glob([PosixPath(path) for path in paths])
-        settings = Mock(rules=self._prepare_rules(conf_rules),
+        settings.update(rules=self._prepare_rules(conf_rules),
                         priority={},
                         exclude_rules=self._prepare_rules(exclude_rules))
-        rules = corrector.get_rules(Path('~'), settings)
+        rules = corrector.get_rules(Path('~'))
         self._compare_names(rules, loaded_rules)
 
 
 class TestIsRuleMatch(object):
-    def test_no_match(self, settings):
+    def test_no_match(self):
         assert not corrector.is_rule_match(
-            Command('ls'), Rule('', lambda *_: False), settings)
+            Command('ls'), Rule('', lambda *_: False))
 
-    def test_match(self, settings):
+    def test_match(self):
         rule = Rule('', lambda x, _: x.script == 'cd ..')
-        assert corrector.is_rule_match(Command('cd ..'), rule, settings)
+        assert corrector.is_rule_match(Command('cd ..'), rule)
 
-    def test_when_rule_failed(self, capsys, settings):
+    @pytest.mark.usefixtures('no_colors')
+    def test_when_rule_failed(self, capsys):
         rule = Rule('test', Mock(side_effect=OSError('Denied')),
                     requires_output=False)
-        assert not corrector.is_rule_match(
-            Command('ls'), rule, settings)
+        assert not corrector.is_rule_match(Command('ls'), rule)
         assert capsys.readouterr()[1].split('\n')[0] == '[WARN] Rule test:'
 
 
@@ -78,14 +79,14 @@ class TestMakeCorrectedCommands(object):
     def test_with_rule_returns_list(self):
         rule = Rule(get_new_command=lambda x, _: [x.script + '!', x.script + '@'],
                     priority=100)
-        assert list(make_corrected_commands(Command(script='test'), rule, None)) \
+        assert list(make_corrected_commands(Command(script='test'), rule)) \
                == [CorrectedCommand(script='test!', priority=100),
                    CorrectedCommand(script='test@', priority=200)]
 
     def test_with_rule_returns_command(self):
         rule = Rule(get_new_command=lambda x, _: x.script + '!',
                     priority=100)
-        assert list(make_corrected_commands(Command(script='test'), rule, None)) \
+        assert list(make_corrected_commands(Command(script='test'), rule)) \
                == [CorrectedCommand(script='test!', priority=100)]
 
 def test_get_corrected_commands(mocker):
@@ -97,5 +98,5 @@ def test_get_corrected_commands(mocker):
                   get_new_command=lambda x, _: [x.script + '@', x.script + ';'],
                   priority=60)]
     mocker.patch('thefuck.corrector.get_rules', return_value=rules)
-    assert [cmd.script for cmd in get_corrected_commands(command, None, Mock(debug=False))] \
+    assert [cmd.script for cmd in get_corrected_commands(command, None)] \
            == ['test!', 'test@', 'test;']

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,14 +1,20 @@
+import pytest
 from mock import Mock
 from thefuck import logs
 
 
-def test_color():
-    assert logs.color('red', Mock(no_colors=False)) == 'red'
-    assert logs.color('red', Mock(no_colors=True)) == ''
+def test_color(settings):
+    settings.no_colors = False
+    assert logs.color('red') == 'red'
+    settings.no_colors = True
+    assert logs.color('red') == ''
 
 
-def test_debug(capsys):
-    logs.debug('test', Mock(no_colors=True, debug=True))
-    assert capsys.readouterr() == ('', 'DEBUG: test\n')
-    logs.debug('test', Mock(no_colors=True, debug=False))
-    assert capsys.readouterr() == ('', '')
+@pytest.mark.usefixtures('no_colors')
+@pytest.mark.parametrize('debug, stderr', [
+    (True, 'DEBUG: test\n'),
+    (False, '')])
+def test_debug(capsys, settings, debug, stderr):
+    settings.debug = debug
+    logs.debug('test')
+    assert capsys.readouterr() == ('', stderr)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,9 +24,9 @@ class TestGetCommand(object):
         monkeypatch.setattr('thefuck.shells.from_shell', lambda x: x)
         monkeypatch.setattr('thefuck.shells.to_shell', lambda x: x)
 
-    def test_get_command_calls(self, Popen):
-        assert main.get_command(Mock(env={}),
-                                ['thefuck', 'apt-get', 'search', 'vim']) \
+    def test_get_command_calls(self, Popen, settings):
+        settings.env = {}
+        assert main.get_command(['thefuck', 'apt-get', 'search', 'vim']) \
                == Command('apt-get search vim', 'stdout', 'stderr')
         Popen.assert_called_once_with('apt-get search vim',
                                       shell=True,
@@ -41,6 +41,6 @@ class TestGetCommand(object):
         (['thefuck', 'ls'], 'ls')])
     def test_get_command_script(self, args, result):
         if result:
-            assert main.get_command(Mock(env={}), args).script == result
+            assert main.get_command(args).script == result
         else:
-            assert main.get_command(Mock(env={}), args) is None
+            assert main.get_command(args) is None

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -10,14 +10,6 @@ def test_rules_names_list():
     assert Rule('bash') not in RulesNamesList(['lisp'])
 
 
-def test_update_settings():
-    settings = Settings({'key': 'val'})
-    new_settings = settings.update(key='new-val', unset='unset-value')
-    assert new_settings.key == 'val'
-    assert new_settings.unset == 'unset-value'
-    assert settings.key == 'val'
-
-
 class TestSortedCorrectedCommandsSequence(object):
     def test_realises_generator_only_on_demand(self, settings):
         should_realise = False
@@ -28,24 +20,23 @@ class TestSortedCorrectedCommandsSequence(object):
             assert should_realise
             yield CorrectedCommand('git checkout', priority=100)
 
-        commands = SortedCorrectedCommandsSequence(gen(), settings)
+        commands = SortedCorrectedCommandsSequence(gen())
         assert commands[0] == CorrectedCommand('git commit')
         should_realise = True
         assert commands[1] == CorrectedCommand('git checkout', priority=100)
         assert commands[2] == CorrectedCommand('git branch', priority=200)
 
-    def test_remove_duplicates(self, settings):
+    def test_remove_duplicates(self):
         side_effect = lambda *_: None
         seq = SortedCorrectedCommandsSequence(
             iter([CorrectedCommand('ls', priority=100),
                   CorrectedCommand('ls', priority=200),
-                  CorrectedCommand('ls', side_effect, 300)]),
-            settings)
+                  CorrectedCommand('ls', side_effect, 300)]))
         assert set(seq) == {CorrectedCommand('ls', priority=100),
                             CorrectedCommand('ls', side_effect, 300)}
 
-    def test_with_blank(self, settings):
-        seq = SortedCorrectedCommandsSequence(iter([]), settings)
+    def test_with_blank(self):
+        seq = SortedCorrectedCommandsSequence(iter([]))
         assert list(seq) == []
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 from mock import Mock
 import six
-from thefuck.utils import wrap_settings, \
+from thefuck.utils import default_settings, \
     memoize, get_closest, get_all_executables, replace_argument, \
     get_all_matched_commands, is_app, for_app, cache
 from thefuck.types import Settings
@@ -12,9 +12,9 @@ from tests.utils import Command
     ({'key': 'val'}, {}, {'key': 'val'}),
     ({'key': 'new-val'}, {'key': 'val'}, {'key': 'val'}),
     ({'key': 'new-val', 'unset': 'unset'}, {'key': 'val'}, {'key': 'val', 'unset': 'unset'})])
-def test_wrap_settings(override, old, new):
+def test_default_settings(override, old, new):
     fn = lambda _, settings: settings
-    assert wrap_settings(override)(fn)(None, Settings(old)) == new
+    assert default_settings(override)(fn)(None, Settings(old)) == new
 
 
 def test_memoize():

--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -1,12 +1,11 @@
-from copy import copy
 from imp import load_source
 import os
 import sys
 from six import text_type
-from . import logs, types
+from .types import RulesNamesList, Settings
 
 
-class _DefaultRulesNames(types.RulesNamesList):
+class _DefaultRulesNames(RulesNamesList):
     def __add__(self, items):
         return _DefaultRulesNames(list(self) + items)
 
@@ -24,7 +23,6 @@ class _DefaultRulesNames(types.RulesNamesList):
 DEFAULT_RULES = _DefaultRulesNames([])
 DEFAULT_PRIORITY = 1000
 
-
 DEFAULT_SETTINGS = {'rules': DEFAULT_RULES,
                     'exclude_rules': [],
                     'wait_command': 3,
@@ -41,7 +39,6 @@ ENV_TO_ATTR = {'THEFUCK_RULES': 'rules',
                'THEFUCK_NO_COLORS': 'no_colors',
                'THEFUCK_PRIORITY': 'priority',
                'THEFUCK_DEBUG': 'debug'}
-
 
 SETTINGS_HEADER = u"""# ~/.thefuck/settings.py: The Fuck settings file
 #
@@ -105,30 +102,28 @@ def _settings_from_env():
             if env in os.environ}
 
 
-def get_settings(user_dir):
-    """Returns settings filled with values from `settings.py` and env."""
-    conf = copy(DEFAULT_SETTINGS)
-    try:
-        conf.update(_settings_from_file(user_dir))
-    except Exception:
-        logs.exception("Can't load settings from file",
-                       sys.exc_info(),
-                       types.Settings(conf))
+settings = Settings(DEFAULT_SETTINGS)
+
+
+def init_settings(user_dir):
+    """Fills `settings` with values from `settings.py` and env."""
+    from .logs import exception
 
     try:
-        conf.update(_settings_from_env())
+        settings.update(_settings_from_file(user_dir))
     except Exception:
-        logs.exception("Can't load settings from env",
-                       sys.exc_info(),
-                       types.Settings(conf))
+        exception("Can't load settings from file", sys.exc_info())
 
-    if not isinstance(conf['rules'], types.RulesNamesList):
-        conf['rules'] = types.RulesNamesList(conf['rules'])
+    try:
+        settings.update(_settings_from_env())
+    except Exception:
+        exception("Can't load settings from env", sys.exc_info())
 
-    if not isinstance(conf['exclude_rules'], types.RulesNamesList):
-        conf['exclude_rules'] = types.RulesNamesList(conf['exclude_rules'])
+    if not isinstance(settings['rules'], RulesNamesList):
+        settings.rules = RulesNamesList(settings['rules'])
 
-    return types.Settings(conf)
+    if not isinstance(settings.exclude_rules, RulesNamesList):
+        settings.exclude_rules = RulesNamesList(settings.exclude_rules)
 
 
 def initialize_settings_file(user_dir):

--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -109,6 +109,8 @@ def init_settings(user_dir):
     """Fills `settings` with values from `settings.py` and env."""
     from .logs import exception
 
+    settings.user_dir = user_dir
+
     try:
         settings.update(_settings_from_file(user_dir))
     except Exception:

--- a/thefuck/corrector.py
+++ b/thefuck/corrector.py
@@ -31,12 +31,12 @@ def get_loaded_rules(rules):
                 yield loaded_rule
 
 
-def get_rules(user_dir):
+def get_rules():
     """Returns all enabled rules."""
     bundled = Path(__file__).parent \
         .joinpath('rules') \
         .glob('*.py')
-    user = user_dir.joinpath('rules').glob('*.py')
+    user = settings.user_dir.joinpath('rules').glob('*.py')
     return sorted(get_loaded_rules(sorted(bundled) + sorted(user)),
                   key=lambda rule: rule.priority)
 
@@ -66,9 +66,9 @@ def make_corrected_commands(command, rule):
                                priority=(n + 1) * rule.priority)
 
 
-def get_corrected_commands(command, user_dir):
+def get_corrected_commands(command):
     corrected_commands = (
-        corrected for rule in get_rules(user_dir)
+        corrected for rule in get_rules()
         if is_rule_match(command, rule)
         for corrected in make_corrected_commands(command, rule))
     return SortedCorrectedCommandsSequence(corrected_commands)

--- a/thefuck/corrector.py
+++ b/thefuck/corrector.py
@@ -13,11 +13,11 @@ def load_rule(rule):
         rule_module = load_source(name, str(rule))
         priority = getattr(rule_module, 'priority', DEFAULT_PRIORITY)
     return Rule(name, rule_module.match,
-                      rule_module.get_new_command,
-                      getattr(rule_module, 'enabled_by_default', True),
-                      getattr(rule_module, 'side_effect', None),
-                      settings.priority.get(name, priority),
-                      getattr(rule_module, 'requires_output', True))
+                rule_module.get_new_command,
+                getattr(rule_module, 'enabled_by_default', True),
+                getattr(rule_module, 'side_effect', None),
+                settings.priority.get(name, priority),
+                getattr(rule_module, 'requires_output', True))
 
 
 def get_loaded_rules(rules):

--- a/thefuck/corrector.py
+++ b/thefuck/corrector.py
@@ -3,6 +3,7 @@ from imp import load_source
 from pathlib import Path
 from .conf import settings, DEFAULT_PRIORITY
 from .types import Rule, CorrectedCommand, SortedCorrectedCommandsSequence
+from .utils import compatibility_call
 from . import logs
 
 
@@ -49,14 +50,14 @@ def is_rule_match(command, rule):
 
     try:
         with logs.debug_time(u'Trying rule: {};'.format(rule.name)):
-            if rule.match(command, settings):
+            if compatibility_call(rule.match, command):
                 return True
     except Exception:
         logs.rule_failed(rule, sys.exc_info())
 
 
 def make_corrected_commands(command, rule):
-    new_commands = rule.get_new_command(command, settings)
+    new_commands = compatibility_call(rule.get_new_command, command)
     if not isinstance(new_commands, list):
         new_commands = (new_commands,)
     for n, new_command in enumerate(new_commands):

--- a/thefuck/corrector.py
+++ b/thefuck/corrector.py
@@ -1,16 +1,18 @@
 import sys
 from imp import load_source
 from pathlib import Path
-from . import conf, types, logs
+from .conf import settings, DEFAULT_PRIORITY
+from .types import Rule, CorrectedCommand, SortedCorrectedCommandsSequence
+from . import logs
 
 
-def load_rule(rule, settings):
+def load_rule(rule):
     """Imports rule module and returns it."""
     name = rule.name[:-3]
-    with logs.debug_time(u'Importing rule: {};'.format(name), settings):
+    with logs.debug_time(u'Importing rule: {};'.format(name)):
         rule_module = load_source(name, str(rule))
-        priority = getattr(rule_module, 'priority', conf.DEFAULT_PRIORITY)
-    return types.Rule(name, rule_module.match,
+        priority = getattr(rule_module, 'priority', DEFAULT_PRIORITY)
+    return Rule(name, rule_module.match,
                       rule_module.get_new_command,
                       getattr(rule_module, 'enabled_by_default', True),
                       getattr(rule_module, 'side_effect', None),
@@ -18,27 +20,27 @@ def load_rule(rule, settings):
                       getattr(rule_module, 'requires_output', True))
 
 
-def get_loaded_rules(rules, settings):
+def get_loaded_rules(rules):
     """Yields all available rules."""
     for rule in rules:
         if rule.name != '__init__.py':
-            loaded_rule = load_rule(rule, settings)
+            loaded_rule = load_rule(rule)
             if loaded_rule in settings.rules and \
-                    loaded_rule not in settings.exclude_rules:
+                            loaded_rule not in settings.exclude_rules:
                 yield loaded_rule
 
 
-def get_rules(user_dir, settings):
+def get_rules(user_dir):
     """Returns all enabled rules."""
     bundled = Path(__file__).parent \
         .joinpath('rules') \
         .glob('*.py')
     user = user_dir.joinpath('rules').glob('*.py')
-    return sorted(get_loaded_rules(sorted(bundled) + sorted(user), settings),
+    return sorted(get_loaded_rules(sorted(bundled) + sorted(user)),
                   key=lambda rule: rule.priority)
 
 
-def is_rule_match(command, rule, settings):
+def is_rule_match(command, rule):
     """Returns first matched rule for command."""
     script_only = command.stdout is None and command.stderr is None
 
@@ -46,27 +48,26 @@ def is_rule_match(command, rule, settings):
         return False
 
     try:
-        with logs.debug_time(u'Trying rule: {};'.format(rule.name),
-                             settings):
+        with logs.debug_time(u'Trying rule: {};'.format(rule.name)):
             if rule.match(command, settings):
                 return True
     except Exception:
-        logs.rule_failed(rule, sys.exc_info(), settings)
+        logs.rule_failed(rule, sys.exc_info())
 
 
-def make_corrected_commands(command, rule, settings):
+def make_corrected_commands(command, rule):
     new_commands = rule.get_new_command(command, settings)
     if not isinstance(new_commands, list):
         new_commands = (new_commands,)
     for n, new_command in enumerate(new_commands):
-        yield types.CorrectedCommand(script=new_command,
-                                     side_effect=rule.side_effect,
-                                     priority=(n + 1) * rule.priority)
+        yield CorrectedCommand(script=new_command,
+                               side_effect=rule.side_effect,
+                               priority=(n + 1) * rule.priority)
 
 
-def get_corrected_commands(command, user_dir, settings):
+def get_corrected_commands(command, user_dir):
     corrected_commands = (
-        corrected for rule in get_rules(user_dir, settings)
-        if is_rule_match(command, rule, settings)
-        for corrected in make_corrected_commands(command, rule, settings))
-    return types.SortedCorrectedCommandsSequence(corrected_commands, settings)
+        corrected for rule in get_rules(user_dir)
+        if is_rule_match(command, rule)
+        for corrected in make_corrected_commands(command, rule))
+    return SortedCorrectedCommandsSequence(corrected_commands)

--- a/thefuck/logs.py
+++ b/thefuck/logs.py
@@ -5,9 +5,10 @@ from datetime import datetime
 import sys
 from traceback import format_exception
 import colorama
+from .conf import settings
 
 
-def color(color_, settings):
+def color(color_):
     """Utility for ability to disabling colored output."""
     if settings.no_colors:
         return ''
@@ -15,37 +16,37 @@ def color(color_, settings):
         return color_
 
 
-def exception(title, exc_info, settings):
+def exception(title, exc_info):
     sys.stderr.write(
         u'{warn}[WARN] {title}:{reset}\n{trace}'
         u'{warn}----------------------------{reset}\n\n'.format(
             warn=color(colorama.Back.RED + colorama.Fore.WHITE
-                       + colorama.Style.BRIGHT, settings),
-            reset=color(colorama.Style.RESET_ALL, settings),
+                       + colorama.Style.BRIGHT),
+            reset=color(colorama.Style.RESET_ALL),
             title=title,
             trace=''.join(format_exception(*exc_info))))
 
 
-def rule_failed(rule, exc_info, settings):
-    exception('Rule {}'.format(rule.name), exc_info, settings)
+def rule_failed(rule, exc_info):
+    exception('Rule {}'.format(rule.name), exc_info)
 
 
-def failed(msg, settings):
+def failed(msg):
     sys.stderr.write('{red}{msg}{reset}\n'.format(
         msg=msg,
-        red=color(colorama.Fore.RED, settings),
-        reset=color(colorama.Style.RESET_ALL, settings)))
+        red=color(colorama.Fore.RED),
+        reset=color(colorama.Style.RESET_ALL)))
 
 
-def show_corrected_command(corrected_command, settings):
+def show_corrected_command(corrected_command):
     sys.stderr.write('{bold}{script}{reset}{side_effect}\n'.format(
         script=corrected_command.script,
         side_effect=' (+side effect)' if corrected_command.side_effect else '',
-        bold=color(colorama.Style.BRIGHT, settings),
-        reset=color(colorama.Style.RESET_ALL, settings)))
+        bold=color(colorama.Style.BRIGHT),
+        reset=color(colorama.Style.RESET_ALL)))
 
 
-def confirm_text(corrected_command, settings):
+def confirm_text(corrected_command):
     sys.stderr.write(
         ('{clear}{bold}{script}{reset}{side_effect} '
          '[{green}enter{reset}/{blue}↑{reset}/{blue}↓{reset}'
@@ -53,42 +54,42 @@ def confirm_text(corrected_command, settings):
             script=corrected_command.script,
             side_effect=' (+side effect)' if corrected_command.side_effect else '',
             clear='\033[1K\r',
-            bold=color(colorama.Style.BRIGHT, settings),
-            green=color(colorama.Fore.GREEN, settings),
-            red=color(colorama.Fore.RED, settings),
-            reset=color(colorama.Style.RESET_ALL, settings),
-            blue=color(colorama.Fore.BLUE, settings)))
+            bold=color(colorama.Style.BRIGHT),
+            green=color(colorama.Fore.GREEN),
+            red=color(colorama.Fore.RED),
+            reset=color(colorama.Style.RESET_ALL),
+            blue=color(colorama.Fore.BLUE)))
 
 
-def debug(msg, settings):
+def debug(msg):
     if settings.debug:
         sys.stderr.write(u'{blue}{bold}DEBUG:{reset} {msg}\n'.format(
             msg=msg,
-            reset=color(colorama.Style.RESET_ALL, settings),
-            blue=color(colorama.Fore.BLUE, settings),
-            bold=color(colorama.Style.BRIGHT, settings)))
+            reset=color(colorama.Style.RESET_ALL),
+            blue=color(colorama.Fore.BLUE),
+            bold=color(colorama.Style.BRIGHT)))
 
 
 @contextmanager
-def debug_time(msg, settings):
+def debug_time(msg):
     started = datetime.now()
     try:
         yield
     finally:
-        debug(u'{} took: {}'.format(msg, datetime.now() - started), settings)
+        debug(u'{} took: {}'.format(msg, datetime.now() - started))
 
 
-def how_to_configure_alias(configuration_details, settings):
+def how_to_configure_alias(configuration_details):
     print("Seems like {bold}fuck{reset} alias isn't configured!".format(
-        bold=color(colorama.Style.BRIGHT, settings),
-        reset=color(colorama.Style.RESET_ALL, settings)))
+        bold=color(colorama.Style.BRIGHT),
+        reset=color(colorama.Style.RESET_ALL)))
     if configuration_details:
         content, path = configuration_details
         print(
             "Please put {bold}{content}{reset} in your "
             "{bold}{path}{reset}.".format(
-                bold=color(colorama.Style.BRIGHT, settings),
-                reset=color(colorama.Style.RESET_ALL, settings),
+                bold=color(colorama.Style.BRIGHT),
+                reset=color(colorama.Style.RESET_ALL),
                 path=path,
                 content=content))
     print('More details - https://github.com/nvbn/thefuck#manual-installation')

--- a/thefuck/main.py
+++ b/thefuck/main.py
@@ -98,7 +98,7 @@ def fix_command():
             logs.debug('Empty command, nothing to do')
             return
 
-        corrected_commands = get_corrected_commands(command, user_dir)
+        corrected_commands = get_corrected_commands(command)
         selected_command = select_command(corrected_commands)
         if selected_command:
             run_command(command, selected_command)

--- a/thefuck/main.py
+++ b/thefuck/main.py
@@ -13,6 +13,7 @@ import six
 from . import logs, types, shells
 from .conf import initialize_settings_file, init_settings, settings
 from .corrector import get_corrected_commands
+from .utils import compatibility_call
 from .ui import select_command
 
 
@@ -77,7 +78,7 @@ def get_command(args):
 def run_command(old_cmd, command):
     """Runs command from rule for passed command."""
     if command.side_effect:
-        command.side_effect(old_cmd, command.script, settings)
+        compatibility_call(command.side_effect, old_cmd, command.script)
     shells.put_to_history(command.script)
     print(command.script)
 

--- a/thefuck/rules/apt_get.py
+++ b/thefuck/rules/apt_get.py
@@ -20,11 +20,11 @@ def get_package(command):
         return None
 
 
-def match(command, settings):
+def match(command):
     return 'not found' in command.stderr and get_package(command.script)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     name = get_package(command.script)
     formatme = shells.and_('sudo apt-get install {}', '{}')
     return formatme.format(name, command.script)

--- a/thefuck/rules/apt_get_search.py
+++ b/thefuck/rules/apt_get_search.py
@@ -3,9 +3,9 @@ from thefuck.utils import for_app
 
 
 @for_app('apt-get')
-def match(command, settings):
+def match(command):
     return command.script.startswith('apt-get search')
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return re.sub(r'^apt-get', 'apt-cache', command.script)

--- a/thefuck/rules/brew_install.py
+++ b/thefuck/rules/brew_install.py
@@ -24,7 +24,7 @@ def _get_similar_formula(formula_name):
     return get_closest(formula_name, _get_formulas(), 1, 0.85)
 
 
-def match(command, settings):
+def match(command):
     is_proper_command = ('brew install' in command.script and
                          'No available formula' in command.stderr)
 
@@ -35,7 +35,7 @@ def match(command, settings):
     return False
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     not_exist_formula = re.findall(r'Error: No available formula for ([a-z]+)',
                                    command.stderr)[0]
     exist_formula = _get_similar_formula(not_exist_formula)

--- a/thefuck/rules/brew_unknown_command.py
+++ b/thefuck/rules/brew_unknown_command.py
@@ -63,7 +63,7 @@ def _brew_commands():
             'doctor', 'create', 'edit']
 
 
-def match(command, settings):
+def match(command):
     is_proper_command = ('brew' in command.script and
                          'Unknown command' in command.stderr)
 
@@ -74,7 +74,7 @@ def match(command, settings):
     return False
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     broken_cmd = re.findall(r'Error: Unknown command: ([a-z]+)',
                             command.stderr)[0]
     return replace_command(command, broken_cmd, _brew_commands())

--- a/thefuck/rules/brew_upgrade.py
+++ b/thefuck/rules/brew_upgrade.py
@@ -6,9 +6,9 @@
 # It currently upgrades all formula but this will soon change to require '--all'.
 
 
-def match(command, settings):
+def match(command):
     return command.script == 'brew upgrade'
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return command.script + ' --all'

--- a/thefuck/rules/cargo.py
+++ b/thefuck/rules/cargo.py
@@ -1,6 +1,6 @@
-def match(command, settings):
+def match(command):
     return command.script == 'cargo'
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return 'cargo build'

--- a/thefuck/rules/cargo_no_command.py
+++ b/thefuck/rules/cargo_no_command.py
@@ -3,12 +3,12 @@ from thefuck.utils import replace_argument, for_app
 
 
 @for_app('cargo')
-def match(command, settings):
+def match(command):
     return ('No such subcommand' in command.stderr
             and 'Did you mean' in command.stderr)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     broken = command.script.split()[1]
     fix = re.findall(r'Did you mean `([^`]*)`', command.stderr)[0]
 

--- a/thefuck/rules/cd_correction.py
+++ b/thefuck/rules/cd_correction.py
@@ -18,7 +18,7 @@ def _get_sub_dirs(parent):
 
 @sudo_support
 @for_app('cd')
-def match(command, settings):
+def match(command):
     """Match function copied from cd_mkdir.py"""
     return (command.script.startswith('cd ')
             and ('no such file or directory' in command.stderr.lower()
@@ -26,7 +26,7 @@ def match(command, settings):
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     """
     Attempt to rebuild the path string by spellchecking the directories.
     If it fails (i.e. no directories are a close enough match), then it
@@ -47,7 +47,7 @@ def get_new_command(command, settings):
         if best_matches:
             cwd = os.path.join(cwd, best_matches[0])
         else:
-            return cd_mkdir.get_new_command(command, settings)
+            return cd_mkdir.get_new_command(command)
     return 'cd "{0}"'.format(cwd)
 
 

--- a/thefuck/rules/cd_mkdir.py
+++ b/thefuck/rules/cd_mkdir.py
@@ -6,12 +6,12 @@ from thefuck.specific.sudo import sudo_support
 
 @sudo_support
 @for_app('cd')
-def match(command, settings):
+def match(command):
     return (('no such file or directory' in command.stderr.lower()
              or 'cd: can\'t cd to' in command.stderr.lower()))
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     repl = shells.and_('mkdir -p \\1', 'cd \\1')
     return re.sub(r'^cd (.*)', repl, command.script)

--- a/thefuck/rules/cd_parent.py
+++ b/thefuck/rules/cd_parent.py
@@ -8,9 +8,9 @@
 # cd..: command not found
 
 
-def match(command, settings):
+def match(command):
     return command.script == 'cd..'
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return 'cd ..'

--- a/thefuck/rules/composer_not_command.py
+++ b/thefuck/rules/composer_not_command.py
@@ -3,12 +3,12 @@ from thefuck.utils import replace_argument, for_app
 
 
 @for_app('composer')
-def match(command, settings):
+def match(command):
     return (('did you mean this?' in command.stderr.lower()
              or 'did you mean one of these?' in command.stderr.lower()))
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     broken_cmd = re.findall(r"Command \"([^']*)\" is not defined", command.stderr)[0]
     new_cmd = re.findall(r'Did you mean this\?[^\n]*\n\s*([^\n]*)', command.stderr)
     if not new_cmd:

--- a/thefuck/rules/cp_omitting_directory.py
+++ b/thefuck/rules/cp_omitting_directory.py
@@ -5,11 +5,11 @@ from thefuck.utils import for_app
 
 @sudo_support
 @for_app('cp')
-def match(command, settings):
+def match(command):
     stderr = command.stderr.lower()
     return 'omitting directory' in stderr or 'is a directory' in stderr
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return re.sub(r'^cp', 'cp -a', command.script)

--- a/thefuck/rules/cpp11.py
+++ b/thefuck/rules/cpp11.py
@@ -2,11 +2,11 @@ from thefuck.utils import for_app
 
 
 @for_app(['g++', 'clang++'])
-def match(command, settings):
+def match(command):
     return ('This file requires compiler and library support for the '
             'ISO C++ 2011 standard.' in command.stderr or
             '-Wc++11-extensions' in command.stderr)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return command.script + ' -std=c++11'

--- a/thefuck/rules/dirty_untar.py
+++ b/thefuck/rules/dirty_untar.py
@@ -25,18 +25,18 @@ def _tar_file(cmd):
 
 
 @for_app('tar')
-def match(command, settings):
+def match(command):
     return ('-C' not in command.script
             and _is_tar_extract(command.script)
             and _tar_file(command.script) is not None)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return shells.and_('mkdir -p {dir}', '{cmd} -C {dir}') \
         .format(dir=_tar_file(command.script)[1], cmd=command.script)
 
 
-def side_effect(old_cmd, command, settings):
+def side_effect(old_cmd, command):
     with tarfile.TarFile(_tar_file(old_cmd.script)[0]) as archive:
         for file in archive.getnames():
             os.remove(file)

--- a/thefuck/rules/dirty_unzip.py
+++ b/thefuck/rules/dirty_unzip.py
@@ -22,16 +22,16 @@ def _zip_file(command):
 
 
 @for_app('unzip')
-def match(command, settings):
+def match(command):
     return ('-d' not in command.script
             and _is_bad_zip(_zip_file(command)))
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return '{} -d {}'.format(command.script, _zip_file(command)[:-4])
 
 
-def side_effect(old_cmd, command, settings):
+def side_effect(old_cmd, command):
     with zipfile.ZipFile(_zip_file(old_cmd), 'r') as archive:
         for file in archive.namelist():
             os.remove(file)

--- a/thefuck/rules/django_south_ghost.py
+++ b/thefuck/rules/django_south_ghost.py
@@ -1,8 +1,8 @@
-def match(command, settings):
+def match(command):
     return 'manage.py' in command.script and \
            'migrate' in command.script \
            and 'or pass --delete-ghost-migrations' in command.stderr
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return u'{} --delete-ghost-migrations'.format(command.script)

--- a/thefuck/rules/django_south_merge.py
+++ b/thefuck/rules/django_south_merge.py
@@ -1,8 +1,8 @@
-def match(command, settings):
+def match(command):
     return 'manage.py' in command.script and \
            'migrate' in command.script \
            and '--merge: will just attempt the migration' in command.stderr
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return u'{} --merge'.format(command.script)

--- a/thefuck/rules/docker_not_command.py
+++ b/thefuck/rules/docker_not_command.py
@@ -7,7 +7,7 @@ from thefuck.specific.sudo import sudo_support
 
 @sudo_support
 @for_app('docker')
-def match(command, settings):
+def match(command):
     return 'is not a docker command' in command.stderr
 
 
@@ -21,7 +21,7 @@ def get_docker_commands():
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     wrong_command = re.findall(
         r"docker: '(\w+)' is not a docker command.", command.stderr)[0]
     return replace_command(command, wrong_command, get_docker_commands())

--- a/thefuck/rules/dry.py
+++ b/thefuck/rules/dry.py
@@ -1,10 +1,10 @@
-def match(command, settings):
+def match(command):
     split_command = command.script.split()
 
     return len(split_command) >= 2 and split_command[0] == split_command[1]
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return command.script[command.script.find(' ')+1:]
 
 # it should be rare enough to actually have to type twice the same word, so

--- a/thefuck/rules/fix_alt_space.py
+++ b/thefuck/rules/fix_alt_space.py
@@ -5,11 +5,11 @@ from thefuck.specific.sudo import sudo_support
 
 
 @sudo_support
-def match(command, settings):
+def match(command):
     return ('command not found' in command.stderr.lower()
             and u' ' in command.script)
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return re.sub(u' ', ' ', command.script)

--- a/thefuck/rules/fix_file.py
+++ b/thefuck/rules/fix_file.py
@@ -1,6 +1,6 @@
 import re
 import os
-from thefuck.utils import memoize, wrap_settings
+from thefuck.utils import memoize, default_settings
 from thefuck import shells
 
 
@@ -57,7 +57,7 @@ def match(command, settings):
     return _search(command.stderr) or _search(command.stdout)
 
 
-@wrap_settings({'fixlinecmd': '{editor} {file} +{line}',
+@default_settings({'fixlinecmd': '{editor} {file} +{line}',
                 'fixcolcmd': None})
 def get_new_command(command, settings):
     m = _search(command.stderr) or _search(command.stdout)

--- a/thefuck/rules/fix_file.py
+++ b/thefuck/rules/fix_file.py
@@ -1,6 +1,7 @@
 import re
 import os
 from thefuck.utils import memoize, default_settings
+from thefuck.conf import settings
 from thefuck import shells
 
 
@@ -50,7 +51,7 @@ def _search(stderr):
             return m
 
 
-def match(command, settings):
+def match(command):
     if 'EDITOR' not in os.environ:
         return False
 
@@ -58,8 +59,8 @@ def match(command, settings):
 
 
 @default_settings({'fixlinecmd': '{editor} {file} +{line}',
-                'fixcolcmd': None})
-def get_new_command(command, settings):
+                   'fixcolcmd': None})
+def get_new_command(command):
     m = _search(command.stderr) or _search(command.stdout)
 
     # Note: there does not seem to be a standard for columns, so they are just

--- a/thefuck/rules/git_add.py
+++ b/thefuck/rules/git_add.py
@@ -4,13 +4,13 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     return ('did not match any file(s) known to git.' in command.stderr
             and "Did you forget to 'git add'?" in command.stderr)
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     missing_file = re.findall(
             r"error: pathspec '([^']*)' "
             r"did not match any file\(s\) known to git.", command.stderr)[0]

--- a/thefuck/rules/git_branch_delete.py
+++ b/thefuck/rules/git_branch_delete.py
@@ -3,11 +3,11 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     return ('branch -d' in command.script
             and 'If you are sure you want to delete it' in command.stderr)
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return replace_argument(command.script, '-d', '-D')

--- a/thefuck/rules/git_branch_list.py
+++ b/thefuck/rules/git_branch_list.py
@@ -3,11 +3,11 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     # catches "git branch list" in place of "git branch"
     return command.script.split()[1:] == 'branch list'.split()
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return shells.and_('git branch --delete list', 'git branch')

--- a/thefuck/rules/git_checkout.py
+++ b/thefuck/rules/git_checkout.py
@@ -6,7 +6,7 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     return ('did not match any file(s) known to git.' in command.stderr
             and "Did you forget to 'git add'?" not in command.stderr)
 
@@ -25,7 +25,7 @@ def get_branches():
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     missing_file = re.findall(
         r"error: pathspec '([^']*)' "
         r"did not match any file\(s\) known to git.", command.stderr)[0]

--- a/thefuck/rules/git_diff_staged.py
+++ b/thefuck/rules/git_diff_staged.py
@@ -3,11 +3,11 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     return ('diff' in command.script and
             '--staged' not in command.script)
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return replace_argument(command.script, 'diff', 'diff --staged')

--- a/thefuck/rules/git_fix_stash.py
+++ b/thefuck/rules/git_fix_stash.py
@@ -4,7 +4,7 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     return (command.script.split()[1] == 'stash'
             and 'usage:' in command.stderr)
 
@@ -21,7 +21,7 @@ stash_commands = (
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     stash_cmd = command.script.split()[2]
     fixed = utils.get_closest(stash_cmd, stash_commands, fallback_to_first=False)
 

--- a/thefuck/rules/git_not_command.py
+++ b/thefuck/rules/git_not_command.py
@@ -4,13 +4,13 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     return (" is not a git command. See 'git --help'." in command.stderr
             and 'Did you mean' in command.stderr)
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     broken_cmd = re.findall(r"git: '([^']*)' is not a git command",
                             command.stderr)[0]
     matched = get_all_matched_commands(command.stderr)

--- a/thefuck/rules/git_pull.py
+++ b/thefuck/rules/git_pull.py
@@ -3,13 +3,13 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     return ('pull' in command.script
             and 'set-upstream' in command.stderr)
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     line = command.stderr.split('\n')[-3].strip()
     branch = line.split(' ')[-1]
     set_upstream = line.replace('<remote>', 'origin')\

--- a/thefuck/rules/git_pull_clone.py
+++ b/thefuck/rules/git_pull_clone.py
@@ -3,11 +3,11 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     return ('fatal: Not a git repository' in command.stderr
             and "Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)." in command.stderr)
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return replace_argument(command.script, 'pull', 'clone')

--- a/thefuck/rules/git_push.py
+++ b/thefuck/rules/git_push.py
@@ -2,11 +2,11 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     return ('push' in command.script
             and 'set-upstream' in command.stderr)
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return command.stderr.split('\n')[-3].strip()

--- a/thefuck/rules/git_push_force.py
+++ b/thefuck/rules/git_push_force.py
@@ -3,7 +3,7 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     return ('push' in command.script
             and '! [rejected]' in command.stderr
             and 'failed to push some refs to' in command.stderr
@@ -11,7 +11,7 @@ def match(command, settings):
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return replace_argument(command.script, 'push', 'push --force')
 
 

--- a/thefuck/rules/git_push_pull.py
+++ b/thefuck/rules/git_push_pull.py
@@ -4,7 +4,7 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     return ('push' in command.script
             and '! [rejected]' in command.stderr
             and 'failed to push some refs to' in command.stderr
@@ -12,6 +12,6 @@ def match(command, settings):
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return shells.and_(replace_argument(command.script, 'push', 'pull'),
                        command.script)

--- a/thefuck/rules/git_stash.py
+++ b/thefuck/rules/git_stash.py
@@ -3,13 +3,13 @@ from thefuck.specific.git import git_support
 
 
 @git_support
-def match(command, settings):
+def match(command):
     # catches "Please commit or stash them" and "Please, commit your changes or
     # stash them before you can switch branches."
     return 'or stash them' in command.stderr
 
 
 @git_support
-def get_new_command(command, settings):
+def get_new_command(command):
     formatme = shells.and_('git stash', '{}')
     return formatme.format(command.script)

--- a/thefuck/rules/go_run.py
+++ b/thefuck/rules/go_run.py
@@ -7,10 +7,10 @@ from thefuck.utils import for_app
 
 
 @for_app('go')
-def match(command, settings):
+def match(command):
     return (command.script.startswith('go run ')
             and not command.script.endswith('.go'))
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return command.script + '.go'

--- a/thefuck/rules/grep_recursive.py
+++ b/thefuck/rules/grep_recursive.py
@@ -2,9 +2,9 @@ from thefuck.utils import for_app
 
 
 @for_app('grep')
-def match(command, settings):
+def match(command):
     return 'is a directory' in command.stderr.lower()
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return 'grep -r {}'.format(command.script[5:])

--- a/thefuck/rules/gulp_not_task.py
+++ b/thefuck/rules/gulp_not_task.py
@@ -4,7 +4,7 @@ from thefuck.utils import replace_command, for_app
 
 
 @for_app('gulp')
-def match(command, script):
+def match(command):
     return 'is not in your gulpfile' in command.stdout
 
 
@@ -15,7 +15,7 @@ def get_gulp_tasks():
             for line in proc.stdout.readlines()]
 
 
-def get_new_command(command, script):
+def get_new_command(command):
     wrong_task = re.findall(r"Task '(\w+)' is not in your gulpfile",
                             command.stdout)[0]
     return replace_command(command, wrong_task, get_gulp_tasks())

--- a/thefuck/rules/has_exists_script.py
+++ b/thefuck/rules/has_exists_script.py
@@ -3,11 +3,11 @@ from thefuck.specific.sudo import sudo_support
 
 
 @sudo_support
-def match(command, settings):
+def match(command):
     return os.path.exists(command.script.split()[0]) \
         and 'command not found' in command.stderr
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return u'./{}'.format(command.script)

--- a/thefuck/rules/heroku_not_command.py
+++ b/thefuck/rules/heroku_not_command.py
@@ -3,7 +3,7 @@ from thefuck.utils import replace_command, for_app
 
 
 @for_app('heroku')
-def match(command, settings):
+def match(command):
     return 'is not a heroku command' in command.stderr and \
            'Perhaps you meant' in command.stderr
 
@@ -14,6 +14,6 @@ def _get_suggests(stderr):
             return re.findall(r'`([^`]+)`', line)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     wrong = re.findall(r'`(\w+)` is not a heroku command', command.stderr)[0]
     return replace_command(command, wrong, _get_suggests(command.stderr))

--- a/thefuck/rules/history.py
+++ b/thefuck/rules/history.py
@@ -24,12 +24,12 @@ def _history_of_exists_without_current(command):
             and line.split(' ')[0] in executables]
 
 
-def match(command, settings):
+def match(command):
     return len(get_close_matches(command.script,
                                  _history_of_exists_without_current(command)))
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return get_closest(command.script,
                        _history_of_exists_without_current(command))
 

--- a/thefuck/rules/java.py
+++ b/thefuck/rules/java.py
@@ -9,9 +9,9 @@ from thefuck.utils import for_app
 
 
 @for_app('java')
-def match(command, settings):
+def match(command):
     return command.script.endswith('.java')
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return command.script[:-5]

--- a/thefuck/rules/javac.py
+++ b/thefuck/rules/javac.py
@@ -10,9 +10,9 @@ from thefuck.utils import for_app
 
 
 @for_app('javac')
-def match(command, settings):
+def match(command):
     return not command.script.endswith('.java')
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return command.script + '.java'

--- a/thefuck/rules/lein_not_task.py
+++ b/thefuck/rules/lein_not_task.py
@@ -5,14 +5,14 @@ from thefuck.specific.sudo import sudo_support
 
 @sudo_support
 @for_app('lein')
-def match(command, settings):
+def match(command):
     return (command.script.startswith('lein')
             and "is not a task. See 'lein help'" in command.stderr
             and 'Did you mean this?' in command.stderr)
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     broken_cmd = re.findall(r"'([^']*)' is not a task",
                             command.stderr)[0]
     new_cmds = get_all_matched_commands(command.stderr, 'Did you mean this?')

--- a/thefuck/rules/ls_lah.py
+++ b/thefuck/rules/ls_lah.py
@@ -2,11 +2,11 @@ from thefuck.utils import for_app
 
 
 @for_app('ls')
-def match(command, settings):
+def match(command):
     return 'ls -' not in command.script
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     command = command.script.split(' ')
     command[0] = 'ls -lah'
     return ' '.join(command)

--- a/thefuck/rules/man.py
+++ b/thefuck/rules/man.py
@@ -1,8 +1,8 @@
-def match(command, settings):
+def match(command):
     return command.script.strip().startswith('man ')
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     if '3' in command.script:
         return command.script.replace("3", "2")
     if '2' in command.script:

--- a/thefuck/rules/man_no_space.py
+++ b/thefuck/rules/man_no_space.py
@@ -1,9 +1,9 @@
-def match(command, settings):
+def match(command):
     return (command.script.startswith(u'man')
             and u'command not found' in command.stderr.lower())
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return u'man {}'.format(command.script[3:])
 
 priority = 2000

--- a/thefuck/rules/mercurial.py
+++ b/thefuck/rules/mercurial.py
@@ -13,14 +13,14 @@ def extract_possibilities(command):
 
 
 @for_app('hg')
-def match(command, settings):
+def match(command):
     return ('hg: unknown command' in command.stderr
             and '(did you mean one of ' in command.stderr
             or "hg: command '" in command.stderr
             and "' is ambiguous:" in command.stderr)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     script = command.script.split(' ')
     possibilities = extract_possibilities(command)
     script[1] = get_closest(script[1], possibilities)

--- a/thefuck/rules/mkdir_p.py
+++ b/thefuck/rules/mkdir_p.py
@@ -3,11 +3,11 @@ from thefuck.specific.sudo import sudo_support
 
 
 @sudo_support
-def match(command, settings):
+def match(command):
     return ('mkdir' in command.script
             and 'No such file or directory' in command.stderr)
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return re.sub('\\bmkdir (.*)', 'mkdir -p \\1', command.script)

--- a/thefuck/rules/mvn_no_command.py
+++ b/thefuck/rules/mvn_no_command.py
@@ -2,10 +2,10 @@ from thefuck.utils import for_app
 
 
 @for_app('mvn')
-def match(command, settings):
+def match(command):
     return 'No goals have been specified for this build' in command.stdout
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return [command.script + ' clean package',
             command.script + ' clean install']

--- a/thefuck/rules/mvn_unknown_lifecycle_phase.py
+++ b/thefuck/rules/mvn_unknown_lifecycle_phase.py
@@ -14,13 +14,13 @@ def _getavailable_lifecycles(command):
 
 
 @for_app('mvn')
-def match(command, settings):
+def match(command):
     failed_lifecycle = _get_failed_lifecycle(command)
     available_lifecycles = _getavailable_lifecycles(command)
     return available_lifecycles and failed_lifecycle
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     failed_lifecycle = _get_failed_lifecycle(command)
     available_lifecycles = _getavailable_lifecycles(command)
     if available_lifecycles and failed_lifecycle:

--- a/thefuck/rules/no_command.py
+++ b/thefuck/rules/no_command.py
@@ -4,14 +4,14 @@ from thefuck.specific.sudo import sudo_support
 
 
 @sudo_support
-def match(command, settings):
+def match(command):
     return 'not found' in command.stderr and \
            bool(get_close_matches(command.script.split(' ')[0],
                                   get_all_executables()))
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     old_command = command.script.split(' ')[0]
     new_cmds = get_close_matches(old_command, get_all_executables(), cutoff=0.1)
     return [' '.join([new_command] + command.script.split(' ')[1:])

--- a/thefuck/rules/no_such_file.py
+++ b/thefuck/rules/no_such_file.py
@@ -10,7 +10,7 @@ patterns = (
 )
 
 
-def match(command, settings):
+def match(command):
     for pattern in patterns:
         if re.search(pattern, command.stderr):
             return True
@@ -18,7 +18,7 @@ def match(command, settings):
     return False
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     for pattern in patterns:
         file = re.findall(pattern, command.stderr)
 

--- a/thefuck/rules/open.py
+++ b/thefuck/rules/open.py
@@ -9,7 +9,7 @@ from thefuck.utils import for_app
 
 
 @for_app('open', 'xdg-open', 'gnome-open', 'kde-open')
-def match(command, settings):
+def match(command):
     return ('.com' in command.script
             or '.net' in command.script
             or '.org' in command.script
@@ -22,5 +22,5 @@ def match(command, settings):
             or 'www.' in command.script)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return command.script.replace('open ', 'open http://')

--- a/thefuck/rules/pacman.py
+++ b/thefuck/rules/pacman.py
@@ -2,11 +2,11 @@ from thefuck.specific.archlinux import get_pkgfile, archlinux_env
 from thefuck import shells
 
 
-def match(command, settings):
+def match(command):
     return 'not found' in command.stderr and get_pkgfile(command.script)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     packages = get_pkgfile(command.script)
 
     formatme = shells.and_('{} -S {}', '{}')

--- a/thefuck/rules/pacman_not_found.py
+++ b/thefuck/rules/pacman_not_found.py
@@ -10,12 +10,12 @@ from thefuck.utils import replace_command
 from thefuck.specific.archlinux import get_pkgfile, archlinux_env
 
 
-def match(command, settings):
+def match(command):
     return (command.script.startswith(('pacman', 'sudo pacman', 'yaourt'))
             and 'error: target not found:' in command.stderr)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     pgr = command.script.split()[-1]
 
     return replace_command(command, pgr, get_pkgfile(pgr))

--- a/thefuck/rules/pip_unknown_command.py
+++ b/thefuck/rules/pip_unknown_command.py
@@ -5,13 +5,13 @@ from thefuck.specific.sudo import sudo_support
 
 @sudo_support
 @for_app('pip')
-def match(command, settings):
+def match(command):
     return ('pip' in command.script and
             'unknown command' in command.stderr and
             'maybe you meant' in command.stderr)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     broken_cmd = re.findall(r'ERROR: unknown command \"([a-z]+)\"',
                             command.stderr)[0]
     new_cmd = re.findall(r'maybe you meant \"([a-z]+)\"', command.stderr)[0]

--- a/thefuck/rules/python_command.py
+++ b/thefuck/rules/python_command.py
@@ -5,7 +5,7 @@ from thefuck.specific.sudo import sudo_support
 
 
 @sudo_support
-def match(command, settings):
+def match(command):
     toks = command.script.split()
     return (len(toks) > 0
             and toks[0].endswith('.py')
@@ -14,5 +14,5 @@ def match(command, settings):
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return 'python ' + command.script

--- a/thefuck/rules/python_execute.py
+++ b/thefuck/rules/python_execute.py
@@ -7,9 +7,9 @@ from thefuck.utils import for_app
 
 
 @for_app('python')
-def match(command, settings):
+def match(command):
     return not command.script.endswith('.py')
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return command.script + '.py'

--- a/thefuck/rules/quotation_marks.py
+++ b/thefuck/rules/quotation_marks.py
@@ -4,9 +4,9 @@
 # > git commit -m 'My Message"
 
 
-def match(command, settings):
+def match(command):
     return '\'' in command.script and '\"' in command.script
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return command.script.replace('\'', '\"')

--- a/thefuck/rules/rm_dir.py
+++ b/thefuck/rules/rm_dir.py
@@ -3,13 +3,13 @@ from thefuck.specific.sudo import sudo_support
 
 
 @sudo_support
-def match(command, settings):
+def match(command):
     return ('rm' in command.script
             and 'is a directory' in command.stderr.lower())
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     arguments = '-rf'
     if 'hdfs' in command.script:
         arguments = '-r'

--- a/thefuck/rules/rm_root.py
+++ b/thefuck/rules/rm_root.py
@@ -4,12 +4,12 @@ enabled_by_default = False
 
 
 @sudo_support
-def match(command, settings):
+def match(command):
     return ({'rm', '/'}.issubset(command.script.split())
             and '--no-preserve-root' not in command.script
             and '--no-preserve-root' in command.stderr)
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     return u'{} --no-preserve-root'.format(command.script)

--- a/thefuck/rules/sed_unterminated_s.py
+++ b/thefuck/rules/sed_unterminated_s.py
@@ -3,11 +3,11 @@ from thefuck.utils import quote, for_app
 
 
 @for_app('sed')
-def match(command, settings):
+def match(command):
     return "unterminated `s' command" in command.stderr
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     script = shlex.split(command.script)
 
     for (i, e) in enumerate(script):

--- a/thefuck/rules/sl_ls.py
+++ b/thefuck/rules/sl_ls.py
@@ -6,9 +6,9 @@ I often fuck up 'ls' and type 'sl'. No more!
 """
 
 
-def match(command, settings):
+def match(command):
     return command.script == 'sl'
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return 'ls'

--- a/thefuck/rules/ssh_known_hosts.py
+++ b/thefuck/rules/ssh_known_hosts.py
@@ -5,7 +5,7 @@ commands = ('ssh', 'scp')
 
 
 @for_app(*commands)
-def match(command, settings):
+def match(command):
     if not command.script:
         return False
     if not command.script.startswith(commands):
@@ -20,11 +20,11 @@ def match(command, settings):
     return any(re.findall(pattern, command.stderr) for pattern in patterns)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return command.script
 
 
-def side_effect(old_cmd, command, settings):
+def side_effect(old_cmd, command):
     offending_pattern = re.compile(
         r'(?:Offending (?:key for IP|\S+ key)|Matching host key) in ([^:]+):(\d+)',
         re.MULTILINE)

--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -19,7 +19,7 @@ patterns = ['permission denied',
             'authentication is required']
 
 
-def match(command, settings):
+def match(command):
     for pattern in patterns:
         if pattern.lower() in command.stderr.lower()\
                 or pattern.lower() in command.stdout.lower():
@@ -27,7 +27,7 @@ def match(command, settings):
     return False
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     if '>' in command.script:
         return u'sudo sh -c "{}"'.format(command.script.replace('"', '\\"'))
     else:

--- a/thefuck/rules/switch_lang.py
+++ b/thefuck/rules/switch_lang.py
@@ -28,7 +28,7 @@ def _switch_command(command, layout):
     return ''.join(_switch(ch, layout) for ch in command.script)
 
 
-def match(command, settings):
+def match(command):
     if 'not found' not in command.stderr:
         return False
     matched_layout = _get_matched_layout(command)
@@ -36,6 +36,6 @@ def match(command, settings):
            _switch_command(command, matched_layout) != thefuck_alias()
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     matched_layout = _get_matched_layout(command)
     return _switch_command(command, matched_layout)

--- a/thefuck/rules/systemctl.py
+++ b/thefuck/rules/systemctl.py
@@ -7,7 +7,7 @@ from thefuck.utils import for_app
 
 @sudo_support
 @for_app('systemctl')
-def match(command, settings):
+def match(command):
     # Catches 'Unknown operation 'service'.' when executing systemctl with
     # misordered arguments
     cmd = command.script.split()
@@ -16,7 +16,7 @@ def match(command, settings):
 
 
 @sudo_support
-def get_new_command(command, settings):
+def get_new_command(command):
     cmd = command.script.split()
     cmd[-1], cmd[-2] = cmd[-2], cmd[-1]
     return ' '.join(cmd)

--- a/thefuck/rules/test.py.py
+++ b/thefuck/rules/test.py.py
@@ -1,8 +1,8 @@
-def match(command, settings):
+def match(command):
     return command.script == 'test.py' and 'not found' in command.stderr
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return 'py.test'
 
 

--- a/thefuck/rules/tmux.py
+++ b/thefuck/rules/tmux.py
@@ -3,12 +3,12 @@ from thefuck.utils import replace_command, for_app
 
 
 @for_app('tmux')
-def match(command, settings):
+def match(command):
     return ('ambiguous command:' in command.stderr
             and 'could be:' in command.stderr)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     cmd = re.match(r"ambiguous command: (.*), could be: (.*)",
                    command.stderr)
 

--- a/thefuck/rules/tsuru_login.py
+++ b/thefuck/rules/tsuru_login.py
@@ -3,10 +3,10 @@ from thefuck.utils import for_app
 
 
 @for_app('tsuru')
-def match(command, settings):
+def match(command):
     return ('not authenticated' in command.stderr
             and 'session has expired' in command.stderr)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     return shells.and_('tsuru login', command.script)

--- a/thefuck/rules/tsuru_not_command.py
+++ b/thefuck/rules/tsuru_not_command.py
@@ -3,12 +3,12 @@ from thefuck.utils import get_all_matched_commands, replace_command, for_app
 
 
 @for_app('tsuru')
-def match(command, settings):
+def match(command):
     return (' is not a tsuru command. See "tsuru help".' in command.stderr
             and '\nDid you mean?\n\t' in command.stderr)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     broken_cmd = re.findall(r'tsuru: "([^"]*)" is not a tsuru command',
                             command.stderr)[0]
     return replace_command(command, broken_cmd,

--- a/thefuck/rules/unknown_command.py
+++ b/thefuck/rules/unknown_command.py
@@ -1,12 +1,12 @@
 import re
 from thefuck.utils import replace_command
 
-def match(command, settings):
+def match(command):
     return (re.search(r"([^:]*): Unknown command.*", command.stderr) != None
             and re.search(r"Did you mean ([^?]*)?", command.stderr) != None)
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     broken_cmd = re.findall(r"([^:]*): Unknown command.*", command.stderr)[0]
     matched = re.findall(r"Did you mean ([^?]*)?", command.stderr)
     return replace_command(command, broken_cmd, matched)

--- a/thefuck/rules/vagrant_up.py
+++ b/thefuck/rules/vagrant_up.py
@@ -3,11 +3,11 @@ from thefuck.utils import for_app
 
 
 @for_app('vagrant')
-def match(command, settings):
+def match(command):
     return 'run `vagrant up`' in command.stderr.lower()
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     cmds = command.script.split(' ')
     machine = None
     if len(cmds) >= 3:

--- a/thefuck/rules/whois.py
+++ b/thefuck/rules/whois.py
@@ -2,7 +2,7 @@
 from six.moves.urllib.parse import urlparse
 
 
-def match(command, settings):
+def match(command):
     """
     What the `whois` command returns depends on the 'Whois server' it contacted
     and is not consistent through different servers. But there can be only two
@@ -22,7 +22,7 @@ def match(command, settings):
     return 'whois ' in command.script.strip()
 
 
-def get_new_command(command, settings):
+def get_new_command(command):
     url = command.script.split()[1]
 
     if '/' in command.script:

--- a/thefuck/specific/git.py
+++ b/thefuck/specific/git.py
@@ -6,7 +6,7 @@ from ..utils import quote, is_app
 
 
 @decorator
-def git_support(fn, command, settings):
+def git_support(fn, command):
     """Resolves git aliases and supports testing for both git and hub."""
     # supports GitHub's `hub` command
     # which is recommended to be used with `alias git=hub`
@@ -29,4 +29,4 @@ def git_support(fn, command, settings):
 
         command = Command._replace(command, script=new_script)
 
-    return fn(command, settings)
+    return fn(command)

--- a/thefuck/specific/sudo.py
+++ b/thefuck/specific/sudo.py
@@ -4,15 +4,14 @@ from ..types import Command
 
 
 @decorator
-def sudo_support(fn, command, settings):
+def sudo_support(fn, command):
     """Removes sudo before calling fn and adds it after."""
     if not command.script.startswith('sudo '):
-        return fn(command, settings)
+        return fn(command)
 
     result = fn(Command(command.script[5:],
                         command.stdout,
-                        command.stderr),
-                settings)
+                        command.stderr))
 
     if result and isinstance(result, six.string_types):
         return u'sudo {}'.format(result)

--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 import sys
+from .conf import settings
 from . import logs
 
 try:
@@ -71,7 +72,7 @@ class CommandSelector(object):
         fn(self.value)
 
 
-def select_command(corrected_commands, settings):
+def select_command(corrected_commands):
     """Returns:
 
      - the first command when confirmation disabled;
@@ -80,21 +81,21 @@ def select_command(corrected_commands, settings):
 
     """
     if not corrected_commands:
-        logs.failed('No fucks given', settings)
+        logs.failed('No fucks given')
         return
 
     selector = CommandSelector(corrected_commands)
     if not settings.require_confirmation:
-        logs.show_corrected_command(selector.value, settings)
+        logs.show_corrected_command(selector.value)
         return selector.value
 
-    selector.on_change(lambda val: logs.confirm_text(val, settings))
+    selector.on_change(lambda val: logs.confirm_text(val))
     for action in read_actions():
         if action == SELECT:
             sys.stderr.write('\n')
             return selector.value
         elif action == ABORT:
-            logs.failed('\nAborted', settings)
+            logs.failed('\nAborted')
             return
         elif action == PREVIOUS:
             selector.previous()

--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -60,18 +60,20 @@ def which(program):
     return None
 
 
-def wrap_settings(params):
+def default_settings(params):
     """Adds default values to settings if it not presented.
 
     Usage:
 
-        @wrap_settings({'apt': '/usr/bin/apt'})
+        @default_settings({'apt': '/usr/bin/apt'})
         def match(command, settings):
             print(settings.apt)
 
     """
     def _wrap_settings(fn, command, settings):
-        return fn(command, Settings(settings, **params))
+        for k, w in params.items():
+            settings.setdefault(k, w)
+        return fn(command, settings)
     return decorator(_wrap_settings)
 
 

--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -187,7 +187,7 @@ def cache(*depends_on):
         if cache.disabled:
             return fn(*args, **kwargs)
 
-        cache_path = os.path.join(tempfile.gettempdir(), '.thefuck-cache')
+        cache_path = settings.user_dir.joinpath('.thefuck-cache').as_posix()
         # A bit obscure, but simplest way to generate unique key for
         # functions and methods in python 2 and 3:
         key = '{}.{}'.format(fn.__module__, repr(fn).split('at')[0])

--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 import pkg_resources
 import six
+from .types import Settings
 
 
 DEVNULL = open(os.devnull, 'w')
@@ -70,7 +71,7 @@ def wrap_settings(params):
 
     """
     def _wrap_settings(fn, command, settings):
-        return fn(command, settings.update(**params))
+        return fn(command, Settings(settings, **params))
     return decorator(_wrap_settings)
 
 


### PR DESCRIPTION
Now settings object can be received with:
```python
from thefuck.conf import settings
```

Rules api changed to:
```python
match(command: Command) -> bool
get_new_command(command: Command) -> str | list[str]
side_effect(old_command: Command, fixed_command: str) -> None
```