### PR TITLE
Fix minor issues with git_remote_delete

### DIFF
--- a/tests/rules/test_git_remote_delete.py
+++ b/tests/rules/test_git_remote_delete.py
@@ -16,6 +16,9 @@ def test_not_match(command):
     assert not match(command)
 
 
-def test_get_new_command():
-    new_command = get_new_command(Command('git remote delete foo', ''))
-    assert new_command == 'git remote remove foo'
+@pytest.mark.parametrize('command, new_command', [
+    (Command('git remote delete foo', ''), 'git remote remove foo'),
+    (Command('git remote delete delete', ''), 'git remote remove delete'),
+])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/git_remote_delete.py
+++ b/thefuck/rules/git_remote_delete.py
@@ -5,7 +5,7 @@ from thefuck.specific.git import git_support
 
 @git_support
 def match(command):
-    return "git remote delete" in command.script
+    return "remote delete" in command.script
 
 
 @git_support

--- a/thefuck/rules/git_remote_delete.py
+++ b/thefuck/rules/git_remote_delete.py
@@ -1,4 +1,5 @@
-from thefuck.utils import replace_argument
+import re
+
 from thefuck.specific.git import git_support
 
 
@@ -9,4 +10,4 @@ def match(command):
 
 @git_support
 def get_new_command(command):
-    return replace_argument(command.script, "delete", "remove")
+    return re.sub(r"delete", "remove", command.script, 1)


### PR DESCRIPTION
* Do not require `git` in the script
* Replace the first single occurrence of `delete`
