### PR TITLE
Changed dbm to anydbm for better not-unix support

### DIFF
--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -1,4 +1,4 @@
-import dbm
+import anydbm
 import os
 import pickle
 import pkg_resources
@@ -16,10 +16,10 @@ from warnings import warn
 
 DEVNULL = open(os.devnull, 'w')
 
-shelve_open_errors = (dbm.error, )
-if six.PY2:
-    import gdbm
-    shelve_open_errors += (gdbm.error, )
+shelve_open_errors = (anydbm.error, )
+#if six.PY2:
+#    import gdbm
+#    shelve_open_errors += (gdbm.error, )
 
 
 def memoize(fn):


### PR DESCRIPTION
I changed the dbm import to anydbm to fix the issue on windows. At my computer it is running very well. It have to be testet on Linux and OSX too.
Like it's written in the python docs (https://docs.python.org/2/library/anydbm.html) the anydbm is a generic interface of the dbm database that is supported from the most systems. So I hope that it works well on linux and osx too.
I created a new branch so you can get the changes to test first, if you want. Maybe you could test one of the systems, because I actually haven't the possibilities.

TODO:
- Test on Linux
- Test on OSX