### PR TITLE
quick fix for #655

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `no_such_file` &ndash; creates missing directories with `mv` and `cp` commands;
 * `open` &ndash; either prepends `http://` to address passed to `open` or create a new file or directory and passes it to `open`;
 * `pip_unknown_command` &ndash; fixes wrong `pip` commands, for example `pip instatl/pip install`;
+* `php_s` &ndash; replaces `-s` by `-S` when trying to run a local php server;
 * `port_already_in_use` &ndash; kills process that bound port;
 * `python_command` &ndash; prepends `python` when you trying to run not executable/without `./` python script;
 * `python_execute` &ndash; appends missing `.py` when executing Python files;

--- a/tests/rules/test_php_s.py
+++ b/tests/rules/test_php_s.py
@@ -1,0 +1,20 @@
+import pytest
+from thefuck.rules.php_s import get_new_command, match
+from thefuck.types import Command
+
+
+def test_match():
+    assert match(Command('php -s localhost:8000', ''))
+
+
+@pytest.mark.parametrize('command', [
+    Command('php -S localhost:8000', ''),
+    Command('vim php -s', '')
+])
+def test_not_match(command):
+    assert not match(command)
+
+
+def test_get_new_command():
+    new_command = get_new_command(Command('php -s localhost:8000', ''))
+    assert new_command == 'php -S localhost:8000'

--- a/thefuck/rules/php_s.py
+++ b/thefuck/rules/php_s.py
@@ -1,9 +1,14 @@
-from thefuck.utils import replace_argument
+from thefuck.utils import replace_argument, for_app
 
 
+@for_app('php')
 def match(command):
     return "php -s" in command.script
 
 
 def get_new_command(command):
     return replace_argument(command.script, "-s", "-S")
+
+
+enabled_by_default = True
+requires_output = False

--- a/thefuck/rules/php_s.py
+++ b/thefuck/rules/php_s.py
@@ -1,0 +1,9 @@
+from thefuck.utils import replace_argument
+
+
+def match(command):
+    return "php -s" in command.script
+
+
+def get_new_command(command):
+    return replace_argument(command.script, "-s", "-S")

--- a/thefuck/rules/php_s.py
+++ b/thefuck/rules/php_s.py
@@ -10,5 +10,4 @@ def get_new_command(command):
     return replace_argument(command.script, "-s", "-S")
 
 
-enabled_by_default = True
 requires_output = False


### PR DESCRIPTION
Simply autocorrects `php -s` to `php -S` as per #655 