### PR TITLE
bash: always honor alter_history setting

### DIFF
--- a/thefuck/shells/bash.py
+++ b/thefuck/shells/bash.py
@@ -14,7 +14,7 @@ class Bash(Generic):
                 " eval $TF_CMD".format(fuck)
 
         if settings.alter_history:
-            return alias + " && history -s $TF_CMD'"
+            return alias + "; history -s $TF_CMD'"
         else:
             return alias + "'"
 


### PR DESCRIPTION
This ensures that even if the command suggested and run by `thefuck`
fails, it will still be added to the history, allowing the user to tweak
it further (or run `fuck` again) if desired.

Note that the fish shell appears to already behave this way.