### PR TITLE
fixed #670

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `git_push_pull` &ndash; runs `git pull` when `push` was rejected;
 * `git_push_without_commits` &ndash; Creates an initial commit if you forget and only `git add .`, when setting up a new project;
 * `git_rebase_no_changes` &ndash; runs `git rebase --skip` instead of `git rebase --continue` when there are no changes;
+* `git_remote_delete` &ndash; replaces `git remote delete remote_name` with `git remote remove remote_name`
 * `git_rm_local_modifications` &ndash;  adds `-f` or `--cached` when you try to `rm` a locally modified file;
 * `git_rm_recursive` &ndash; adds `-r` when you try to `rm` a directory;
 * `git_rm_staged` &ndash;  adds `-f` or `--cached` when you try to `rm` a file with staged changes

--- a/tests/rules/test_git_remote_delete.py
+++ b/tests/rules/test_git_remote_delete.py
@@ -1,0 +1,21 @@
+import pytest
+from thefuck.rules.git_remote_delete import get_new_command, match
+from thefuck.types import Command
+
+
+def test_match():
+    assert match(Command('git remote delete foo', ''))
+
+
+@pytest.mark.parametrize('command', [
+    Command('git remote remove foo', ''),
+    Command('git remote add foo', ''),
+    Command('git commit', '')
+])
+def test_not_match(command):
+    assert not match(command)
+
+
+def test_get_new_command():
+    new_command = get_new_command(Command('git remote delete foo', ''))
+    assert new_command == 'git remote remove foo'

--- a/thefuck/rules/git_remote_delete.py
+++ b/thefuck/rules/git_remote_delete.py
@@ -1,0 +1,12 @@
+from thefuck.utils import replace_argument
+from thefuck.specific.git import git_support
+
+
+@git_support
+def match(command):
+    return "git remote delete" in command.script
+
+
+@git_support
+def get_new_command(command):
+    return replace_argument(command.script, "delete", "remove")

--- a/thefuck/rules/git_remote_delete.py
+++ b/thefuck/rules/git_remote_delete.py
@@ -10,3 +10,6 @@ def match(command):
 @git_support
 def get_new_command(command):
     return replace_argument(command.script, "delete", "remove")
+
+
+enabled_by_default = True


### PR DESCRIPTION
now automatically unfucks `git remote delete something` into `git remote remove something`
as per #670 