### PR TITLE
Add git_add_force rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `fix_file` &ndash; opens a file with an error in your `$EDITOR`;
 * `gem_unknown_command` &ndash; fixes wrong `gem` commands;
 * `git_add` &ndash; fixes *"pathspec 'foo' did not match any file(s) known to git."*;
+* `git_add_force` &ndash; adds `--force` to `git add <pathspec>...` when paths are .gitignore'd;
 * `git_bisect_usage` &ndash; fixes `git bisect strt`, `git bisect goood`, `git bisect rset`, etc. when bisecting;
 * `git_branch_delete` &ndash; changes `git branch -d` to `git branch -D`;
 * `git_branch_exists` &ndash; offers `git branch -d foo`, `git branch -D foo` or `git checkout foo` when creating a branch that already exists;

--- a/tests/rules/test_git_add_force.py
+++ b/tests/rules/test_git_add_force.py
@@ -1,0 +1,22 @@
+import pytest
+from thefuck.rules.git_add_force import match, get_new_command
+from tests.utils import Command
+
+
+@pytest.fixture
+def stderr():
+    return ('The following paths are ignored by one of your .gitignore files:\n'
+            'dist/app.js\n'
+            'dist/background.js\n'
+            'dist/options.js\n'
+            'Use -f if you really want to add them.\n')
+
+
+def test_match(stderr):
+    assert match(Command('git add dist/*.js', stderr=stderr))
+    assert not match(Command('git add dist/*.js'))
+
+
+def test_get_new_command(stderr):
+    assert get_new_command(Command('git add dist/*.js', stderr=stderr)) \
+           == "git add --force dist/*.js"

--- a/thefuck/rules/git_add_force.py
+++ b/thefuck/rules/git_add_force.py
@@ -1,0 +1,13 @@
+from thefuck.utils import replace_argument
+from thefuck.specific.git import git_support
+
+
+@git_support
+def match(command):
+    return ('add' in command.script_parts
+            and 'Use -f if you really want to add them.' in command.stderr)
+
+
+@git_support
+def get_new_command(command):
+	return replace_argument(command.script, 'add', 'add --force')


### PR DESCRIPTION
This adds `--force` to `git add` when needed. For example:

    $ git add dist/*.js
    The following paths are ignored by one of your .gitignore files:
    dist/app.js
    dist/background.js
    dist/options.js
    Use -f if you really want to add them.
    $ fuck
    git add --force dist/app.js dist/background.js dist/options.js [enter/↑/↓/ctrl+c]
    $