### PR TITLE
#N/A: Use curl to download get-pip.py on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
   - ps: "ls C:/Python*"
 
 install:
-  - ps: (new-object net.webclient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', 'C:/get-pip.py')
+  - "curl -fsS -o C:/get-pip.py https://bootstrap.pypa.io/get-pip.py"
   - "%PYTHON%/python.exe C:/get-pip.py"
   - "%PYTHON%/Scripts/pip.exe install -U setuptools"
   - "%PYTHON%/python.exe setup.py develop"


### PR DESCRIPTION
`curl` seems to be smarter than `net.webclient` when dealing with SSL.