### PR TITLE
Fix zsh alias

### DIFF
--- a/thefuck/shells/zsh.py
+++ b/thefuck/shells/zsh.py
@@ -13,14 +13,16 @@ class Zsh(Generic):
         # It is VERY important to have the variables declared WITHIN the function
         return '''
             {name} () {{
-                TF_HISTORY=$(fc -ln -10)
+                TF_PYTHONIOENCODING=$PYTHONIOENCODING;
+                export TF_ALIAS={name};
+                export TF_SHELL_ALIASES=$(alias);
+                export TF_HISTORY="$(fc -ln -10)";
+                export PYTHONIOENCODING=utf-8;
                 TF_CMD=$(
-                    TF_ALIAS={name}
-                    TF_SHELL_ALIASES=$(alias)
-                    TF_HISTORY=$TF_HISTORY
-                    PYTHONIOENCODING=utf-8
-                    thefuck {argument_placeholder} $*
+                    thefuck {argument_placeholder} $@
                 ) && eval $TF_CMD;
+                unset TF_HISTORY;
+                export PYTHONIOENCODING=$TF_PYTHONIOENCODING;
                 {alter_history}
             }}
         '''.format(


### PR DESCRIPTION
It would appear that the alias printed out in v3.24 has a variable scoping issue with the TF_HISTORY variable. The bash alias exports TF_HISTORY and does an unset on it afterwards, which seems to make it work fine. With the zsh alias in its current form, os.environ never sees the TF_HISTORY variable, and since $TF_PREVIOUS is no longer being fed into thefuck it just prints out the usage message. I have tested this change locally and it seems to make it work again.

This should resolve issue #725 