### PR TITLE
Support parameters in PowerShell

### DIFF
--- a/thefuck/shells/powershell.py
+++ b/thefuck/shells/powershell.py
@@ -6,7 +6,7 @@ class Powershell(Generic):
         return 'function ' + alias_name + ' {\n' \
                '    $history = (Get-History -Count 1).CommandLine;\n' \
                '    if (-not [string]::IsNullOrWhiteSpace($history)) {\n' \
-               '        $fuck = $(thefuck $history);\n' \
+               '        $fuck = $(thefuck $args $history);\n' \
                '        if (-not [string]::IsNullOrWhiteSpace($fuck)) {\n' \
                '            if ($fuck.StartsWith("echo")) { $fuck = $fuck.Substring(5); }\n' \
                '            else { iex "$fuck"; }\n' \


### PR DESCRIPTION
Update the PowerShell alias so it passes thefuck parameters (e.g. `-y` or `-r`).