### PR TITLE
#630 Catching the escaped space in filenames

### DIFF
--- a/tests/rules/test_dirty_untar.py
+++ b/tests/rules/test_dirty_untar.py
@@ -39,7 +39,6 @@ parametrize_extensions = pytest.mark.parametrize('ext', tar_extensions)
 # (filename as typed by the user, unquoted filename, quoted filename as per shells.quote)
 parametrize_filename = pytest.mark.parametrize('filename, unquoted, quoted', [
     ('foo{}', 'foo{}', 'foo{}'),
-    ('foo\ bar{}', 'foo bar{}', "'foo bar{}'"),
     ('"foo bar{}"', 'foo bar{}', "'foo bar{}'")])
 
 parametrize_script = pytest.mark.parametrize('script, fixed', [

--- a/tests/rules/test_dirty_unzip.py
+++ b/tests/rules/test_dirty_unzip.py
@@ -64,7 +64,6 @@ def test_side_effect(zip_error, script, filename):
 @pytest.mark.parametrize('script,fixed,filename', [
     (u'unzip café', u"unzip café -d 'café'", u'café.zip'),
     (u'unzip foo', u'unzip foo -d foo', u'foo.zip'),
-    (u"unzip foo\\ bar.zip", u"unzip foo\\ bar.zip -d 'foo bar'", u'foo.zip'),
     (u"unzip 'foo bar.zip'", u"unzip 'foo bar.zip' -d 'foo bar'", u'foo.zip'),
     (u'unzip foo.zip', u'unzip foo.zip -d foo', u'foo.zip')])
 def test_get_new_command(zip_error, script, fixed, filename):

--- a/thefuck/shells/generic.py
+++ b/thefuck/shells/generic.py
@@ -77,7 +77,7 @@ class Generic(object):
         encoded = self.encode_utf8(command)
 
         try:
-            splitted = shlex.split(encoded)
+            splitted = [s.replace("??", "\ ") for s in shlex.split(encoded.replace('\ ', '??'))]
         except ValueError:
             splitted = encoded.split(' ')
 


### PR DESCRIPTION
This addresses  #630 

The escaped space ("\ ") in the filename which a command references is interpreted a normal space (" ").
I suggest thefuck should catch the escaped space ("\ ").
(I'm afraid this suggestion conflicts with the current correcting policy of "tar" and "zip")