### PR TITLE
Add new aws cli rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ sudo -H pip install thefuck --upgrade
 The Fuck tries to match a rule for the previous command, creates a new command
 using the matched rule and runs it. Rules enabled by default are as follows:
 
+* `aws_cli` &ndash; fixes misspelled commands like `aws dynamdb scan`
 * `cargo` &ndash; runs `cargo build` instead of `cargo`;
 * `cargo_no_command` &ndash; fixes wrongs commands like `cargo buid`;
 * `cd_correction` &ndash; spellchecks and correct failed cd commands;

--- a/tests/rules/test_aws_cli.py
+++ b/tests/rules/test_aws_cli.py
@@ -1,0 +1,101 @@
+import pytest
+
+from thefuck.rules.aws_cli import match, get_new_command
+from tests.utils import Command
+
+
+no_suggestions = '''\
+usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
+To see help text, you can run:
+
+  aws help
+  aws <command> help
+  aws <command> <subcommand> help
+aws: error: argument command: Invalid choice, valid choices are:
+
+dynamodb                                 | dynamodbstreams
+ec2                                      | ecr
+'''
+
+
+misspelled_command = '''\
+usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
+To see help text, you can run:
+
+  aws help
+  aws <command> help
+  aws <command> <subcommand> help
+aws: error: argument command: Invalid choice, valid choices are:
+
+dynamodb                                 | dynamodbstreams
+ec2                                      | ecr
+
+
+Invalid choice: 'dynamdb', maybe you meant:
+
+  * dynamodb
+'''
+
+
+misspelled_subcommand = '''\
+usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
+To see help text, you can run:
+
+  aws help
+  aws <command> help
+  aws <command> <subcommand> help
+aws: error: argument operation: Invalid choice, valid choices are:
+
+query                                    | scan
+update-item                              | update-table
+
+
+Invalid choice: 'scn', maybe you meant:
+
+  * scan
+'''
+
+
+misspelled_subcommand_with_multiple_options = '''\
+usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
+To see help text, you can run:
+
+  aws help
+  aws <command> help
+  aws <command> <subcommand> help
+aws: error: argument operation: Invalid choice, valid choices are:
+
+describe-table                           | get-item
+list-tables                              | put-item
+
+
+Invalid choice: 't-item', maybe you meant:
+
+  * put-item
+  * get-item
+'''
+
+
+@pytest.mark.parametrize('command', [
+    Command('aws dynamdb scan', stderr=misspelled_command),
+    Command('aws dynamodb scn', stderr=misspelled_subcommand),
+    Command('aws dynamodb t-item',
+            stderr=misspelled_subcommand_with_multiple_options)])
+def test_match(command):
+    assert match(command)
+
+
+def test_not_match():
+    assert not match(Command('aws dynamodb invalid', stderr=no_suggestions))
+
+
+@pytest.mark.parametrize('command, result', [
+    (Command('aws dynamdb scan', stderr=misspelled_command),
+     ['aws dynamodb scan']),
+    (Command('aws dynamodb scn', stderr=misspelled_subcommand),
+     ['aws dynamodb scan']),
+    (Command('aws dynamodb t-item',
+             stderr=misspelled_subcommand_with_multiple_options),
+     ['aws dynamodb put-item', 'aws dynamodb get-item'])])
+def test_get_new_command(command, result):
+    assert get_new_command(command) == result

--- a/thefuck/rules/aws_cli.py
+++ b/thefuck/rules/aws_cli.py
@@ -1,0 +1,17 @@
+import re
+
+from thefuck.utils import for_app, replace_argument
+
+INVALID_CHOICE = "(?<=Invalid choice: ')(.*)(?=', maybe you meant:)"
+OPTIONS = "^\s*\*\s(.*)"
+
+
+@for_app('aws')
+def match(command):
+    return "usage:" in command.stderr and "maybe you meant:" in command.stderr
+
+
+def get_new_command(command):
+    mistake = re.search(INVALID_CHOICE, command.stderr).group(0)
+    options = re.findall(OPTIONS, command.stderr, flags=re.MULTILINE)
+    return [replace_argument(command.script, mistake, o) for o in options]


### PR DESCRIPTION
This rule corrects spelling mistakes for aws cli commands and subcommands.