### PR TITLE
Added "contains work" error for git push

### DIFF
--- a/tests/rules/test_git_push_pull.py
+++ b/tests/rules/test_git_push_pull.py
@@ -13,6 +13,17 @@ To /tmp/foo
  hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 '''
 
+git_err2 = '''
+To /tmp/foo
+ ! [rejected]        master -> master (non-fast-forward)
+ error: failed to push some refs to '/tmp/bar'
+hint: Updates were rejected because the remote contains work that you do
+hint: not have locally. This is usually caused by another repository pushing
+hint: to the same ref. You may want to first integrate the remote changes
+hint: (e.g., 'git pull ...') before pushing again.
+hint: See the 'Note about fast-forwards' in 'git push --help' for details.
+'''
+
 git_uptodate = 'Everything up-to-date'
 git_ok = '''
 Counting objects: 3, done.
@@ -34,6 +45,14 @@ def test_match(command):
 
 
 @pytest.mark.parametrize('command', [
+    Command(script='git push', stderr=git_err2),
+    Command(script='git push nvbn', stderr=git_err2),
+    Command(script='git push nvbn master', stderr=git_err2)])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command', [
     Command(script='git push', stderr=git_ok),
     Command(script='git push', stderr=git_uptodate),
     Command(script='git push nvbn', stderr=git_ok),
@@ -49,6 +68,16 @@ def test_not_match(command):
     (Command(script='git push nvbn', stderr=git_err),
      'git pull nvbn && git push nvbn'),
     (Command(script='git push nvbn master', stderr=git_err),
+     'git pull nvbn master && git push nvbn master')])
+def test_get_new_command(command, output):
+    assert get_new_command(command) == output
+
+
+@pytest.mark.parametrize('command, output', [
+    (Command(script='git push', stderr=git_err2), 'git pull && git push'),
+    (Command(script='git push nvbn', stderr=git_err2),
+     'git pull nvbn && git push nvbn'),
+    (Command(script='git push nvbn master', stderr=git_err2),
      'git pull nvbn master && git push nvbn master')])
 def test_get_new_command(command, output):
     assert get_new_command(command) == output

--- a/thefuck/rules/git_push_pull.py
+++ b/thefuck/rules/git_push_pull.py
@@ -8,7 +8,7 @@ def match(command):
     return ('push' in command.script
             and '! [rejected]' in command.stderr
             and 'failed to push some refs to' in command.stderr
-            and 'Updates were rejected because the tip of your current branch is behind' in command.stderr)
+            and (('Updates were rejected because the tip of your current branch is behind' in command.stderr) or 'Updates were rejected because the remote contains work that you do' in command.stderr))
 
 
 @git_support


### PR DESCRIPTION
I'm not 100% sure what the difference between "because the tip of your current branch is behind" and "because the remote contains work that you do not have locally" is, but since git pull seems to be a valid solution for both, I added it to the rule.