### PR TITLE
Add `yarn_help` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `workon_doesnt_exists` &ndash; fixes `virtualenvwrapper` env name os suggests to create new.
 * `yarn_alias` &ndash; fixes aliased `yarn` commands like `yarn ls`;
 * `yarn_command_not_found` &ndash; fixes misspelled `yarn` commands;
+* `yarn_help` &ndash; makes it easier to open `yarn` documentation;
 
 Enabled by default only on specific platforms:
 

--- a/tests/rules/test_yarn_help.py
+++ b/tests/rules/test_yarn_help.py
@@ -1,6 +1,7 @@
 import pytest
 from thefuck.rules.yarn_help import match, get_new_command
 from tests.utils import Command
+from thefuck.system import open_command
 
 
 stdout_clean = '''
@@ -50,6 +51,6 @@ def test_match(command):
 
 
 @pytest.mark.parametrize('command, new_command', [
-    (Command('yarn help clean', stdout=stdout_clean), 'open https://yarnpkg.com/en/docs/cli/clean')])
+    (Command('yarn help clean', stdout=stdout_clean), open_command('https://yarnpkg.com/en/docs/cli/clean'))])
 def test_get_new_command(command, new_command):
     assert get_new_command(command) == new_command

--- a/tests/rules/test_yarn_help.py
+++ b/tests/rules/test_yarn_help.py
@@ -1,0 +1,55 @@
+import pytest
+from thefuck.rules.yarn_help import match, get_new_command
+from tests.utils import Command
+
+
+stdout_clean = '''
+
+  Usage: yarn [command] [flags]
+
+  Options:
+
+    -h, --help                      output usage information
+    -V, --version                   output the version number
+    --verbose                       output verbose messages on internal operations
+    --offline                       trigger an error if any required dependencies are not available in local cache
+    --prefer-offline                use network only if dependencies are not available in local cache
+    --strict-semver                 
+    --json                          
+    --ignore-scripts                don't run lifecycle scripts
+    --har                           save HAR output of network traffic
+    --ignore-platform               ignore platform checks
+    --ignore-engines                ignore engines check
+    --ignore-optional               ignore optional dependencies
+    --force                         ignore all caches
+    --no-bin-links                  don't generate bin links when setting up packages
+    --flat                          only allow one version of a package
+    --prod, --production [prod]     
+    --no-lockfile                   don't read or generate a lockfile
+    --pure-lockfile                 don't generate a lockfile
+    --frozen-lockfile               don't generate a lockfile and fail if an update is needed
+    --link-duplicates               create hardlinks to the repeated modules in node_modules
+    --global-folder <path>          
+    --modules-folder <path>         rather than installing modules into the node_modules folder relative to the cwd, output them here
+    --cache-folder <path>           specify a custom folder to store the yarn cache
+    --mutex <type>[:specifier]      use a mutex to ensure only one yarn instance is executing
+    --no-emoji                      disable emoji in output
+    --proxy <host>                  
+    --https-proxy <host>            
+    --no-progress                   disable progress bar
+    --network-concurrency <number>  maximum number of concurrent network requests
+
+  Visit https://yarnpkg.com/en/docs/cli/clean for documentation about this command.
+'''  # noqa
+
+
+@pytest.mark.parametrize('command', [
+    Command(script='yarn help clean', stdout=stdout_clean)])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('yarn help clean', stdout=stdout_clean), 'open https://yarnpkg.com/en/docs/cli/clean')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/yarn_help.py
+++ b/thefuck/rules/yarn_help.py
@@ -1,5 +1,6 @@
 import re
 from thefuck.utils import for_app
+from thefuck.system import open_command
 
 
 @for_app('yarn', at_least=2)
@@ -8,6 +9,6 @@ def match(command):
 
 
 def get_new_command(command):
-    fix = re.findall(r'Visit ([^ ]*) for documentation about this command.', command.stdout)[0]
+    url = re.findall(r'Visit ([^ ]*) for documentation about this command.', command.stdout)[0]
 
-    return 'open ' + fix
+    return open_command(url)

--- a/thefuck/rules/yarn_help.py
+++ b/thefuck/rules/yarn_help.py
@@ -1,0 +1,13 @@
+import re
+from thefuck.utils import for_app
+
+
+@for_app('yarn', at_least=2)
+def match(command):
+    return command.script_parts[1] == 'help' and ('for documentation about this command.' in command.stdout)
+
+
+def get_new_command(command):
+    fix = re.findall(r'Visit ([^ ]*) for documentation about this command.', command.stdout)[0]
+
+    return 'open ' + fix

--- a/thefuck/system/unix.py
+++ b/thefuck/system/unix.py
@@ -3,6 +3,7 @@ import sys
 import tty
 import termios
 import colorama
+from distutils.spawn import find_executable
 from .. import const
 
 init_output = colorama.init
@@ -34,6 +35,13 @@ def get_key():
                 return const.KEY_DOWN
 
     return ch
+
+
+def open_command(arg):
+    if (find_executable('xdg-open')):
+        return 'xdg-open ' + arg
+    return 'open ' + arg
+
 
 try:
     from pathlib import Path

--- a/thefuck/system/win32.py
+++ b/thefuck/system/win32.py
@@ -26,6 +26,11 @@ def get_key():
     encoding = sys.stdout.encoding or os.environ.get('PYTHONIOENCODING', 'utf-8')
     return ch.decode(encoding)
 
+
+def open_command(arg):
+    return 'cmd /c start ' + arg
+
+
 try:
     from pathlib import Path
 except ImportError:


### PR DESCRIPTION
Yarn likes to keep its documentation online, rather than in `yarn help`
output. For example, `yarn help clean` doesn't tell you anything about
the `clean` subcommand. Instead, it points you towards
https://yarnpkg.com/en/docs/cli/clean

This rule detects when that happens, and suggests opening the URL. <strike>One
caveat is that currently only OSX is supported, as Linux uses `xdg-open`
instead of `open`, and Windows uses `start` (see https://www.dwheeler.com/essays/open-files-urls.html).</strike> EDIT: Added LInux/Windows support