### PR TITLE
add THEFUCK_HISTORY_LIMIT, my machine is so slow

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,8 @@ Or via environment variables:
 * `THEFUCK_NO_COLORS` &ndash; disable colored output, `true/false`;
 * `THEFUCK_PRIORITY` &ndash; priority of the rules, like `no_command=9999:apt_get=100`,
 rule with lower `priority` will be matched first;
-* `THEFUCK_DEBUG` &ndash; enables debug output, `true/false`.
+* `THEFUCK_DEBUG` &ndash; enables debug output, `true/false`;
+* `THEFUCK_HISTORY_LIMIT` &ndash; how many history commands will be scanned, like `2000`.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ export THEFUCK_REQUIRE_CONFIRMATION='true'
 export THEFUCK_WAIT_COMMAND=10
 export THEFUCK_NO_COLORS='false'
 export THEFUCK_PRIORITY='no_command=9999:apt_get=100'
+export THEFUCK_HISTORY_LIMIT='2000'
 ```
 
 ## Developing

--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -24,7 +24,8 @@ ENV_TO_ATTR = {'THEFUCK_RULES': 'rules',
                'THEFUCK_REQUIRE_CONFIRMATION': 'require_confirmation',
                'THEFUCK_NO_COLORS': 'no_colors',
                'THEFUCK_PRIORITY': 'priority',
-               'THEFUCK_DEBUG': 'debug'}
+               'THEFUCK_DEBUG': 'debug',
+               'THEFUCK_HISTORY_LIMIT': 'history_limit'}
 
 SETTINGS_HEADER = u"""# ~/.thefuck/settings.py: The Fuck settings file
 #
@@ -125,3 +126,4 @@ class Settings(dict):
 
 
 settings = Settings(DEFAULT_SETTINGS)
+settings.init()

--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -16,6 +16,7 @@ DEFAULT_SETTINGS = {'rules': DEFAULT_RULES,
                     'no_colors': False,
                     'debug': False,
                     'priority': {},
+                    'history_limit': None,
                     'env': {'LC_ALL': 'C', 'LANG': 'C', 'GIT_TRACE': '1'}}
 
 ENV_TO_ATTR = {'THEFUCK_RULES': 'rules',
@@ -126,4 +127,3 @@ class Settings(dict):
 
 
 settings = Settings(DEFAULT_SETTINGS)
-settings.init()

--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -114,6 +114,8 @@ class Settings(dict):
             return dict(self._priority_from_env(val))
         elif attr == 'wait_command':
             return int(val)
+        elif attr == 'history_limit':
+            return int(val)
         elif attr in ('require_confirmation', 'no_colors', 'debug'):
             return val.lower() == 'true'
         else:

--- a/thefuck/shells.py
+++ b/thefuck/shells.py
@@ -60,10 +60,10 @@ class Generic(object):
 
     def get_history(self):
         """Returns list of history entries."""
-        tail_num = settings.get("history_limit", None)
+        tail_num = settings.history_limit
         history_file_name = self._get_history_file_name()
         if os.path.isfile(history_file_name):
-            if tail_num is not None:
+            if tail_num is not None and tail_num.isdigit():
                 _, f = os.popen2("tail -n {} {}".format(tail_num, history_file_name))
                 _.close()
             else:

--- a/thefuck/shells.py
+++ b/thefuck/shells.py
@@ -10,6 +10,7 @@ from time import time
 import io
 import os
 from .utils import DEVNULL, memoize, cache
+from .conf import settings
 
 
 class Generic(object):
@@ -59,10 +60,16 @@ class Generic(object):
 
     def get_history(self):
         """Returns list of history entries."""
+        tail_num = settings.get("history_limit", None)
         history_file_name = self._get_history_file_name()
         if os.path.isfile(history_file_name):
-            with io.open(history_file_name, 'r',
-                         encoding='utf-8', errors='ignore') as history:
+            if tail_num is not None:
+                _, f = os.popen2("tail -n {} {}".format(tail_num, history_file_name))
+                _.close()
+            else:
+                f = io.open(history_file_name, 'r',
+                         encoding='utf-8', errors='ignore')
+            with f as history:
                 for line in history:
                     prepared = self._script_from_history(line)\
                                    .strip()


### PR DESCRIPTION
when my history commands is greater than 10000 lines, it will cost me one second to run fuck command. So i wish i can control how many history command the fuck will scan in order to match the closest command.