### PR TITLE
Add semi-colons in powershell alias

### DIFF
--- a/thefuck/shells/powershell.py
+++ b/thefuck/shells/powershell.py
@@ -4,10 +4,10 @@ from .generic import Generic
 class Powershell(Generic):
     def app_alias(self, fuck):
         return 'function ' + fuck + ' { \n' \
-               '    $fuck = $(thefuck (Get-History -Count 1).CommandLine)\n' \
+               '    $fuck = $(thefuck (Get-History -Count 1).CommandLine);\n' \
                '    if (-not [string]::IsNullOrWhiteSpace($fuck)) {\n' \
-               '        if ($fuck.StartsWith("echo")) { $fuck = $fuck.Substring(5) }\n' \
-               '        else { iex "$fuck" }\n' \
+               '        if ($fuck.StartsWith("echo")) { $fuck = $fuck.Substring(5); }\n' \
+               '        else { iex "$fuck"; }\n' \
                '    }\n' \
                '}\n'
 


### PR DESCRIPTION
Add semi-colons in powershell alias so that if line breaks get lost the function can still be invoked directly. This makes it possible to add thefuck to the current session by running

```powershell
iex "$(thefuck --alias)"
```

which mirrors the eval syntax in bash