### PR TITLE
#493: Add `put_to_history` back to Fish

### DIFF
--- a/tests/shells/test_fish.py
+++ b/tests/shells/test_fish.py
@@ -78,3 +78,12 @@ class TestFish(object):
         history_lines(['- cmd: ls', '  when: 1432613911',
                        '- cmd: rm', '  when: 1432613916'])
         assert list(shell.get_history()) == ['ls', 'rm']
+
+    @pytest.mark.parametrize('entry, entry_utf8', [
+        ('ls', '- cmd: ls\n   when: 1430707243\n'),
+        (u'echo café', '- cmd: echo café\n   when: 1430707243\n')])
+    def test_put_to_history(self, entry, entry_utf8, builtins_open, mocker, shell):
+        mocker.patch('thefuck.shells.fish.time', return_value=1430707243.3517463)
+        shell.put_to_history(entry)
+        builtins_open.return_value.__enter__.return_value. \
+            write.assert_called_once_with(entry_utf8)

--- a/thefuck/shells/generic.py
+++ b/thefuck/shells/generic.py
@@ -81,3 +81,6 @@ class Generic(object):
 
     def _script_from_history(self, line):
         return line
+
+    def put_to_history(self, command):
+        pass

--- a/thefuck/types.py
+++ b/thefuck/types.py
@@ -280,6 +280,8 @@ class CorrectedCommand(object):
         """
         if self.side_effect:
             compatibility_call(self.side_effect, old_cmd, self.script)
+        if settings.alter_history:
+            shell.put_to_history(self.script)
         # This depends on correct setting of PYTHONIOENCODING by the alias:
         logs.debug(u'PYTHONIOENCODING: {}'.format(
             os.environ.get('PYTHONIOENCODING', '!!not-set!!')))


### PR DESCRIPTION
Fish Shell does not support appending to history yet

Fix #493