### PR TITLE
Add a CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Report issues
+If you have any issue with The Fuck, sorry about that, but we will do what we
+can to fix that. Actually, maybe we already have, so first thing to do is to
+update The Fuck and see if the bug is still there.
+
+If it is (sorry again), check if the problem has not already been reported and
+if not, just open an issue on [GitHub](https://github.com/nvbn/thefuck) with
+the following basic information:
+  - the output of `thefuck --version` (something like `The Fuck 3.1 using
+    Python 3.5.0`);
+  - your shell and its version (`bash`, `zsh`, *Windows PowerShell*, etc.);
+  - your system (Debian 7, ArchLinux, Windows, etc.);
+  - how to reproduce the bug;
+  - the output of The Fuck with `THEFUCK_DEBUG=true` exported (typically execute
+    `export THEFUCK_DEBUG=true` in your shell before The Fuck);
+  - if the bug only appears with a specific application, the output of that
+    application and its version;
+  - anything else you think is relevant.
+
+It's only with enough information that we can do something to fix the problem.
+
+# Make a pull request
+We gladly accept pull request on the [official
+repository](https://github.com/nvbn/thefuck) for new rules, new features, bug
+fixes, etc.


### PR DESCRIPTION
This adds the distinctive message “Please review the [guidelines for contributing](https://github.com/nvbn/thefuck/blob/master/CONTRIBUTING.md) to this repository.” in GitHub when someone make a PR or opens an issue.
It list basic information issues should contain.