### PR TITLE
#702: fix minor issues with `php_s` rule

### DIFF
--- a/tests/rules/test_php_s.py
+++ b/tests/rules/test_php_s.py
@@ -3,8 +3,12 @@ from thefuck.rules.php_s import get_new_command, match
 from thefuck.types import Command
 
 
-def test_match():
-    assert match(Command('php -s localhost:8000', ''))
+@pytest.mark.parametrize('command', [
+    Command('php -s localhost:8000', ''),
+    Command('php -t pub -s 0.0.0.0:8080', '')
+])
+def test_match(command):
+    assert match(command)
 
 
 @pytest.mark.parametrize('command', [
@@ -15,6 +19,9 @@ def test_not_match(command):
     assert not match(command)
 
 
-def test_get_new_command():
-    new_command = get_new_command(Command('php -s localhost:8000', ''))
-    assert new_command == 'php -S localhost:8000'
+@pytest.mark.parametrize('command, new_command', [
+    (Command('php -s localhost:8000', ''), 'php -S localhost:8000'),
+    (Command('php -t pub -s 0.0.0.0:8080', ''), 'php -t pub -S 0.0.0.0:8080')
+])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/php_s.py
+++ b/thefuck/rules/php_s.py
@@ -3,11 +3,8 @@ from thefuck.utils import replace_argument, for_app
 
 @for_app('php')
 def match(command):
-    return "php -s" in command.script
+    return " -s " in command.script
 
 
 def get_new_command(command):
     return replace_argument(command.script, "-s", "-S")
-
-
-requires_output = False


### PR DESCRIPTION
Unfortunately, I didn't catch these issues while reviewing #702.

After looking more closely at `php` options, `-S` requires additional arguments (&lt;address&gt;:&lt;port&gt;) and `-s` may produce output if used that way. So, matching ` -s ` seems to be better.

Also, `@for_app('php')` already asserts the presence of `php ` in the command script. Matching `php -s` prevents the rule from fixing commands like `php -t public -s 0.0.0.0:8080`.

Reviews are more than welcome 😃 