### PR TITLE
#N/A: Add new `git_rm_recursive` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `git_pull_clone` &ndash; clones instead of pulling when the repo does not exist;
 * `git_push` &ndash; adds `--set-upstream origin $branch` to previous failed `git push`;
 * `git_push_pull` &ndash; runs `git pull` when `push` was rejected;
+* `git_rm_recursive` &ndash; adds `-r` when you try to `rm` a directory;
 * `git_remote_seturl_add` &ndash; runs `git remote add` when `git remote set_url` on nonexistant remote;
 * `git_stash` &ndash; stashes you local modifications before rebasing or switching branch;
 * `git_two_dashes` &ndash; adds a missing dash to commands like `git commit -amend` or `git rebase -continue`;

--- a/tests/rules/test_git_rm_recursive.py
+++ b/tests/rules/test_git_rm_recursive.py
@@ -1,0 +1,27 @@
+import pytest
+from thefuck.rules.git_rm_recursive import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.fixture
+def stderr(target):
+    return "fatal: not removing '{}' recursively without -r".format(target)
+
+
+@pytest.mark.parametrize('script, target', [
+    ('git rm foo', 'foo'),
+    ('git rm foo bar', 'foo bar')])
+def test_match(stderr, script, target):
+    assert match(Command(script=script, stderr=stderr))
+
+
+@pytest.mark.parametrize('script', ['git rm foo', 'git rm foo bar'])
+def test_not_match(script):
+    assert not match(Command(script=script, stderr=''))
+
+
+@pytest.mark.parametrize('script, target, new_command', [
+    ('git rm foo', 'foo', 'git rm -r foo'),
+    ('git rm foo bar', 'foo bar', 'git rm -r foo bar')])
+def test_get_new_command(stderr, script, target, new_command):
+    assert get_new_command(Command(script=script, stderr=stderr)) == new_command

--- a/thefuck/rules/git_rm_recursive.py
+++ b/thefuck/rules/git_rm_recursive.py
@@ -1,0 +1,15 @@
+from thefuck.specific.git import git_support
+
+
+@git_support
+def match(command):
+    return (' rm ' in command.script
+            and "fatal: not removing '" in command.stderr
+            and "' recursively without -r" in command.stderr)
+
+
+@git_support
+def get_new_command(command):
+    index = command.script_parts.index('rm') + 1
+    command.script_parts.insert(index, '-r')
+    return u' '.join(command.script_parts)


### PR DESCRIPTION
```bash
$ git rm thefuck
fatal: not removing 'thefuck' recursively without -r
$ fuck
git rm -r thefuck [enter/↑/↓/ctrl+c]
Aborted
```