### PR TITLE
Preserve args for git_push

### DIFF
--- a/tests/rules/test_git_push.py
+++ b/tests/rules/test_git_push.py
@@ -14,6 +14,7 @@ To push the current branch and set the remote as upstream, use
 
 
 def test_match(stderr):
+    assert match(Command('git push', stderr=stderr))
     assert match(Command('git push master', stderr=stderr))
     assert not match(Command('git push master'))
     assert not match(Command('ls', stderr=stderr))

--- a/tests/rules/test_git_push.py
+++ b/tests/rules/test_git_push.py
@@ -23,3 +23,5 @@ def test_match(stderr):
 def test_get_new_command(stderr):
     assert get_new_command(Command('git push', stderr=stderr))\
         == "git push --set-upstream origin master"
+    assert get_new_command(Command('git push --quiet', stderr=stderr))\
+        == "git push --set-upstream origin master --quiet"

--- a/thefuck/rules/git_push.py
+++ b/thefuck/rules/git_push.py
@@ -1,3 +1,4 @@
+from thefuck.utils import replace_argument
 from thefuck.specific.git import git_support
 
 
@@ -9,4 +10,5 @@ def match(command):
 
 @git_support
 def get_new_command(command):
-    return command.stderr.split('\n')[-3].strip()
+    push_upstream = command.stderr.split('\n')[-3].strip().partition('git ')[2]
+    return replace_argument(command.script, 'push', push_upstream)


### PR DESCRIPTION
Fixes #537 

Preserves `git push` arguments when adding upstream.

Previous behaviour:

```
$ git push --quiet
fatal: The current branch new-branch has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin new-branch

$ fuck
git push --set-upstream origin new-branch [enter/↑/↓/ctrl+c]
```

New behaviour:

```
$ git push --quiet
fatal: The current branch new-branch has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin new-branch

$ fuck
git push --set-upstream origin new-branch --quiet [enter/↑/↓/ctrl+c]
```