### PR TITLE
Add j, k key for arrow action at read_actions

### DIFF
--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -44,9 +44,9 @@ def read_actions():
         buffer.append(ch)
         buffer = buffer[-3:]
 
-        if buffer == ['\x1b', '[', 'A']:  # ↑
+        if buffer == ['\x1b', '[', 'A'] or ch == 'k':  # ↑
             yield PREVIOUS
-        elif buffer == ['\x1b', '[', 'B']:  # ↓
+        elif buffer == ['\x1b', '[', 'B'] or ch == 'j':  # ↓
             yield NEXT
 
 


### PR DESCRIPTION
Hello nvbn.

I think that `j` and `k` key are known to many shell users as navigator keys. (such as vim, less, etc..) So i added `j` `k` for move ↑ or ↓.

