### PR TITLE
Bugfix: brew_update_formula.py

### DIFF
--- a/thefuck/rules/brew_update_formula.py
+++ b/thefuck/rules/brew_update_formula.py
@@ -5,7 +5,8 @@ from thefuck.utils import for_app
 def match(command):
     return ('update' in command.script
             and "Error: This command updates brew itself" in command.output
-            and "Use 'brew upgrade <formula>'" in command.output)
+            and "Use 'brew upgrade" in command.output
+            and "instead" in command.output)
 
 
 def get_new_command(command):


### PR DESCRIPTION
Sample command output is:

    Error: This command updates brew itself, and does not take formula names.
    Use 'brew upgrade thefuck' instead.

This will never match the previous `"Use 'brew upgrade <formula>'" in command.output` test.