### PR TITLE
Fix issue with scrolling when package not found

### DIFF
--- a/thefuck/specific/archlinux.py
+++ b/thefuck/specific/archlinux.py
@@ -24,8 +24,11 @@ def get_pkgfile(command):
         ).splitlines()
 
         return [package.split()[0] for package in packages]
-    except subprocess.CalledProcessError:
-        return []
+    except subprocess.CalledProcessError as err:
+        if err.returncode == 1 and err.output == "":
+            return []
+        else:
+            raise err
 
 
 def archlinux_env():

--- a/thefuck/specific/archlinux.py
+++ b/thefuck/specific/archlinux.py
@@ -25,7 +25,7 @@ def get_pkgfile(command):
 
         return [package.split()[0] for package in packages]
     except subprocess.CalledProcessError:
-        return None
+        return []
 
 
 def archlinux_env():


### PR DESCRIPTION
Fix issue with attempting to scroll through possible corrections when not-found package has no packages with matching names causing crash.

This behavior originates with commit 6624ecb3b85e82e9f1a08823f6e41ee805d35a9e, to my knowledge, where pacman rules were created. In both uses of `get_pkgfile` (in pacman.py and in pacman_not_found.py), it would be appropriate for `get_pkgfile` to return an empty list when the `pkgfile` does not find any packages by the correct name. However, the `pkgfile` command returns 1 in these circumstances, and as such `subprocess` raises an exception. Now, when this exception is caused by `pkgfile` returning 1 with no output (when it finds no packages), `get_pkgfile` will not cause a crash.

To reproduce bug:
```
yaourt -S e
fuck
```
then press ↑ or ↓