### PR TITLE
Improve the Fish Shell function making it faster

### DIFF
--- a/thefuck/shells.py
+++ b/thefuck/shells.py
@@ -126,19 +126,20 @@ class Fish(Generic):
             return ['cd', 'grep', 'ls', 'man', 'open']
 
     def app_alias(self, fuck):
-        return ("set TF_ALIAS {0}\n"
-                "function {0} -d 'Correct your previous console command'\n"
-                "    set -l exit_code $status\n"
-                "    set -l eval_script"
-                " (mktemp 2>/dev/null ; or mktemp -t 'thefuck')\n"
-                "    set -l fucked_up_command $history[1]\n"
-                "    thefuck $fucked_up_command > $eval_script\n"
-                "    . $eval_script\n"
-                "    /bin/rm $eval_script\n"
-                "    if test $exit_code -ne 0\n"
-                "        history --delete $fucked_up_command\n"
-                "    end\n"
-                "end").format(fuck)
+        return ('function {0} -d "Correct your previous console command"\n'
+                '    set -l exit_code $status\n'
+                '    set -x TF_ALIAS {0}\n'
+                '    set -l fucked_up_command $history[1]\n'
+                '    thefuck $fucked_up_command | read -l unfucked_command\n'
+                '    if [ "$unfucked_command" != "" ]\n'
+                '        eval $unfucked_command\n'
+                '        if test $exit_code -ne 0\n'
+                '            history --delete $fucked_up_command\n'
+                '            history --merge ^ /dev/null\n'
+                '            return 0\n'
+                '        end\n'
+                '    end\n'
+                'end').format(fuck)
 
     @memoize
     def get_aliases(self):


### PR DESCRIPTION
It works now with no temp file involved, which makes it a lot faster. Also, `history --merge`, although only supported on Fish Shell 2.2+, merges the corrected entry back into history. Neat!

Ref #89