### PR TITLE
Add special error message for 'shit' alias

### DIFF
--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -70,8 +70,14 @@ def select_command(corrected_commands):
     try:
         selector = CommandSelector(corrected_commands)
     except NoRuleMatched:
-        logs.failed('No fucks given' if get_alias() == 'fuck'
-                    else 'Nothing found')
+        alias = get_alias()
+        if alias == 'fuck':
+            message = 'No fucks given'
+        elif alias == 'shit':
+            message = 'Don\'t give a shit'
+        else:
+            message = 'Nothing found'
+        logs.failed(message)
         return
 
     if not settings.require_confirmation:


### PR DESCRIPTION
I wanted to add a pattern for ways to make more funny aliases like No
fucks given and I figured shit was a fun one to start with.

If this is not wanted I totally understand and you can close the PR. I just thought it was a fun idea and it didn't take very long to clone and develop. I made sure all the tests passed with my changes.