### PR TITLE
Make alias autoconfiguration work in Bash

### DIFF
--- a/tests/test_not_configured.py
+++ b/tests/test_not_configured.py
@@ -77,7 +77,7 @@ def test_on_first_run(usage_tracker, shell_pid, logs):
 
 def test_on_run_after_other_commands(usage_tracker, shell_pid, shell, logs):
     shell_pid.return_value = 12
-    shell.get_history.return_value = ['fuck', 'ls']
+    shell.is_last_history_item_good.return_value = False
     _change_tracker(usage_tracker, 12)
     main()
     logs.how_to_configure_alias.assert_called_once()

--- a/thefuck/not_configured.py
+++ b/thefuck/not_configured.py
@@ -37,7 +37,7 @@ def _record_first_run():
 def _is_second_run():
     """Returns `True` when we know that `fuck` called second time."""
     tracker_path = _get_not_configured_usage_tracker_path()
-    if not tracker_path.exists() or not shell.get_history()[-1] == 'fuck':
+    if not tracker_path.exists() or not shell.is_last_history_item_good():
         return False
 
     current_pid = _get_shell_pid()

--- a/thefuck/shells/bash.py
+++ b/thefuck/shells/bash.py
@@ -46,6 +46,11 @@ class Bash(Generic):
     def _get_history_line(self, command_script):
         return u'{}\n'.format(command_script)
 
+    # bash unfortunately stores its recent history in ram only with
+    # no way to get the last history item of the calling bash instance
+    def is_last_history_item_good(self):
+        return True
+
     def how_to_configure(self):
         if os.path.join(os.path.expanduser('~'), '.bashrc'):
             config = '~/.bashrc'

--- a/thefuck/shells/generic.py
+++ b/thefuck/shells/generic.py
@@ -42,6 +42,9 @@ class Generic(object):
     def _get_history_line(self, command_script):
         return ''
 
+    def is_last_history_item_good(self):
+        return self.get_history()[-1] == 'fuck'
+
     @memoize
     def get_history(self):
         return list(self._get_history_lines())


### PR DESCRIPTION
Bash hides its command history from other processes until it exits,
unless the Bash builtin "history -a" is executed. The builtin only
writes the history of the Bash process it has been called in, so there
is no way to programmatically call it from a Python program.

Due to this, the only way to get autoconfiguration to work is to disable
the last history item check for Bash.