### PR TITLE
#439 & #447: Remove cache if created with unavailable db

### DIFF
--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -228,8 +228,8 @@ def cache(*depends_on):
                     value = fn(*args, **kwargs)
                     db[key] = {'etag': etag, 'value': value}
                     return value
-        except shelve_open_error:
-            # Caused when going from Python 2 to Python 3 and vice-versa
+        except (shelve_open_error, ImportError):
+            # Caused when switching between Python versions
             warn("Removing possibly out-dated cache")
             os.remove(cache_path)
 


### PR DESCRIPTION
When switching from/to a virtualenv, the database package used to create the cache might be unavailable and an ImportError is raised, such as `ImportError: No module named gdbm`.