### PR TITLE
ui: accept 'q' as quit character

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -25,15 +25,16 @@ def test_read_actions(patch_get_key):
         # Ignored:
         'x', 'y',
         # Up:
-        const.KEY_UP,
+        const.KEY_UP, 'k',
         # Down:
-        const.KEY_DOWN,
+        const.KEY_DOWN, 'j',
         # Ctrl+C:
-        const.KEY_CTRL_C])
-    assert list(islice(ui.read_actions(), 5)) \
+        const.KEY_CTRL_C, 'q'])
+    assert list(islice(ui.read_actions(), 8)) \
            == [const.ACTION_SELECT, const.ACTION_SELECT,
-               const.ACTION_PREVIOUS, const.ACTION_NEXT,
-               const.ACTION_ABORT]
+               const.ACTION_PREVIOUS, const.ACTION_PREVIOUS,
+               const.ACTION_NEXT, const.ACTION_NEXT,
+               const.ACTION_ABORT, const.ACTION_ABORT]
 
 
 def test_command_selector():

--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -16,7 +16,7 @@ def read_actions():
             yield const.ACTION_PREVIOUS
         elif key in (const.KEY_DOWN, 'j'):
             yield const.ACTION_NEXT
-        elif key == const.KEY_CTRL_C:
+        elif key in (const.KEY_CTRL_C, 'q'):
             yield const.ACTION_ABORT
         elif key in ('\n', '\r'):
             yield const.ACTION_SELECT


### PR DESCRIPTION
'q' is a standard character used in traditional UNIX environment used for 'quit', so it makes sense to support it, in my opinion

Added tests and ammended the previous commit, added missing tests for 'j' and 'k'