### PR TITLE
Extend yarn_alias rule to handle package.json scripts

### DIFF
--- a/tests/rules/test_yarn_alias.py
+++ b/tests/rules/test_yarn_alias.py
@@ -4,12 +4,13 @@ from tests.utils import Command
 
 
 stderr_remove = 'error Did you mean `yarn remove`?'
-
+stderr_etl = 'error Command "etil" not found. Did you mean "etl"?'
 stderr_list = 'error Did you mean `yarn list`?'
 
 
 @pytest.mark.parametrize('command', [
     Command(script='yarn rm', stderr=stderr_remove),
+    Command(script='yarn etil', stderr=stderr_etl),
     Command(script='yarn ls', stderr=stderr_list)])
 def test_match(command):
     assert match(command)
@@ -17,6 +18,7 @@ def test_match(command):
 
 @pytest.mark.parametrize('command, new_command', [
     (Command('yarn rm', stderr=stderr_remove), 'yarn remove'),
+    (Command('yarn etil', stderr=stderr_etl), 'yarn etl'),
     (Command('yarn ls', stderr=stderr_list), 'yarn list')])
 def test_get_new_command(command, new_command):
     assert get_new_command(command) == new_command

--- a/thefuck/rules/yarn_alias.py
+++ b/thefuck/rules/yarn_alias.py
@@ -9,6 +9,6 @@ def match(command):
 
 def get_new_command(command):
     broken = command.script_parts[1]
-    fix = re.findall(r'Did you mean `yarn ([^`]*)`', command.stderr)[0]
+    fix = re.findall(r'Did you mean [`"](?:yarn )?([^`"]*)[`"]', command.stderr)[0]
 
     return replace_argument(command.script, broken, fix)


### PR DESCRIPTION
For example, if an "etl" script is defined in package.json, it can be
run with `yarn etl`. However, if `yarn etil` is run, `yarn` will
suggest the correction. This change lets `thefuck` take advantage of
that:

    $ yarn etil
    yarn etil v0.21.3
    error Command "etil" not found. Did you mean "etl"?
    $ fuck
    yarn etl [enter/?/?/ctrl+c]