### PR TITLE
Delete NULL bytes from command.script_parts[0]

### DIFF
--- a/thefuck/rules/has_exists_script.py
+++ b/thefuck/rules/has_exists_script.py
@@ -4,7 +4,8 @@ from thefuck.specific.sudo import sudo_support
 
 @sudo_support
 def match(command):
-    return command.script_parts and os.path.exists(command.script_parts[0]) \
+    return command.script_parts and os.path.exists(
+        command.script_parts[0].translate(None, '\x00')) \
         and 'command not found' in command.stderr
 
 


### PR DESCRIPTION
The byte sequence in command.script_parts[0] can contain one or more
'\x00' which will cause os.stat(path) to throw this error:

        TypeError: must be encoded string without NULL bytes, not str