### PR TITLE
Add a new rule `git_rebase_no_changes`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `git_pull_clone` &ndash; clones instead of pulling when the repo does not exist;
 * `git_push` &ndash; adds `--set-upstream origin $branch` to previous failed `git push`;
 * `git_push_pull` &ndash; runs `git pull` when `push` was rejected;
+* `git_rebase_no_changes` &ndash runs `git rebase --skip` instead of `git rebase --continue` when there are no changes;
 * `git_rm_recursive` &ndash; adds `-r` when you try to `rm` a directory;
 * `git_remote_seturl_add` &ndash; runs `git remote add` when `git remote set_url` on nonexistant remote;
 * `git_stash` &ndash; stashes you local modifications before rebasing or switching branch;

--- a/tests/rules/test_git_rebase_no_changes.py
+++ b/tests/rules/test_git_rebase_no_changes.py
@@ -1,0 +1,28 @@
+import pytest
+from thefuck.rules.git_rebase_no_changes import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.fixture
+def stdout():
+    return '''Applying: Test commit
+No changes - did you forget to use 'git add'?
+If there is nothing left to stage, chances are that something else
+already introduced the same changes; you might want to skip this patch.
+
+When you have resolved this problem, run "git rebase --continue".
+If you prefer to skip this patch, run "git rebase --skip" instead.
+To check out the original branch and stop rebasing, run "git rebase --abort".
+
+'''
+
+
+def test_match(stdout):
+    assert match(Command('git rebase --continue', stdout=stdout))
+    assert not match(Command('git rebase --continue'))
+    assert not match(Command('git rebase --skip'))
+
+
+def test_get_new_command(stdout):
+    assert (get_new_command(Command('git rebase --continue', stdout=stdout)) ==
+            'git rebase --skip')

--- a/thefuck/rules/git_rebase_no_changes.py
+++ b/thefuck/rules/git_rebase_no_changes.py
@@ -1,0 +1,15 @@
+from thefuck.specific.git import git_support
+
+
+#@git_support
+def match(command):
+    return (command.script == 'git rebase --continue' and
+            'No changes - did you forget to use \'git add\'?' in command.stdout)
+
+
+def get_new_command(command):
+    return 'git rebase --skip'
+
+
+enabled_by_default = True
+requires_output = True


### PR DESCRIPTION
This rule fixes the case where you've run "git rebase --continue", as instructed by "git status", only to be rejected because there are no changes in the commit. The fix is rote; you run "git rebase --skip" instead of "git rebase --continue".