### PR TITLE
Fix aliased `yarn` commands like `yarn ls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `vagrant_up` &ndash; starts up the vagrant instance;
 * `whois` &ndash; fixes `whois` command;
 * `workon_doesnt_exists` &ndash; fixes `virtualenvwrapper` env name os suggests to create new.
+* `yarn_alias` &ndash; fixes aliased `yarn` commands like `yarn ls`;
 
 Enabled by default only on specific platforms:
 

--- a/tests/rules/test_yarn_alias.py
+++ b/tests/rules/test_yarn_alias.py
@@ -1,0 +1,22 @@
+import pytest
+from thefuck.rules.yarn_alias import match, get_new_command
+from tests.utils import Command
+
+
+stderr_remove = 'error Did you mean `yarn remove`?'
+
+stderr_list = 'error Did you mean `yarn list`?'
+
+
+@pytest.mark.parametrize('command', [
+    Command(script='yarn rm', stderr=stderr_remove),
+    Command(script='yarn ls', stderr=stderr_list)])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('yarn rm', stderr=stderr_remove), 'yarn remove'),
+    (Command('yarn ls', stderr=stderr_list), 'yarn list')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/yarn_alias.py
+++ b/thefuck/rules/yarn_alias.py
@@ -1,0 +1,14 @@
+import re
+from thefuck.utils import replace_argument, for_app
+
+
+@for_app('yarn', at_least=1)
+def match(command):
+    return ('Did you mean' in command.stderr)
+
+
+def get_new_command(command):
+    broken = command.script_parts[1]
+    fix = re.findall(r'Did you mean `yarn ([^`]*)`', command.stderr)[0]
+
+    return replace_argument(command.script, broken, fix)


### PR DESCRIPTION
[Yarn] has a handful of subcommand [aliases] but does not automatically
[correct] them for the user. This makes it so that `fuck` will do the
trick. For example:

    $ yarn ls
    yarn ls v0.20.3
    error Did you mean `yarn list`?
    info Visit https://yarnpkg.com/en/docs/cli/list for documentation about this command.
    $ fuck
    yarn list [enter/?/?/ctrl+c]

[Yarn]: https://yarnpkg.com/en/
[aliases]: https://github.com/yarnpkg/yarn/blob/0adbc59b18b38b6ac6e4b248e19788ed1d2e80da/src/cli/aliases.js
[correct]: https://github.com/yarnpkg/yarn/pull/1044#issuecomment-253763230