### PR TITLE
Switch from pathlib to pathlib2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ elif (3, 0) < version < (3, 3):
 VERSION = '3.9'
 
 install_requires = ['psutil', 'colorama', 'six', 'decorator']
-extras_require = {':python_version<"3.4"': ['pathlib'],
+extras_require = {':python_version<"3.4"': ['pathlib2'],
                   ":sys_platform=='win32'": ['win_unicode_console']}
 
 setup(name='thefuck',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 import pytest
 from thefuck import shells
 from thefuck import conf, const

--- a/tests/test_corrector.py
+++ b/tests/test_corrector.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from pathlib import Path
+try:
+    from pathlib import Path
+    pathlib_name = 'pathlib'
+except ImportError:
+    from pathlib2 import Path
+    pathlib_name = 'pathlib2'
 from thefuck import corrector, const
 from tests.utils import Rule, Command, CorrectedCommand
 from thefuck.corrector import get_corrected_commands, organize_commands
@@ -11,7 +16,7 @@ class TestGetRules(object):
     @pytest.fixture
     def glob(self, mocker):
         results = {}
-        mocker.patch('pathlib.Path.glob',
+        mocker.patch(pathlib_name + '.Path.glob',
                      new_callable=lambda: lambda *_: results.pop('value', []))
         return lambda value: results.update({'value': value})
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,7 +3,10 @@
 import os
 from subprocess import PIPE
 from mock import Mock
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 import pytest
 from tests.utils import CorrectedCommand, Rule, Command
 from thefuck import const

--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -1,7 +1,10 @@
 from imp import load_source
 import os
 import sys
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 from six import text_type
 from . import const
 

--- a/thefuck/corrector.py
+++ b/thefuck/corrector.py
@@ -1,4 +1,7 @@
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 from .conf import settings
 from .types import Rule
 from . import logs

--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -10,7 +10,10 @@ from decorator import decorator
 from difflib import get_close_matches
 from functools import wraps
 from inspect import getargspec
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 from warnings import warn
 
 DEVNULL = open(os.devnull, 'w')


### PR DESCRIPTION
The pathlib backport module is no longer maintained. The development
has moved to the pathlib2 module instead.

Quoting from the pathlib's README:
"Attention: this backport module isn't maintained anymore. If you want
to report issues or contribute patches, please consider the pathlib2
project instead."