### PR TITLE
Suggest `brew link --overwrite --dry-run` when relevant

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Enabled by default only on specific platforms:
 * `apt_get_search` &ndash; changes trying to search using `apt-get` with searching using `apt-cache`;
 * `apt_invalid_operation` &ndash; fixes invalid `apt` and `apt-get` calls, like `apt-get isntall vim`;
 * `brew_install` &ndash; fixes formula name for `brew install`;
+* `brew_link` &ndash; adds `--overwrite --dry-run` if linking fails
 * `brew_unknown_command` &ndash; fixes wrong brew commands, for example `brew docto/brew doctor`;
 * `brew_update_formula` &ndash; turns `brew update <formula>` into `brew upgrade <formula>`;
 * `brew_upgrade` &ndash; appends `--all` to `brew upgrade` as per Homebrew's new behaviour;

--- a/tests/rules/test_brew_link.py
+++ b/tests/rules/test_brew_link.py
@@ -1,0 +1,38 @@
+import pytest
+from tests.utils import Command
+from thefuck.rules.brew_link import get_new_command, match
+
+
+@pytest.fixture
+def stderr():
+    return ("Error: Could not symlink bin/gcp\n"
+			"Target /usr/local/bin/gcp\n"
+			"already exists. You may want to remove it:\n"
+			  "rm '/usr/local/bin/gcp'\n"
+			"\n"
+			"To force the link and overwrite all conflicting files:\n"
+			  "brew link --overwrite coreutils\n"
+			"\n"
+			"To list all files that would be deleted:\n"
+			  "brew link --overwrite --dry-run coreutils\n")
+
+
+@pytest.fixture
+def new_command(formula):
+    return 'brew link --overwrite --dry-run {}'.format(formula)
+
+
+@pytest.mark.parametrize('script', ['brew link coreutils', 'brew ln coreutils'])
+def test_match(stderr, script):
+    assert match(Command(script=script, stderr=stderr))
+
+
+@pytest.mark.parametrize('script', ['brew link coreutils'])
+def test_not_match(script):
+    stderr=''
+    assert not match(Command(script=script, stderr=stderr))
+
+
+@pytest.mark.parametrize('script, formula, ', [('brew link coreutils', 'coreutils')])
+def test_get_new_command(stderr, new_command, script, formula):
+    assert get_new_command(Command(script=script, stderr=stderr)) == new_command

--- a/thefuck/rules/brew_link.py
+++ b/thefuck/rules/brew_link.py
@@ -1,0 +1,14 @@
+from thefuck.utils import for_app
+
+
+@for_app('brew', at_least=2)
+def match(command):
+    return (command.script_parts[1] in ['ln', 'link']
+            and "brew link --overwrite --dry-run" in command.stderr)
+
+
+def get_new_command(command):
+    command.script_parts[1] = 'link'
+    command.script_parts.insert(2, '--overwrite')
+    command.script_parts.insert(3, '--dry-run')
+    return ' '.join(command.script_parts)


### PR DESCRIPTION
This makes it easier to see which files would be overwritten by
`brew link --overwrite`