### PR TITLE
Added support for "not installed" message in apt_get

### DIFF
--- a/tests/rules/test_apt_get.py
+++ b/tests/rules/test_apt_get.py
@@ -7,6 +7,8 @@ from tests.utils import Command
     (Command(script='vim', stderr='vim: command not found'),
      [('vim', 'main'), ('vim-tiny', 'main')]),
     (Command(script='sudo vim', stderr='vim: command not found'),
+     [('vim', 'main'), ('vim-tiny', 'main')]),
+    (Command(script='vim', stderr="The program 'vim' is currently not installed. You can install it by typing: sudo apt install vim"),
      [('vim', 'main'), ('vim-tiny', 'main')])])
 def test_match(mocker, command, packages):
     mocker.patch('thefuck.rules.apt_get.which', return_value=None)

--- a/thefuck/rules/apt_get.py
+++ b/thefuck/rules/apt_get.py
@@ -1,6 +1,7 @@
 from thefuck.specific.apt import apt_available
 from thefuck.utils import memoize, which
 from thefuck.shells import shell
+from pprint import pprint
 
 try:
     from CommandNotFound import CommandNotFound
@@ -29,7 +30,7 @@ def get_package(executable):
 
 
 def match(command):
-    if 'not found' in command.stderr:
+    if 'not found' in command.stderr or 'not installed' in command.stderr:
         executable = _get_executable(command)
         return not which(executable) and get_package(executable)
     else:


### PR DESCRIPTION
The error message "The program 'vim' is currently not installed. You can install it by typing: sudo apt install vim" has the same solution as "vim: command not found", so I added it as a case for installing the program with apt.