### PR TITLE
#N/A: Update cargo_no_command rule to support current Cargo

### DIFF
--- a/tests/rules/test_cargo_no_command.py
+++ b/tests/rules/test_cargo_no_command.py
@@ -3,19 +3,26 @@ from thefuck.rules.cargo_no_command import match, get_new_command
 from tests.utils import Command
 
 
-no_such_subcommand = """No such subcommand
+no_such_subcommand_old = """No such subcommand
 
         Did you mean `build`?
 """
 
+no_such_subcommand = """error: no such subcommand
+
+\tDid you mean `build`?
+"""
+
 
 @pytest.mark.parametrize('command', [
-    Command(script='cargo buid', stderr=no_such_subcommand)])
+    Command(script='cargo buid', stderr=no_such_subcommand_old),
+    Command(script='cargo buils', stderr=no_such_subcommand)])
 def test_match(command):
     assert match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
-    (Command('cargo buid', stderr=no_such_subcommand), 'cargo build')])
+    (Command('cargo buid', stderr=no_such_subcommand_old), 'cargo build'),
+    (Command('cargo buils', stderr=no_such_subcommand), 'cargo build')])
 def test_get_new_command(command, new_command):
     assert get_new_command(command) == new_command

--- a/thefuck/rules/cargo_no_command.py
+++ b/thefuck/rules/cargo_no_command.py
@@ -4,7 +4,7 @@ from thefuck.utils import replace_argument, for_app
 
 @for_app('cargo', at_least=1)
 def match(command):
-    return ('No such subcommand' in command.stderr
+    return ('o such subcommand' in command.stderr
             and 'Did you mean' in command.stderr)
 
 


### PR DESCRIPTION
Since [0.7.0](https://github.com/rust-lang/cargo/commit/20b768e6ba214c469c9972b36de9cf122f45f28c#diff-847cd20bb1f94e626f11c2eb7358f4beL185), Cargo outputs `no such subcommand` instead of `No such subcommand`.