### PR TITLE
Improve performance of history rule

### DIFF
--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -264,7 +264,7 @@ def get_valid_history_without_current(command):
     from thefuck.shells import shell
     history = shell.get_history()
     tf_alias = get_alias()
-    executables = get_all_executables()
+    executables = set(get_all_executables())
     return [line for line in _not_corrected(history, tf_alias)
             if not line.startswith(tf_alias) and not line == command.script
             and line.split(' ')[0] in executables]


### PR DESCRIPTION
```bash
$ history | wc -l
   26954
$ ll
...
$ fuck
...
DEBUG: Trying rule: history; took: 0:00:02.685889
ls -al [enter/↑/↓/ctrl+c]


$ ll
...
$ fuck
...
DEBUG: Trying rule: history; took: 0:00:00.140865
ls -al [enter/↑/↓/ctrl+c]
```

The issue is the function `get_valid_history_without_current()`; it does a linear scan through the list `executables` once per line of history. Changing `executables` to a set allows for constant-time lookup instead. This should help address #334, #353, and maybe #371.