### PR TITLE
Add Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ matrix:
   include:
     - os: linux
       dist: trusty
+      python: "3.6"
+    - os: linux
+      dist: trusty
       python: "3.5"
     - os: linux
       dist: trusty
@@ -41,7 +44,7 @@ install:
 script:
   - export COVERAGE_PYTHON_VERSION=python-${TRAVIS_PYTHON_VERSION:0:1}
   - export RUN_TESTS="coverage run --source=thefuck,tests -m py.test -v --capture=sys tests"
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 && $TRAVIS_OS_NAME != "osx" ]]; then $RUN_TESTS --enable-functional; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != 3.5 || $TRAVIS_OS_NAME == "osx" ]]; then $RUN_TESTS; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 && $TRAVIS_OS_NAME != "osx" ]]; then $RUN_TESTS --enable-functional; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != 3.6 || $TRAVIS_OS_NAME == "osx" ]]; then $RUN_TESTS; fi
 after_success:
   - coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     - PYTHON: "C:/Python33"
     - PYTHON: "C:/Python34"
     - PYTHON: "C:/Python35"
+    - PYTHON: "C:/Python36"
 
 init:
   - "ECHO %PYTHON%"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py33,py34,py35,py36
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
Python 3.6.0 is the newest major release of the Python language, and it contains many new features and optimizations. 

Add it to all CI configuration files.