### PR TITLE
Suggest `ag -Q` when relevant

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ sudo -H pip install thefuck --upgrade
 The Fuck tries to match a rule for the previous command, creates a new command
 using the matched rule and runs it. Rules enabled by default are as follows:
 
+* `ag_literal` &ndash; adds `-Q` to `ag` when suggested;
 * `aws_cli` &ndash; fixes misspelled commands like `aws dynamdb scan`
 * `cargo` &ndash; runs `cargo build` instead of `cargo`;
 * `cargo_no_command` &ndash; fixes wrongs commands like `cargo buid`;

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The Fuck tries to match a rule for the previous command, creates a new command
 using the matched rule and runs it. Rules enabled by default are as follows:
 
 * `ag_literal` &ndash; adds `-Q` to `ag` when suggested;
-* `aws_cli` &ndash; fixes misspelled commands like `aws dynamdb scan`
+* `aws_cli` &ndash; fixes misspelled commands like `aws dynamdb scan`;
 * `cargo` &ndash; runs `cargo build` instead of `cargo`;
 * `cargo_no_command` &ndash; fixes wrongs commands like `cargo buid`;
 * `cd_correction` &ndash; spellchecks and correct failed cd commands;

--- a/tests/rules/test_ag_literal.py
+++ b/tests/rules/test_ag_literal.py
@@ -1,26 +1,25 @@
 import pytest
-from thefuck.rules.ag_literal import match, get_new_command
+from thefuck.rules.ag_literal import get_new_command, match
 from tests.utils import Command
 
-stderr = ('ERR: Bad regex! pcre_compile() failed at position 1: missing )\n'
-          'If you meant to search for a literal string, run ag with -Q\n')
 
-matching_command = Command(script='ag \\(', stderr=stderr)
-
-
-@pytest.mark.parametrize('command', [
-    matching_command])
-def test_match(command):
-    assert match(matching_command)
+@pytest.fixture
+def stderr():
+    return ('ERR: Bad regex! pcre_compile() failed at position 1: missing )\n'
+            'If you meant to search for a literal string, run ag with -Q\n')
 
 
-@pytest.mark.parametrize('command', [
-    Command(script='ag foo', stderr='')])
-def test_not_match(command):
-    assert not match(command)
+@pytest.mark.parametrize('script', ['ag \('])
+def test_match(script, stderr):
+    assert match(Command(script=script, stderr=stderr))
 
 
-@pytest.mark.parametrize('command, new_command', [
-    (matching_command, 'ag -Q \\(')])
-def test_get_new_command(command, new_command):
-    assert get_new_command(command) == new_command
+@pytest.mark.parametrize('script', ['ag foo'])
+def test_not_match(script):
+    assert not match(Command(script=script))
+
+
+@pytest.mark.parametrize('script, new_cmd', [
+    ('ag \(', 'ag -Q \(')])
+def test_get_new_command(script, new_cmd, stderr):
+    assert get_new_command((Command(script=script, stderr=stderr))) == new_cmd

--- a/tests/rules/test_ag_literal.py
+++ b/tests/rules/test_ag_literal.py
@@ -7,6 +7,7 @@ stderr = ('ERR: Bad regex! pcre_compile() failed at position 1: missing )\n'
 
 matching_command = Command(script='ag \\(', stderr=stderr)
 
+
 @pytest.mark.parametrize('command', [
     matching_command])
 def test_match(command):

--- a/tests/rules/test_ag_literal.py
+++ b/tests/rules/test_ag_literal.py
@@ -1,0 +1,25 @@
+import pytest
+from thefuck.rules.ag_literal import match, get_new_command
+from tests.utils import Command
+
+stderr = ('ERR: Bad regex! pcre_compile() failed at position 1: missing )\n'
+          'If you meant to search for a literal string, run ag with -Q\n')
+
+matching_command = Command(script='ag \\(', stderr=stderr)
+
+@pytest.mark.parametrize('command', [
+    matching_command])
+def test_match(command):
+    assert match(matching_command)
+
+
+@pytest.mark.parametrize('command', [
+    Command(script='ag foo', stderr='')])
+def test_not_match(command):
+    assert not match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (matching_command, 'ag -Q \\(')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/ag_literal.py
+++ b/thefuck/rules/ag_literal.py
@@ -1,0 +1,11 @@
+from thefuck.utils import for_app
+from thefuck.utils import replace_argument
+
+
+@for_app('ag')
+def match(command):
+    return 'run ag with -Q' in command.stderr
+
+
+def get_new_command(command):
+    return command.script.replace('ag', 'ag -Q', 1)

--- a/thefuck/rules/ag_literal.py
+++ b/thefuck/rules/ag_literal.py
@@ -1,5 +1,4 @@
 from thefuck.utils import for_app
-from thefuck.utils import replace_argument
 
 
 @for_app('ag')

--- a/thefuck/rules/ag_literal.py
+++ b/thefuck/rules/ag_literal.py
@@ -3,7 +3,7 @@ from thefuck.utils import for_app
 
 @for_app('ag')
 def match(command):
-    return 'run ag with -Q' in command.stderr
+    return command.stderr.endswith('run ag with -Q\n')
 
 
 def get_new_command(command):


### PR DESCRIPTION
This detects when `ag` suggests the `-Q` option, and adds it.