### PR TITLE
prevent infinity loop while detecting shell

### DIFF
--- a/thefuck/shells/__init__.py
+++ b/thefuck/shells/__init__.py
@@ -22,7 +22,7 @@ shells = {'bash': Bash,
 def _get_shell():
     proc = Process(os.getpid())
 
-    while proc is not None:
+    while proc is not None and proc.pid > 0:
         try:
             name = proc.name()
         except TypeError:


### PR DESCRIPTION
In OS X, Process(pid=0).parent() == Process(pid=0)