### PR TITLE
Suggest `ls -A` when `ls` has no output

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `lein_not_task` &ndash; fixes wrong `lein` tasks like `lein rpl`;
 * `ln_no_hard_link` &ndash; catches hard link creation on directories, suggest symbolic link;
 * `ln_s_order` &ndash; fixes `ln -s` arguments order;
+* `ls_all` &ndash; adds `-A` to `ls` when output is empty;
 * `ls_lah` &ndash; adds `-lah` to `ls`;
 * `man` &ndash; changes manual section;
 * `man_no_space` &ndash; fixes man commands without spaces, for example `mandiff`;

--- a/tests/rules/test_ls_all.py
+++ b/tests/rules/test_ls_all.py
@@ -1,0 +1,12 @@
+from thefuck.rules.ls_all import match, get_new_command
+from tests.utils import Command
+
+
+def test_match():
+    assert match(Command(script='ls'))
+    assert not match(Command(script='ls', stdout='file.py\n'))
+
+
+def test_get_new_command():
+    assert get_new_command(Command(script='ls empty_dir')) == 'ls -A empty_dir'
+    assert get_new_command(Command(script='ls')) == 'ls -A'

--- a/thefuck/rules/ls_all.py
+++ b/thefuck/rules/ls_all.py
@@ -1,0 +1,10 @@
+from thefuck.utils import for_app
+
+
+@for_app('ls')
+def match(command):
+    return command.stdout.strip() == ''
+
+
+def get_new_command(command):
+    return ' '.join(['ls', '-A'] + command.script_parts[1:])


### PR DESCRIPTION
For example:

    $ ls dotfiles/
    $ fuck
    ls -A dotfiles/ [enter/↑/↓/ctrl+c]