### PR TITLE
Update install procedure for pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ wget -O - https://raw.githubusercontent.com/nvbn/thefuck/master/install.sh | sh 
 Install `The Fuck` with `pip`:
 
 ```bash
-sudo pip install thefuck
+sudo -H pip install thefuck
 ```
 
 [Or using an OS package manager (OS X, Ubuntu, Arch).](https://github.com/nvbn/thefuck/wiki/Installation)


### PR DESCRIPTION
Avoid the warning:

    The directory '/home/someuser/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.