### PR TITLE
Update PowerShell alias to handle no history

### DIFF
--- a/thefuck/shells/powershell.py
+++ b/thefuck/shells/powershell.py
@@ -3,11 +3,14 @@ from .generic import Generic
 
 class Powershell(Generic):
     def app_alias(self, fuck):
-        return 'function ' + fuck + ' { \n' \
-               '    $fuck = $(thefuck (Get-History -Count 1).CommandLine);\n' \
-               '    if (-not [string]::IsNullOrWhiteSpace($fuck)) {\n' \
-               '        if ($fuck.StartsWith("echo")) { $fuck = $fuck.Substring(5); }\n' \
-               '        else { iex "$fuck"; }\n' \
+        return 'function ' + fuck + ' {\n' \
+               '    $history = (Get-History -Count 1).CommandLine;\n' \
+               '    if (-not [string]::IsNullOrWhiteSpace($history)) {\n' \
+               '        $fuck = $(thefuck $history);\n' \
+               '        if (-not [string]::IsNullOrWhiteSpace($fuck)) {\n' \
+               '            if ($fuck.StartsWith("echo")) { $fuck = $fuck.Substring(5); }\n' \
+               '            else { iex "$fuck"; }\n' \
+               '        }\n' \
                '    }\n' \
                '}\n'
 


### PR DESCRIPTION
If history is cleared (or the shell is new and there is no history),
invoking thefuck results in an error because the alias attempts to execute
the usage string.

The fix is to check if Get-History returns anything before invoking
thefuck.