### PR TITLE
fixes #692 : multiline PS1 breaking instant mode

### DIFF
--- a/thefuck/output_readers/read_log.py
+++ b/thefuck/output_readers/read_log.py
@@ -11,6 +11,10 @@ from .. import const, logs
 
 
 def _group_by_calls(log):
+    ps1 = os.environ['PS1']
+    ps1_newlines = ps1.count('\\n') + ps1.count('\n')
+    ps1_counter = 0
+
     script_line = None
     lines = []
     for line in log:
@@ -19,9 +23,15 @@ def _group_by_calls(log):
         except UnicodeDecodeError:
             continue
 
-        if const.USER_COMMAND_MARK in line:
-            if script_line:
+        if const.USER_COMMAND_MARK in line or ps1_counter > 0:
+            if script_line and ps1_counter == 0:
                 yield script_line, lines
+
+            if ps1_newlines > 0:
+                if ps1_counter <= 0:
+                    ps1_counter = ps1_newlines
+                else:
+                    ps1_counter -= 1
 
             script_line = line
             lines = [line]


### PR DESCRIPTION
When $PS1 is multi-lined, the instant mode breaks, this fix aims to resolve this issue
My PS1:
    \[\033[0;37m\]\342\224\214\342\224\200$([[ $? != 0 ]] && echo "[\[\033[0;31m\]\342\234\227[\033[0;37m\]]\342\224\200")[\[\033[0;33m\]\u\[\033[0;37m\]\[\033[0;37m\]]\342\224\200[\[\033[0;32m\]\w\[\033[0;37m\]]\n[\033[0;37m\]\342\224\224\342\224\200\342\224\200\342\225\274 \[\033[0m\]