### PR TITLE
Add Powershell as shell

### DIFF
--- a/tests/shells/test_powershell.py
+++ b/tests/shells/test_powershell.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from thefuck.shells import Powershell
+
+
+@pytest.mark.usefixtures('isfile', 'no_memoize', 'no_cache')
+class TestPowershell(object):
+    @pytest.fixture
+    def shell(self):
+        return Powershell()
+
+    def test_and_(self, shell):
+        assert shell.and_('ls', 'cd') == '(ls) -and (cd)'
+
+    def test_app_alias(self, shell):
+        assert 'function fuck' in shell.app_alias('fuck')
+        assert 'function FUCK' in shell.app_alias('FUCK')
+        assert 'thefuck' in shell.app_alias('fuck')

--- a/thefuck/shells/__init__.py
+++ b/thefuck/shells/__init__.py
@@ -9,12 +9,14 @@ from .fish import Fish
 from .generic import Generic
 from .tcsh import Tcsh
 from .zsh import Zsh
+from .powershell import Powershell
 
 shells = {'bash': Bash,
           'fish': Fish,
           'zsh': Zsh,
           'csh': Tcsh,
-          'tcsh': Tcsh}
+          'tcsh': Tcsh,
+          'powershell': Powershell}
 
 
 def _get_shell():

--- a/thefuck/shells/__init__.py
+++ b/thefuck/shells/__init__.py
@@ -18,11 +18,26 @@ shells = {'bash': Bash,
 
 
 def _get_shell():
-    try:
-        shell_name = Process(os.getpid()).parent().name()
-    except TypeError:
-        shell_name = Process(os.getpid()).parent.name
-    return shells.get(shell_name, Generic)()
+    proc = Process(os.getpid())
+
+    while (proc is not None):
+        name = None
+        try:
+            name = proc.name()
+        except TypeError:
+            name = proc.name
+
+        name = os.path.splitext(name)[0]
+
+        if name in shells:
+            return shells[name]()
+
+        try:
+            proc = proc.parent()
+        except TypeError:
+            proc = proc.parent
+
+    return Generic()
 
 
 shell = _get_shell()

--- a/thefuck/shells/powershell.py
+++ b/thefuck/shells/powershell.py
@@ -1,0 +1,18 @@
+from .generic import Generic
+
+
+class Powershell(Generic):
+    def app_alias(self, fuck):
+        return 'function ' + fuck + ' { \n' \
+               '    $fuck = $(thefuck (Get-History -Count 1).CommandLine)\n' \
+               '    if (-not [string]::IsNullOrWhiteSpace($fuck)) {\n' \
+               '        if ($fuck.StartsWith("echo")) { $fuck = $fuck.Substring(5) }\n' \
+               '        else { iex "$fuck" }\n' \
+               '    }\n' \
+               '}\n'
+
+    def and_(self, *commands):
+        return u' -and '.join('({0})'.format(c) for c in commands)
+
+    def how_to_configure(self):
+        return 'iex "thefuck --alias"', '$profile'

--- a/thefuck/system/win32.py
+++ b/thefuck/system/win32.py
@@ -16,7 +16,7 @@ def get_key():
         ch = msvcrt.getch()  # second call returns the actual key code
 
     if ch == b'\x03':
-        raise const.KEY_CTRL_C
+        return const.KEY_CTRL_C
     if ch == b'H':
         return const.KEY_UP
     if ch == b'P':


### PR DESCRIPTION
- Add Powershell as a supported shell
  - There may be additional functionality to implement, but I've been
    running this way for a month with no known issues
- Update _get_shell to work with Windows
  - _get_shell assumed the parent process would always be the shell
    process, in Powershell the parent process is Python, with the
    grandparent being the shell
  - Switched to walking the process tree so the same code path can be used
    in both places
- Change Ctrl+C on Windows to match Unix