### PR TITLE
#425 command had to be re escaped

### DIFF
--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -110,7 +110,7 @@ def get_all_executables():
 
 def replace_argument(script, from_, to):
     """Replaces command line argument."""
-    replaced_in_the_end = re.sub(u' {}$'.format(from_), u' {}'.format(to),
+    replaced_in_the_end = re.sub(u' {}$'.format(re.escape(from_)), u' {}'.format(to),
                                  script, count=1)
     if replaced_in_the_end != script:
         return replaced_in_the_end


### PR DESCRIPTION
The ```'['``` in the broken command was interpreted as a python-re **special character**
