### PR TITLE
Use official Python images for Docker tests

### DIFF
--- a/tests/functional/test_bash.py
+++ b/tests/functional/test_bash.py
@@ -3,18 +3,11 @@ from tests.functional.plots import with_confirmation, without_confirmation, \
     refuse_with_confirmation, history_changed, history_not_changed, \
     select_command_with_arrows, how_to_configure
 
-containers = ((u'thefuck/ubuntu-python3-bash',
-               u'''FROM ubuntu:latest
-                   RUN apt-get update
-                   RUN apt-get install -yy python3 python3-pip python3-dev git
-                   RUN pip3 install -U setuptools
-                   RUN ln -s /usr/bin/pip3 /usr/bin/pip''',
+containers = ((u'thefuck/python3-bash',
+               u'FROM python:3',
                u'bash'),
-              (u'thefuck/ubuntu-python2-bash',
-               u'''FROM ubuntu:latest
-                   RUN apt-get update
-                   RUN apt-get install -yy python python-pip python-dev git
-                   RUN pip2 install -U pip setuptools''',
+              (u'thefuck/python2-bash',
+               u'FROM python:2',
                u'bash'))
 
 

--- a/tests/functional/test_fish.py
+++ b/tests/functional/test_fish.py
@@ -2,19 +2,20 @@ import pytest
 from tests.functional.plots import with_confirmation, without_confirmation, \
     refuse_with_confirmation, select_command_with_arrows
 
-containers = (('thefuck/ubuntu-python3-fish',
-               u'''FROM ubuntu:latest
+containers = (('thefuck/python3-fish',
+               u'''FROM python:3
+                   # Use jessie-backports since it has the fish package. See here for details:
+                   # https://github.com/tianon/docker-brew-debian/blob/88ae21052affd8a14553bb969f9d41c464032122/jessie/backports/Dockerfile
+                   RUN awk '$1 ~ "^deb" { $3 = $3 "-backports"; print; exit }' /etc/apt/sources.list > /etc/apt/sources.list.d/backports.list
                    RUN apt-get update
-                   RUN apt-get install -yy python3 python3-pip python3-dev fish git
-                   RUN pip3 install -U setuptools
-                   RUN ln -s /usr/bin/pip3 /usr/bin/pip
                    RUN apt-get install -yy fish''',
                u'fish'),
-              ('thefuck/ubuntu-python2-fish',
-               u'''FROM ubuntu:latest
+              ('thefuck/python2-fish',
+               u'''FROM python:2
+                   # Use jessie-backports since it has the fish package. See here for details:
+                   # https://github.com/tianon/docker-brew-debian/blob/88ae21052affd8a14553bb969f9d41c464032122/jessie/backports/Dockerfile
+                   RUN awk '$1 ~ "^deb" { $3 = $3 "-backports"; print; exit }' /etc/apt/sources.list > /etc/apt/sources.list.d/backports.list
                    RUN apt-get update
-                   RUN apt-get install -yy python python-pip python-dev git
-                   RUN pip2 install -U pip setuptools
                    RUN apt-get install -yy fish''',
                u'fish'))
 

--- a/tests/functional/test_performance.py
+++ b/tests/functional/test_performance.py
@@ -2,11 +2,7 @@ import pytest
 import time
 
 dockerfile = u'''
-FROM ubuntu:latest
-RUN apt-get update
-RUN apt-get install -yy python3 python3-pip python3-dev git
-RUN pip3 install -U setuptools
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
+FROM python:3
 RUN adduser --disabled-password --gecos '' test
 ENV SEED "{seed}"
 WORKDIR /src
@@ -42,7 +38,7 @@ def plot(proc, TIMEOUT):
 @pytest.mark.functional
 @pytest.mark.benchmark(min_rounds=10)
 def test_performance(spawnu, TIMEOUT, benchmark):
-    proc = spawnu(u'thefuck/ubuntu-python3-bash-performance',
+    proc = spawnu(u'thefuck/python3-bash-performance',
                   dockerfile, u'bash')
     proc.sendline(u'pip install /src')
     proc.sendline(u'su test')

--- a/tests/functional/test_tcsh.py
+++ b/tests/functional/test_tcsh.py
@@ -2,19 +2,14 @@ import pytest
 from tests.functional.plots import with_confirmation, without_confirmation, \
     refuse_with_confirmation, select_command_with_arrows
 
-containers = (('thefuck/ubuntu-python3-tcsh',
-               u'''FROM ubuntu:latest
+containers = (('thefuck/python3-tcsh',
+               u'''FROM python:3
                    RUN apt-get update
-                   RUN apt-get install -yy python3 python3-pip python3-dev git
-                   RUN pip3 install -U setuptools
-                   RUN ln -s /usr/bin/pip3 /usr/bin/pip
                    RUN apt-get install -yy tcsh''',
                u'tcsh'),
-              ('thefuck/ubuntu-python2-tcsh',
-               u'''FROM ubuntu:latest
+              ('thefuck/python2-tcsh',
+               u'''FROM python:2
                    RUN apt-get update
-                   RUN apt-get install -yy python python-pip python-dev git
-                   RUN pip2 install -U pip setuptools
                    RUN apt-get install -yy tcsh''',
                u'tcsh'))
 

--- a/tests/functional/test_zsh.py
+++ b/tests/functional/test_zsh.py
@@ -3,19 +3,14 @@ from tests.functional.plots import with_confirmation, without_confirmation, \
     refuse_with_confirmation, history_changed, history_not_changed, \
     select_command_with_arrows, how_to_configure
 
-containers = (('thefuck/ubuntu-python3-zsh',
-               u'''FROM ubuntu:latest
+containers = (('thefuck/python3-zsh',
+               u'''FROM python:3
                    RUN apt-get update
-                   RUN apt-get install -yy python3 python3-pip python3-dev git
-                   RUN pip3 install -U setuptools
-                   RUN ln -s /usr/bin/pip3 /usr/bin/pip
                    RUN apt-get install -yy zsh''',
                u'zsh'),
-              ('thefuck/ubuntu-python2-zsh',
-               u'''FROM ubuntu:latest
+              ('thefuck/python2-zsh',
+               u'''FROM python:2
                    RUN apt-get update
-                   RUN apt-get install -yy python python-pip python-dev git
-                   RUN pip2 install -U pip setuptools
                    RUN apt-get install -yy zsh''',
                u'zsh'))
 


### PR DESCRIPTION
This reduces build times by about 2 minutes, since Travis no longer has to install python/pip/git/setuptools on top of the Ubuntu images:

Before (7 min 1 sec): https://travis-ci.org/nvbn/thefuck/jobs/164603738
After (5 min 15 sec): https://travis-ci.org/josephfrazier/thefuck/jobs/165560110