### PR TITLE
git_flag_after_filename: Handle new error message

### DIFF
--- a/tests/rules/test_git_flag_after_filename.py
+++ b/tests/rules/test_git_flag_after_filename.py
@@ -8,10 +8,16 @@ command2 = Command('git log README.md -p CONTRIBUTING.md',
                    "fatal: bad flag '-p' used after filename")
 command3 = Command('git log -p README.md --name-only',
                    "fatal: bad flag '--name-only' used after filename")
+command4 = Command('git log README.md -p',
+                   "fatal: option '-p' must come before non-option arguments")
+command5 = Command('git log README.md -p CONTRIBUTING.md',
+                   "fatal: option '-p' must come before non-option arguments")
+command6 = Command('git log -p README.md --name-only',
+                   "fatal: option '--name-only' must come before non-option arguments")
 
 
 @pytest.mark.parametrize('command', [
-    command1, command2, command3])
+    command1, command2, command3, command4, command5, command6])
 def test_match(command):
     assert match(command)
 
@@ -26,6 +32,9 @@ def test_not_match(command):
 @pytest.mark.parametrize('command, result', [
     (command1, "git log -p README.md"),
     (command2, "git log -p README.md CONTRIBUTING.md"),
-    (command3, "git log -p --name-only README.md")])
+    (command3, "git log -p --name-only README.md"),
+    (command4, "git log -p README.md"),
+    (command5, "git log -p README.md CONTRIBUTING.md"),
+    (command6, "git log -p --name-only README.md")])
 def test_get_new_command(command, result):
     assert get_new_command(command) == result

--- a/thefuck/rules/git_flag_after_filename.py
+++ b/thefuck/rules/git_flag_after_filename.py
@@ -2,11 +2,12 @@ import re
 from thefuck.specific.git import git_support
 
 error_pattern = "fatal: bad flag '(.*?)' used after filename"
+error_pattern2 = "fatal: option '(.*?)' must come before non-option arguments"
 
 
 @git_support
 def match(command):
-    return re.search(error_pattern, command.output)
+    return re.search(error_pattern, command.output) or re.search(error_pattern2, command.output)
 
 
 @git_support

--- a/thefuck/rules/git_flag_after_filename.py
+++ b/thefuck/rules/git_flag_after_filename.py
@@ -14,7 +14,7 @@ def get_new_command(command):
     command_parts = command.script_parts[:]
 
     # find the bad flag
-    bad_flag = re.search(error_pattern, command.output).group(1)
+    bad_flag = match(command).group(1)
     bad_flag_index = command_parts.index(bad_flag)
 
     # find the filename


### PR DESCRIPTION
git version 2.15.0 has updated wording that we need to account for.

See https://github.com/git/git/commit/2a5aa826eec2eec64b4065f599ee7fb613a871ba
