### PR TITLE
Fix heroku_not_command for new stderr format

### DIFF
--- a/tests/rules/test_heroku_not_command.py
+++ b/tests/rules/test_heroku_not_command.py
@@ -1,34 +1,31 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 from tests.utils import Command
 from thefuck.rules.heroku_not_command import match, get_new_command
 
 
-def suggest_stderr(cmd):
-    return ''' !    `{}` is not a heroku command.
-     !    Perhaps you meant `logs`, `pg`.
-     !    See `heroku help` for a list of available commands.'''.format(cmd)
+suggest_stderr = '''
+ ▸    log is not a heroku command.
+ ▸    Perhaps you meant logs?
+ ▸    Run heroku _ to run heroku logs.
+ ▸    Run heroku help for a list of available commands.'''
 
 
-no_suggest_stderr = ''' !    `aaaaa` is not a heroku command.
- !    See `heroku help` for a list of available commands.'''
-
-
-@pytest.mark.parametrize('cmd', ['log', 'pge'])
+@pytest.mark.parametrize('cmd', ['log'])
 def test_match(cmd):
     assert match(
-        Command('heroku {}'.format(cmd), stderr=suggest_stderr(cmd)))
+        Command('heroku {}'.format(cmd), stderr=suggest_stderr))
 
 
 @pytest.mark.parametrize('script, stderr', [
-    ('cat log', suggest_stderr('log')),
-    ('heroku aaa', no_suggest_stderr)])
+    ('cat log', suggest_stderr)])
 def test_not_match(script, stderr):
     assert not match(Command(script, stderr=stderr))
 
 
 @pytest.mark.parametrize('cmd, result', [
-    ('log', ['heroku logs', 'heroku pg']),
-    ('pge', ['heroku pg', 'heroku logs'])])
+    ('log', 'heroku logs')])
 def test_get_new_command(cmd, result):
-    command = Command('heroku {}'.format(cmd), stderr=suggest_stderr(cmd))
+    command = Command('heroku {}'.format(cmd), stderr=suggest_stderr)
     assert get_new_command(command) == result

--- a/thefuck/rules/heroku_not_command.py
+++ b/thefuck/rules/heroku_not_command.py
@@ -1,19 +1,11 @@
 import re
-from thefuck.utils import replace_command, for_app
+from thefuck.utils import for_app
 
 
 @for_app('heroku')
 def match(command):
-    return 'is not a heroku command' in command.stderr and \
-           'Perhaps you meant' in command.stderr
-
-
-def _get_suggests(stderr):
-    for line in stderr.split('\n'):
-        if 'Perhaps you meant' in line:
-            return re.findall(r'`([^`]+)`', line)
+    return 'Run heroku _ to run' in command.stderr
 
 
 def get_new_command(command):
-    wrong = re.findall(r'`(\w+)` is not a heroku command', command.stderr)[0]
-    return replace_command(command, wrong, _get_suggests(command.stderr))
+    return re.findall('Run heroku _ to run ([^.]*)', command.stderr)[0]


### PR DESCRIPTION
heroku updated its command suggestion formatting, so account for that.
For example:

    $ heroku log
     ▸    log is not a heroku command.
     ▸    Perhaps you meant logs?
     ▸    Run heroku _ to run heroku logs.
     ▸    Run heroku help for a list of available commands.
    $ fuck
    heroku logs [enter/↑/↓/ctrl+c]