### PR TITLE
Suggest `git diff --no-index` when relevant

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `git_branch_exists` &ndash; offers `git branch -d foo`, `git branch -D foo` or `git checkout foo` when creating a branch that already exists;
 * `git_branch_list` &ndash; catches `git branch list` in place of `git branch` and removes created branch;
 * `git_checkout` &ndash; fixes branch name or creates new branch;
+* `git_diff_no_index` &ndash; adds `--no-index` to previous `git diff` on untracked files;
 * `git_diff_staged` &ndash; adds `--staged` to previous `git diff` with unexpected output;
 * `git_fix_stash` &ndash; fixes `git stash` commands (misspelled subcommand and missing `save`);
 * `git_help_aliased` &ndash; fixes `git help <alias>` commands replacing <alias> with the aliased command;

--- a/tests/rules/test_git_diff_no_index.py
+++ b/tests/rules/test_git_diff_no_index.py
@@ -1,0 +1,23 @@
+import pytest
+from thefuck.rules.git_diff_no_index import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.mark.parametrize('command', [
+    Command(script='git diff foo bar')])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command', [
+    Command(script='git diff --no-index foo bar'),
+    Command(script='git diff foo'),
+    Command(script='git diff foo bar baz')])
+def test_not_match(command):
+    assert not match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('git diff foo bar'), 'git diff --no-index foo bar')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/git_diff_no_index.py
+++ b/thefuck/rules/git_diff_no_index.py
@@ -1,0 +1,20 @@
+from six.moves import filterfalse
+from thefuck.utils import replace_argument
+from thefuck.specific.git import git_support
+
+
+@git_support
+def match(command):
+    args = command.script_parts[2:]
+    files = list(filterfalse(is_option, args))
+    return ('diff' in command.script and
+            '--no-index' not in command.script and
+            len(command.stdout) is 0 and
+            len(files) is 2)
+
+def is_option(script_part):
+    return script_part.startswith('-')
+
+@git_support
+def get_new_command(command):
+    return replace_argument(command.script, 'diff', 'diff --no-index')


### PR DESCRIPTION
This makes it easier to use `git diff` on untracked files.