### PR TITLE
Test on python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 python:
+  - "3.5"
   - "3.4"
   - "3.3"
   - "2.7"


### PR DESCRIPTION
Python 3.5 has been out and available on travis for some time now, but we were blocked by a *py.test* bug. Now that it's fixed, we should test on Python 3.5 as well.