### PR TITLE
Custom rule: Remove trailing cedillas

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `python_execute` &ndash; appends missing `.py` when executing Python files;
 * `quotation_marks` &ndash; fixes uneven usage of `'` and `"` when containing args';
 * `react_native_command_unrecognized` &ndash; fixes unrecognized `react-native` commands;
+* `remove_trailing_cedilla` &ndash; remove trailling cedillas `ç`, a common typo for european keyboard layouts;
 * `rm_dir` &ndash; adds `-rf` when you trying to remove directory;
 * `sed_unterminated_s` &ndash; adds missing '/' to `sed`'s `s` commands;
 * `sl_ls` &ndash; changes `sl` to `ls`;
@@ -231,7 +232,6 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `vagrant_up` &ndash; starts up the vagrant instance;
 * `whois` &ndash; fixes `whois` command;
 * `workon_doesnt_exists` &ndash; fixes `virtualenvwrapper` env name os suggests to create new.
-* `remove_trailing_cedilla` &ndash; remove trailling cedillas `ç`, a common typo for european keyboard layouts;
 
 Enabled by default only on specific platforms:
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `vagrant_up` &ndash; starts up the vagrant instance;
 * `whois` &ndash; fixes `whois` command;
 * `workon_doesnt_exists` &ndash; fixes `virtualenvwrapper` env name os suggests to create new.
+* `remove_trailing_cedilla` &ndash; remove trailling cedillas `ç`, a common typo for european keyboard layouts;
 
 Enabled by default only on specific platforms:
 

--- a/tests/rules/test_remove_trailing_cedilla.py
+++ b/tests/rules/test_remove_trailing_cedilla.py
@@ -1,18 +1,15 @@
-# -*- coding: utf-8 -*-
-
 import pytest
-from thefuck.rules.remove_trailing_cedilla import match, get_new_command
+from thefuck.rules.remove_trailing_cedilla import match, get_new_command, CEDILLA
 from tests.utils import Command
 
 @pytest.mark.parametrize('command', [
-    Command(script='wrongç'),
-    Command(script='wrong with argsç')])
-
+    Command(script='wrong' + CEDILLA),
+    Command(script='wrong with args' + CEDILLA)])
 def test_match(command):
     assert match(command)
 
 @pytest.mark.parametrize('command, new_command', [
-    (Command('wrongç'), 'wrong'),
-    (Command('wrong with argsç'), 'wrong with args')])
+    (Command('wrong' + CEDILLA), 'wrong'),
+    (Command('wrong with args' + CEDILLA), 'wrong with args')])
 def test_get_new_command(command, new_command):
     assert get_new_command(command) == new_command

--- a/tests/rules/test_remove_trailing_cedilla.py
+++ b/tests/rules/test_remove_trailing_cedilla.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 from thefuck.rules.remove_trailing_cedilla import match, get_new_command
 from tests.utils import Command

--- a/tests/rules/test_remove_trailing_cedilla.py
+++ b/tests/rules/test_remove_trailing_cedilla.py
@@ -1,0 +1,16 @@
+import pytest
+from thefuck.rules.remove_trailing_cedilla import match, get_new_command
+from tests.utils import Command
+
+@pytest.mark.parametrize('command', [
+    Command(script='wrongç'),
+    Command(script='wrong with argsç')])
+
+def test_match(command):
+    assert match(command)
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('wrongç'), 'wrong'),
+    (Command('wrong with argsç'), 'wrong with args')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/remove_trailing_cedilla.py
+++ b/thefuck/rules/remove_trailing_cedilla.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 def match(command):
     return command.script.endswith('ç')
 

--- a/thefuck/rules/remove_trailing_cedilla.py
+++ b/thefuck/rules/remove_trailing_cedilla.py
@@ -1,8 +1,9 @@
-# -*- coding: utf-8 -*-
+# encoding=utf8
+
+CEDILLA = u"ç"
 
 def match(command):
-    return command.script.endswith('ç')
+    return command.script.endswith(CEDILLA)
 
 def get_new_command(command):
     return command.script[:-1]
-

--- a/thefuck/rules/remove_trailing_cedilla.py
+++ b/thefuck/rules/remove_trailing_cedilla.py
@@ -1,0 +1,6 @@
+def match(command):
+    return command.script.endswith('ç')
+
+def get_new_command(command):
+    return command.script[:-1]
+


### PR DESCRIPTION
### Summary

Many programmers use european keyboards, like this one:

![BÉPO Keyboard Layout](http://xahlee.info/kbd/i/layout/bepo_keyboard_layout.png)

Some users (like me), have some fat-brute-fingers, and, when pressing the `enter` key, we also press that tedious `ç` key. I've created this new rule to fix those typos.

### Features
- [x] Create a new rule to match those cases, and fix them.
- [x] Create a new test.

### Questions

- Should the priority be changed to a lower value?

### References
- [Cedilla in Wikipedia](https://en.wikipedia.org/wiki/Cedilla)
- [Keyboard layouts in Wikipedia](https://en.wikipedia.org/wiki/Keyboard_layout)