### PR TITLE
Use --force-with-lease instead of --force for git push

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Enabled by default only on specific platforms:
 
 Bundled, but not enabled by default:
 
-* `git_push_force` &ndash; adds `--force` to a `git push` (may conflict with `git_push_pull`);
+* `git_push_force` &ndash; adds `--force-with-lease` to a `git push` (may conflict with `git_push_pull`);
 * `rm_root` &ndash; adds `--no-preserve-root` to `rm -rf /` command.
 
 ## Creating your own rules

--- a/tests/rules/test_git_push_force.py
+++ b/tests/rules/test_git_push_force.py
@@ -45,8 +45,8 @@ def test_not_match(command):
 
 
 @pytest.mark.parametrize('command, output', [
-    (Command(script='git push', stderr=git_err), 'git push --force'),
-    (Command(script='git push nvbn', stderr=git_err), 'git push --force nvbn'),
-    (Command(script='git push nvbn master', stderr=git_err), 'git push --force nvbn master')])
+    (Command(script='git push', stderr=git_err), 'git push --force-with-lease'),
+    (Command(script='git push nvbn', stderr=git_err), 'git push --force-with-lease nvbn'),
+    (Command(script='git push nvbn master', stderr=git_err), 'git push --force-with-lease nvbn master')])
 def test_get_new_command(command, output):
     assert get_new_command(command) == output

--- a/thefuck/rules/git_push_force.py
+++ b/thefuck/rules/git_push_force.py
@@ -12,7 +12,7 @@ def match(command):
 
 @git_support
 def get_new_command(command):
-    return replace_argument(command.script, 'push', 'push --force')
+    return replace_argument(command.script, 'push', 'push --force-with-lease')
 
 
 enabled_by_default = False


### PR DESCRIPTION
--force flag can be very dangerous, because it unconditionally
overwrites remote branch - if someone pushed new commits to the remote
repo after you last fetched/pulled, and you do push --force, you will
overwrite his commits without even knowing that you did that.  Using
--force-with-lease is much safer because it only overwrites remote
branch when it points to the same commit that you think it points to.

Read more:
https://developer.atlassian.com/blog/2015/04/force-with-lease/