### PR TITLE
add aliases rule that resolves aliases

### DIFF
--- a/thefuck/rules/aliases.py
+++ b/thefuck/rules/aliases.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python2
+import subprocess
+import re
+from thefuck.corrector import get_corrected_command
+
+
+enabled_by_default = True
+priority = 100000
+
+
+def list_aliases():
+
+    aliases_list = subprocess.check_output(["bash", "-li", "-c", "alias"]).strip().split('\n')
+    p = re.compile(r'^alias ')
+    aliases_list = {re.sub(p, '', a).split("=")[0]: re.sub(p, '', a).split("=")[1] for a in aliases_list}
+    return aliases_list
+
+
+def match(command):
+
+    return command in list_aliases()
+
+
+def get_new_command(command):
+    command = list_aliases()[command]
+    return get_corrected_command(command)
+
+
+if __name__ == "__main__":
+
+    command = "gs"
+
+    m = match(command)
+    print(m)
+    if m:
+        print(get_new_command(command))
+


### PR DESCRIPTION
This aims to add a rule that resolves shell aliases and replaces them with the full version and then runs thefuck on that with the already supplied outputs.
(i.e. replaces the alias in command.script with the full version.)

I am not sure how to test this further. Could you please give me  a hand?
I am currently not able to call the `get_corrected_command` function

TODO:
- import the needed function(s) correctly
- not hardcode the bash shell: use $SHELL or run command in the already open shell(?)
- write test (as of writing a lot of the tests seem to fail, is this correct?)
