### PR TITLE
#484: Use PIPE as stdin when Popening the script

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -110,6 +110,7 @@ class TestCommand(object):
             'apt-get search vim', 'stdout', 'stderr')
         Popen.assert_called_once_with('apt-get search vim',
                                       shell=True,
+                                      stdin=PIPE,
                                       stdout=PIPE,
                                       stderr=PIPE,
                                       env={})

--- a/thefuck/types.py
+++ b/thefuck/types.py
@@ -114,7 +114,7 @@ class Command(object):
         env.update(settings.env)
 
         with logs.debug_time(u'Call: {}; with env: {};'.format(script, env)):
-            result = Popen(script, shell=True, stdout=PIPE, stderr=PIPE, env=env)
+            result = Popen(script, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=env)
             if cls._wait_output(result):
                 stdout = result.stdout.read().decode('utf-8')
                 stderr = result.stderr.read().decode('utf-8')


### PR DESCRIPTION
Fix #484