### PR TITLE
Created a rule for trying to push a new repository with no commits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `git_pull_uncommitted_changes` &ndash; stashes changes before pulling and pops them afterwards;
 * `git_push` &ndash; adds `--set-upstream origin $branch` to previous failed `git push`;
 * `git_push_pull` &ndash; runs `git pull` when `push` was rejected;
+* `git_push_without_commits` &ndash; Creates an initial commit if you forget and only `git add .`, when setting up a new project;
 * `git_rebase_no_changes` &ndash; runs `git rebase --skip` instead of `git rebase --continue` when there are no changes;
 * `git_rm_local_modifications` &ndash;  adds `-f` or `--cached` when you try to `rm` a locally modified file;
 * `git_rm_recursive` &ndash; adds `-r` when you try to `rm` a directory;

--- a/tests/rules/test_git_push_without_commits.py
+++ b/tests/rules/test_git_push_without_commits.py
@@ -5,7 +5,6 @@ from thefuck.rules.git_push_without_commits import (
     fix,
     get_new_command,
     match,
-    refspec_does_not_match,
 )
 
 command = 'git push -u origin master'

--- a/tests/rules/test_git_push_without_commits.py
+++ b/tests/rules/test_git_push_without_commits.py
@@ -1,0 +1,28 @@
+import pytest
+
+from tests.utils import Command
+from thefuck.rules.git_push_without_commits import (
+    fix,
+    get_new_command,
+    match,
+    refspec_does_not_match,
+)
+
+command = 'git push -u origin master'
+expected_error = '''
+error: src refspec master does not match any.
+error: failed to push some refs to 'git@github.com:User/repo.git'
+'''
+
+
+@pytest.mark.parametrize('command', [Command(command, stderr=expected_error)])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command, result', [(
+    Command(command, stderr=expected_error),
+    fix.format(command=command),
+)])
+def test_get_new_command(command, result):
+    assert get_new_command(command) == result

--- a/thefuck/rules/git_push_without_commits.py
+++ b/thefuck/rules/git_push_without_commits.py
@@ -1,7 +1,5 @@
 import re
 
-from thefuck.utils import replace_command
-
 fix = 'git commit -m "Initial commit." && {command}'
 refspec_does_not_match = re.compile(r'src refspec \w+ does not match any\.')
 

--- a/thefuck/rules/git_push_without_commits.py
+++ b/thefuck/rules/git_push_without_commits.py
@@ -1,0 +1,17 @@
+import re
+
+from thefuck.utils import replace_command
+
+fix = 'git commit -m "Initial commit." && {command}'
+refspec_does_not_match = re.compile(r'src refspec \w+ does not match any\.')
+
+
+def match(command):
+    if refspec_does_not_match.search(command.stderr):
+        return True
+
+    return False
+
+
+def get_new_command(command):
+    return fix.format(command=command.script)


### PR DESCRIPTION
I made this because the error message `git` provides is entirely cryptic, and always requires a googling.