### PR TITLE
Add sudo rule for Aura

### DIFF
--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -19,7 +19,8 @@ patterns = ['permission denied',
             'you don\'t have access to the history db.',
             'authentication is required',
             'edspermissionerror',
-            'you don\'t have write permissions']
+            'you don\'t have write permissions',
+            'use `sudo`']
 
 
 def match(command):


### PR DESCRIPTION
When installing from Arch User Repository without root:
    aura >>= You have to use `sudo` for that.

This PR adds the slightly more general, but unambiguous, "use `sudo`".

It might be helpful to also add "use sudo" (no backticks) - but I haven't since I don't know for sure it's in use.

Closes #543.