### PR TITLE
rm -f $eval_script

### DIFF
--- a/thefuck/shells.py
+++ b/thefuck/shells.py
@@ -134,7 +134,7 @@ class Fish(Generic):
                 "    set -l fucked_up_command $history[1]\n"
                 "    thefuck $fucked_up_command > $eval_script\n"
                 "    . $eval_script\n"
-                "    rm $eval_script\n"
+                "    rm -f $eval_script\n"
                 "    if test $exit_code -ne 0\n"
                 "        history --delete $fucked_up_command\n"
                 "    end\n"

--- a/thefuck/shells.py
+++ b/thefuck/shells.py
@@ -134,7 +134,7 @@ class Fish(Generic):
                 "    set -l fucked_up_command $history[1]\n"
                 "    thefuck $fucked_up_command > $eval_script\n"
                 "    . $eval_script\n"
-                "    rm -f $eval_script\n"
+                "    /bin/rm $eval_script\n"
                 "    if test $exit_code -ne 0\n"
                 "        history --delete $fucked_up_command\n"
                 "    end\n"


### PR DESCRIPTION
Without this change, users who have "rm" aliased to "rm -i"
have to confirm removal of the file after running fuck. This
change allows such users to run fuck without having to do
the superfluous rm confirmation.