### PR TITLE
git: fix `fatal: bad flag '...' after filename`

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `git_diff_no_index` &ndash; adds `--no-index` to previous `git diff` on untracked files;
 * `git_diff_staged` &ndash; adds `--staged` to previous `git diff` with unexpected output;
 * `git_fix_stash` &ndash; fixes `git stash` commands (misspelled subcommand and missing `save`);
+* `git_flag_after_filename` &ndash; fixes `fatal: bad flag '...' after filename`
 * `git_help_aliased` &ndash; fixes `git help <alias>` commands replacing <alias> with the aliased command;
 * `git_not_command` &ndash; fixes wrong git commands like `git brnch`;
 * `git_pull` &ndash; sets upstream before executing previous `git pull`;

--- a/tests/rules/test_git_flag_after_filename.py
+++ b/tests/rules/test_git_flag_after_filename.py
@@ -1,19 +1,23 @@
 from thefuck.rules.git_flag_after_filename import match, get_new_command
 from tests.utils import Command
 
+command1 = Command('git log README.md -p',
+                   stderr="fatal: bad flag '-p' used after filename")
+command2 = Command('git log README.md -p CONTRIBUTING.md',
+                   stderr="fatal: bad flag '-p' used after filename")
+command3 = Command('git log -p README.md --name-only',
+                   stderr="fatal: bad flag '--name-only' used after filename")
+
 
 def test_match():
-    assert match(Command('git log README.md -p', stderr="fatal: bad flag '-p' used after filename"))
-    assert match(Command('git log README.md -p CONTRIBUTING.md', stderr="fatal: bad flag '-p' used after filename"))
-    assert match(Command('git log -p README.md --name-only', stderr="fatal: bad flag '--name-only' used after filename"))
+    assert match(command1)
+    assert match(command2)
+    assert match(command3)
     assert not match(Command('git log README.md'))
     assert not match(Command('git log -p README.md'))
 
 
 def test_get_new_command():
-    assert get_new_command(Command('git log README.md -p', stderr="fatal: bad flag '-p' used after filename"))\
-        == "git log -p README.md"
-    assert get_new_command(Command('git log README.md -p CONTRIBUTING.md', stderr="fatal: bad flag '-p' used after filename"))\
-        == "git log -p README.md CONTRIBUTING.md"
-    assert get_new_command(Command('git log -p README.md --name-only', stderr="fatal: bad flag '--name-only' used after filename"))\
-        == "git log -p --name-only README.md"
+    assert get_new_command(command1) == "git log -p README.md"
+    assert get_new_command(command2) == "git log -p README.md CONTRIBUTING.md"
+    assert get_new_command(command3) == "git log -p --name-only README.md"

--- a/tests/rules/test_git_flag_after_filename.py
+++ b/tests/rules/test_git_flag_after_filename.py
@@ -1,0 +1,20 @@
+import pytest
+from thefuck.rules.git_flag_after_filename import match, get_new_command
+from tests.utils import Command
+
+
+def test_match():
+    assert match(Command('git log README.md -p', stderr="fatal: bad flag '-p' used after filename"))
+    assert match(Command('git log README.md -p CONTRIBUTING.md', stderr="fatal: bad flag '-p' used after filename"))
+    assert match(Command('git log -p README.md --name-only', stderr="fatal: bad flag '--name-only' used after filename"))
+    assert not match(Command('git log README.md'))
+    assert not match(Command('git log -p README.md'))
+
+
+def test_get_new_command():
+    assert get_new_command(Command('git log README.md -p', stderr="fatal: bad flag '-p' used after filename"))\
+        == "git log -p README.md"
+    assert get_new_command(Command('git log README.md -p CONTRIBUTING.md', stderr="fatal: bad flag '-p' used after filename"))\
+        == "git log -p README.md CONTRIBUTING.md"
+    assert get_new_command(Command('git log -p README.md --name-only', stderr="fatal: bad flag '--name-only' used after filename"))\
+        == "git log -p --name-only README.md"

--- a/tests/rules/test_git_flag_after_filename.py
+++ b/tests/rules/test_git_flag_after_filename.py
@@ -1,4 +1,3 @@
-import pytest
 from thefuck.rules.git_flag_after_filename import match, get_new_command
 from tests.utils import Command
 

--- a/thefuck/rules/git_flag_after_filename.py
+++ b/thefuck/rules/git_flag_after_filename.py
@@ -1,0 +1,29 @@
+import re
+from thefuck.specific.git import git_support
+
+error_pattern = "fatal: bad flag '(.*?)' used after filename"
+
+@git_support
+def match(command):
+    return re.search(error_pattern, command.stderr)
+
+
+@git_support
+def get_new_command(command):
+    command_parts = command.script_parts[:]
+
+    # find the bad flag
+    bad_flag = re.search(error_pattern, command.stderr).group(1)
+    bad_flag_index = command_parts.index(bad_flag)
+
+    # find the filename
+    for index in reversed(range(bad_flag_index)):
+        if command_parts[index][0] != '-':
+            filename_index = index
+            break
+
+    # swap them
+    command_parts[bad_flag_index], command_parts[filename_index] = \
+    command_parts[filename_index], command_parts[bad_flag_index]
+
+    return u' '.join(command_parts)

--- a/thefuck/rules/git_flag_after_filename.py
+++ b/thefuck/rules/git_flag_after_filename.py
@@ -3,6 +3,7 @@ from thefuck.specific.git import git_support
 
 error_pattern = "fatal: bad flag '(.*?)' used after filename"
 
+
 @git_support
 def match(command):
     return re.search(error_pattern, command.stderr)
@@ -24,6 +25,6 @@ def get_new_command(command):
 
     # swap them
     command_parts[bad_flag_index], command_parts[filename_index] = \
-    command_parts[filename_index], command_parts[bad_flag_index]
+    command_parts[filename_index], command_parts[bad_flag_index]  # noqa: E122
 
     return u' '.join(command_parts)


### PR DESCRIPTION
For example:

```
$ git log README.md -p
fatal: bad flag '-p' used after filename
$ fuck
git log -p README.md [enter/↑/↓/ctrl+c]
Aborted

$ git log -p README.md --name-only
fatal: bad flag '--name-only' used after filename
$ fuck
git log -p --name-only README.md [enter/↑/↓/ctrl+c]
Aborted

$ git log README.md -p CONTRIBUTING.md
fatal: bad flag '-p' used after filename
$ fuck
git log -p README.md CONTRIBUTING.md [enter/↑/↓/ctrl+c]
```

See also:
- https://twitter.com/bitprophet/status/232901966383161345
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=621601
