### PR TITLE
#577: Use builtin `history` in Fish function

### DIFF
--- a/tests/shells/test_fish.py
+++ b/tests/shells/test_fish.py
@@ -76,11 +76,11 @@ class TestFish(object):
 
     def test_app_alias_alter_history(self, settings, shell):
         settings.alter_history = True
-        assert 'history --delete' in shell.app_alias('FUCK')
-        assert 'history --merge' in shell.app_alias('FUCK')
+        assert 'builtin history delete' in shell.app_alias('FUCK')
+        assert 'builtin history merge' in shell.app_alias('FUCK')
         settings.alter_history = False
-        assert 'history --delete' not in shell.app_alias('FUCK')
-        assert 'history --merge' not in shell.app_alias('FUCK')
+        assert 'builtin history delete' not in shell.app_alias('FUCK')
+        assert 'builtin history merge' not in shell.app_alias('FUCK')
 
     def test_get_history(self, history_lines, shell):
         history_lines(['- cmd: ls', '  when: 1432613911',

--- a/thefuck/shells/fish.py
+++ b/thefuck/shells/fish.py
@@ -20,8 +20,9 @@ class Fish(Generic):
 
     def app_alias(self, fuck):
         if settings.alter_history:
-            alter_history = ('    history --delete $fucked_up_command\n'
-                             '    history --merge ^ /dev/null\n')
+            alter_history = ('    builtin history delete --exact'
+                             ' --case-sensitive -- $fucked_up_command\n'
+                             '    builtin history merge ^ /dev/null\n')
         else:
             alter_history = ''
         # It is VERY important to have the variables declared WITHIN the alias


### PR DESCRIPTION
Fix #577