### PR TITLE
#486: Use alternative encoding when sys.stdout.encoding is None

### DIFF
--- a/thefuck/system/win32.py
+++ b/thefuck/system/win32.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import msvcrt
 import win_unicode_console
@@ -22,4 +23,5 @@ def get_key():
     if ch == b'P':
         return const.KEY_DOWN
 
-    return ch.decode(sys.stdout.encoding)
+    encoding = sys.stdout.encoding or os.environ.get('PYTHONIOENCODING', 'utf-8')
+    return ch.decode(encoding)


### PR DESCRIPTION
Fix #486