### PR TITLE
sudo sh execute for && in commands - preventing double sudo

### DIFF
--- a/tests/rules/test_sudo.py
+++ b/tests/rules/test_sudo.py
@@ -25,6 +25,7 @@ def test_not_match():
 @pytest.mark.parametrize('before, after', [
     ('ls', 'sudo ls'),
     ('echo a > b', 'sudo sh -c "echo a > b"'),
-    ('echo "a" >> b', 'sudo sh -c "echo \\"a\\" >> b"')])
+    ('echo "a" >> b', 'sudo sh -c "echo \\"a\\" >> b"'),
+    ('mkdir && touch a', 'sudo sh -c "mkdir && touch a"')])
 def test_get_new_command(before, after):
     assert get_new_command(Command(before)) == after

--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -21,7 +21,7 @@ patterns = ['permission denied',
 
 
 def match(command):
-    if command.script_parts and command.script_parts[0] == 'sudo':
+    if command.script_parts and '&&' not in command.script_parts and command.script_parts[0] == 'sudo':
         return False
 
     for pattern in patterns:
@@ -32,7 +32,9 @@ def match(command):
 
 
 def get_new_command(command):
-    if '>' in command.script:
+    if '&&' in command.script:
+        return u'sudo sh -c "{}"'.format(" ".join([part for part in command.script_parts if part != "sudo"]))
+    elif '>' in command.script:
         return u'sudo sh -c "{}"'.format(command.script.replace('"', '\\"'))
     else:
         return u'sudo {}'.format(command.script)


### PR DESCRIPTION
Followed the same procedure in handling this as in handling ```'>' in command.script```
@nvbn This is in reference to #415 