### PR TITLE
README.md: fix typo in git_stash description

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `git_rm_recursive` &ndash; adds `-r` when you try to `rm` a directory;
 * `git_rebase_merge_dir` &ndash; offers `git rebase (--continue | --abort | --skip)` or removing the `.git/rebase-merge` dir when a rebase is in progress;
 * `git_remote_seturl_add` &ndash; runs `git remote add` when `git remote set_url` on nonexistant remote;
-* `git_stash` &ndash; stashes you local modifications before rebasing or switching branch;
+* `git_stash` &ndash; stashes your local modifications before rebasing or switching branch;
 * `git_stash_pop` &ndash; adds your local modifications before popping stash, then resets;
 * `git_two_dashes` &ndash; adds a missing dash to commands like `git commit -amend` or `git rebase -continue`;
 * `go_run` &ndash; appends `.go` extension when compiling/running Go programs;


### PR DESCRIPTION
from "stashes you local modifications"
to   "stashes your local modifications"