### PR TITLE
Add `brew update` to Homebrew commands

### DIFF
--- a/thefuck/rules/brew_unknown_command.py
+++ b/thefuck/rules/brew_unknown_command.py
@@ -15,7 +15,7 @@ def _get_brew_commands(brew_path_prefix):
     brew_cmd_path = brew_path_prefix + BREW_CMD_PATH
 
     return [name[:-3] for name in os.listdir(brew_cmd_path)
-            if name.endswith('.rb')]
+            if name.endswith(('.rb', '.sh'))]
 
 
 def _get_brew_tap_specific_commands(brew_path_prefix):


### PR DESCRIPTION
`brew update` is implemented in shell instead of ruby, so
`_get_brew_commands` needs to list .sh files as well as .rb

Resolves https://github.com/nvbn/thefuck/issues/526