### PR TITLE
#N/A: Use git_branch_exists rule with `checkout` too

### DIFF
--- a/tests/rules/test_git_branch_exists.py
+++ b/tests/rules/test_git_branch_exists.py
@@ -12,22 +12,23 @@ def stderr(branch_name):
 def new_command(branch_name):
     return [cmd.format(branch_name) for cmd in [
         'git branch -d {0} && git branch {0}',
-        'git branch -D {0} && git branch {0}', 'git checkout {0}']]
+        'git branch -d {0} && git checkout -b {0}',
+        'git branch -D {0} && git branch {0}',
+        'git branch -D {0} && git checkout -b {0}', 'git checkout {0}']]
 
 
 @pytest.mark.parametrize('script, branch_name', [
-    ('git branch foo', 'foo'),
-    ('git branch bar', 'bar')])
+    ('git branch foo', 'foo'), ('git checkout bar', 'bar')])
 def test_match(stderr, script, branch_name):
     assert match(Command(script=script, stderr=stderr))
 
 
-@pytest.mark.parametrize('script', ['git branch foo', 'git branch bar'])
+@pytest.mark.parametrize('script', ['git branch foo', 'git checkout bar'])
 def test_not_match(script):
     assert not match(Command(script=script, stderr=''))
 
 
 @pytest.mark.parametrize('script, branch_name, ', [
-    ('git branch foo', 'foo'), ('git branch bar', 'bar')])
+    ('git branch foo', 'foo'), ('git checkout bar', 'bar')])
 def test_get_new_command(stderr, new_command, script, branch_name):
     assert get_new_command(Command(script=script, stderr=stderr)) == new_command

--- a/thefuck/rules/git_branch_exists.py
+++ b/thefuck/rules/git_branch_exists.py
@@ -6,8 +6,7 @@ from thefuck.utils import eager
 
 @git_support
 def match(command):
-    return ('branch' in command.script
-            and "fatal: A branch named '" in command.stderr
+    return ("fatal: A branch named '" in command.stderr
             and " already exists." in command.stderr)
 
 
@@ -17,7 +16,9 @@ def get_new_command(command):
     branch_name = re.findall(
         r"fatal: A branch named '([^']*)' already exists.", command.stderr)[0]
     new_command_templates = [['git branch -d {0}', 'git branch {0}'],
+                             ['git branch -d {0}', 'git checkout -b {0}'],
                              ['git branch -D {0}', 'git branch {0}'],
+                             ['git branch -D {0}', 'git checkout -b {0}'],
                              ['git checkout {0}']]
     for new_command_template in new_command_templates:
         yield shell.and_(*new_command_template).format(branch_name)


### PR DESCRIPTION
What it solves and how: ![git-branch-exists](https://cloud.githubusercontent.com/assets/2112697/17033009/6dc14e80-4f52-11e6-9d5a-d8310d392409.png)

Please review and comment.