### PR TITLE
Avoid importing pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
-import pip
+import pkg_resources
 import sys
 import os
 
-if int(pip.__version__.split('.')[0]) < 6:
+if int(pkg_resources.get_distribution("pip").version.split('.')[0]) < 6:
     print('pip older than 6.0 not supported, please upgrade pip with:\n\n'
           '    pip install -U pip')
     sys.exit(-1)

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,13 @@ import pkg_resources
 import sys
 import os
 
-if int(pkg_resources.get_distribution("pip").version.split('.')[0]) < 6:
-    print('pip older than 6.0 not supported, please upgrade pip with:\n\n'
-          '    pip install -U pip')
-    sys.exit(-1)
+try:
+    if int(pkg_resources.get_distribution("pip").version.split('.')[0]) < 6:
+        print('pip older than 6.0 not supported, please upgrade pip with:\n\n'
+              '    pip install -U pip')
+        sys.exit(-1)
+except pkg_resources.DistributionNotFound:
+    pass
 
 if os.environ.get('CONVERT_README'):
     import pypandoc


### PR DESCRIPTION
Pip doesn't have a stable Python API and shouldn't be `import`ed, and may not be used to install this package at all.