### PR TITLE
Rules: git remote add instead of set-url if remote does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `git_pull_clone` &ndash; clones instead of pulling when the repo does not exist;
 * `git_push` &ndash; adds `--set-upstream origin $branch` to previous failed `git push`;
 * `git_push_pull` &ndash; runs `git pull` when `push` was rejected;
+* `git_remote_seturl_add` &ndash; runs `git remote add` when `git remote set_url` on nonexistant remote;
 * `git_stash` &ndash; stashes you local modifications before rebasing or switching branch;
 * `git_two_dashes` &ndash; adds a missing dash to commands like `git commit -amend` or `git rebase -continue`;
 * `go_run` &ndash; appends `.go` extension when compiling/running Go programs;

--- a/tests/rules/test_git_remote_seturl_add.py
+++ b/tests/rules/test_git_remote_seturl_add.py
@@ -1,0 +1,26 @@
+import pytest
+from thefuck.rules.git_remote_seturl_add import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.mark.parametrize('command', [
+    Command(script='git remote set-url origin url', stderr="fatal: No such remote")])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command', [
+    Command('git remote set-url origin url', stderr=""),
+    Command('git remote add origin url'),
+    Command('git remote remove origin'),
+    Command('git remote prune origin'),
+    Command('git remote set-branches origin branch')
+    ])
+def test_not_match(command):
+    assert not match(command)
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('git remote set-url origin git@github.com:nvbn/thefuck.git'),
+     'git remote add origin git@github.com:nvbn/thefuck.git')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/git_remote_seturl_add.py
+++ b/thefuck/rules/git_remote_seturl_add.py
@@ -1,0 +1,14 @@
+from thefuck.utils import replace_argument
+from thefuck.specific.git import git_support
+
+
+@git_support
+def match(command):
+    return ('set-url' in command.script and 'fatal: No such remote' in command.stderr)
+
+
+def get_new_command(command):
+    return replace_argument(command.script, 'set-url', 'add')
+
+
+enabled_by_default = True


### PR DESCRIPTION
<img width="599" alt="screen shot 2016-03-04 at 13 49 37" src="https://cloud.githubusercontent.com/assets/1821404/13527542/fa54d4bc-e20f-11e5-8f80-1d082e6aa331.png">
