### PR TITLE
add rule for: yarn install [pkg]

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `workon_doesnt_exists` &ndash; fixes `virtualenvwrapper` env name os suggests to create new.
 * `yarn_alias` &ndash; fixes aliased `yarn` commands like `yarn ls`;
 * `yarn_command_not_found` &ndash; fixes misspelled `yarn` commands;
+* `yarn_command_replaced` &ndash; fixes replaced `yarn` commands;
 * `yarn_help` &ndash; makes it easier to open `yarn` documentation;
 
 Enabled by default only on specific platforms:

--- a/tests/rules/test_yarn_command_replaced.py
+++ b/tests/rules/test_yarn_command_replaced.py
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
 
-from io import BytesIO
 import pytest
 from tests.utils import Command
 from thefuck.rules.yarn_command_replaced import match, get_new_command

--- a/tests/rules/test_yarn_command_replaced.py
+++ b/tests/rules/test_yarn_command_replaced.py
@@ -30,4 +30,3 @@ def test_get_new_command(command, new_command):
     Command('yarn install')])
 def test_not_match(command):
     assert not match(command)
-

--- a/tests/rules/test_yarn_command_replaced.py
+++ b/tests/rules/test_yarn_command_replaced.py
@@ -1,0 +1,27 @@
+# -*- encoding: utf-8 -*-
+
+from io import BytesIO
+import pytest
+from tests.utils import Command
+from thefuck.rules.yarn_command_replaced import match, get_new_command
+
+
+stderr = '''
+error `install` has been replaced with `add` to add new dependencies. Run "yarn add {}" instead.
+'''.format
+
+
+@pytest.mark.parametrize('command', [
+    Command(script='yarn install asdklj', stderr=stderr('asdklj')),
+    Command(script='yarn install liuqowe', stderr=stderr('liuqowe')),
+    Command(script='yarn install zxmnc', stderr=stderr('zxmnc'))])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('yarn install asdklj', stderr=stderr('asdklj')), 'yarn add asdklj'),
+    (Command('yarn install iiuqowe', stderr=stderr('iiuqowe')), 'yarn add iiuqowe'),
+    (Command('yarn install zxmnc', stderr=stderr('zxmnc')), 'yarn add zxmnc')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_yarn_command_replaced.py
+++ b/tests/rules/test_yarn_command_replaced.py
@@ -24,3 +24,10 @@ def test_match(command):
     (Command('yarn install zxmnc', stderr=stderr('zxmnc')), 'yarn add zxmnc')])
 def test_get_new_command(command, new_command):
     assert get_new_command(command) == new_command
+
+
+@pytest.mark.parametrize('command', [
+    Command('yarn install')])
+def test_not_match(command):
+    assert not match(command)
+

--- a/thefuck/rules/yarn_command_replaced.py
+++ b/thefuck/rules/yarn_command_replaced.py
@@ -1,5 +1,5 @@
 import re
-from thefuck.utils import for_app;
+from thefuck.utils import for_app
 
 regex = re.compile(r'Run "(.*)" instead')
 

--- a/thefuck/rules/yarn_command_replaced.py
+++ b/thefuck/rules/yarn_command_replaced.py
@@ -3,9 +3,11 @@ from thefuck.utils import for_app
 
 regex = re.compile(r'Run "(.*)" instead')
 
+
 @for_app('yarn', at_least=1)
 def match(command):
     return regex.findall(command.stderr)
+
 
 def get_new_command(command):
     return regex.findall(command.stderr)[0]

--- a/thefuck/rules/yarn_command_replaced.py
+++ b/thefuck/rules/yarn_command_replaced.py
@@ -1,0 +1,12 @@
+import re
+from thefuck.utils import for_app;
+
+regex = re.compile(r'Run "(.*)" instead')
+
+@for_app('yarn', at_least=1)
+def match(command):
+    return regex.findall(command.stderr)
+
+
+def get_new_command(command):
+    return regex.findall(command.stderr)[0]

--- a/thefuck/rules/yarn_command_replaced.py
+++ b/thefuck/rules/yarn_command_replaced.py
@@ -7,6 +7,5 @@ regex = re.compile(r'Run "(.*)" instead')
 def match(command):
     return regex.findall(command.stderr)
 
-
 def get_new_command(command):
     return regex.findall(command.stderr)[0]


### PR DESCRIPTION
--- `install` has been replaced with `add` to add new dependencies. Run $0 instead.

https://github.com/yarnpkg/yarn/blob/6e9a9a6596ca8f177f68f6672a1ef4ff16705336/src/reporters/lang/en.js#L18