### PR TITLE
Add git_tag_force rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `git_remote_seturl_add` &ndash; runs `git remote add` when `git remote set_url` on nonexistant remote;
 * `git_stash` &ndash; stashes you local modifications before rebasing or switching branch;
 * `git_stash_pop` &ndash; adds your local modifications before popping stash, then resets;
+* `git_tag_force` &ndash; adds `--force` to `git tag <tagname>` when the tag already exists;
 * `git_two_dashes` &ndash; adds a missing dash to commands like `git commit -amend` or `git rebase -continue`;
 * `go_run` &ndash; appends `.go` extension when compiling/running Go programs;
 * `gradle_no_task` &ndash; fixes not found or ambiguous `gradle` task;

--- a/tests/rules/test_git_tag_force.py
+++ b/tests/rules/test_git_tag_force.py
@@ -1,0 +1,18 @@
+import pytest
+from thefuck.rules.git_tag_force import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.fixture
+def stderr():
+    return '''fatal: tag 'alert' already exists'''
+
+
+def test_match(stderr):
+    assert match(Command('git tag alert', stderr=stderr))
+    assert not match(Command('git tag alert'))
+
+
+def test_get_new_command(stderr):
+    assert get_new_command(Command('git tag alert', stderr=stderr)) \
+           == "git tag --force alert"

--- a/thefuck/rules/git_tag_force.py
+++ b/thefuck/rules/git_tag_force.py
@@ -1,0 +1,13 @@
+from thefuck.utils import replace_argument
+from thefuck.specific.git import git_support
+
+
+@git_support
+def match(command):
+    return ('tag' in command.script_parts
+            and 'already exists' in command.stderr)
+
+
+@git_support
+def get_new_command(command):
+    return replace_argument(command.script, 'tag', 'tag --force')


### PR DESCRIPTION
This adds `--force` to `git tag` when needed. For example:

    $ git tag alert
    fatal: tag 'alert' already exists
    $ fuck
    git tag --force alert [enter/↑/↓/ctrl+c]
    Updated tag 'alert' (was dec6956)
    $