### PR TITLE
Continue work started in #738

### DIFF
--- a/tests/shells/test_bash.py
+++ b/tests/shells/test_bash.py
@@ -51,6 +51,7 @@ class TestBash(object):
     def test_app_alias_variables_correctly_set(self, shell):
         alias = shell.app_alias('fuck')
         assert "fuck () {" in alias
+        assert 'TF_SHELL=bash' in alias
         assert "TF_ALIAS=fuck" in alias
         assert 'PYTHONIOENCODING=utf-8' in alias
         assert 'TF_SHELL_ALIASES=$(alias)' in alias

--- a/tests/shells/test_fish.py
+++ b/tests/shells/test_fish.py
@@ -71,6 +71,7 @@ class TestFish(object):
         assert 'function fuck' in shell.app_alias('fuck')
         assert 'function FUCK' in shell.app_alias('FUCK')
         assert 'thefuck' in shell.app_alias('fuck')
+        assert 'TF_SHELL=fish' in shell.app_alias('fuck')
         assert 'TF_ALIAS=fuck PYTHONIOENCODING' in shell.app_alias('fuck')
         assert 'PYTHONIOENCODING=utf-8 thefuck' in shell.app_alias('fuck')
 

--- a/tests/shells/test_tcsh.py
+++ b/tests/shells/test_tcsh.py
@@ -44,6 +44,7 @@ class TestTcsh(object):
                                        'll': 'ls -alF'}
 
     def test_app_alias(self, shell):
+        assert 'setenv TF_SHELL tcsh' in shell.app_alias('fuck')
         assert 'alias fuck' in shell.app_alias('fuck')
         assert 'alias FUCK' in shell.app_alias('FUCK')
         assert 'thefuck' in shell.app_alias('fuck')

--- a/tests/shells/test_zsh.py
+++ b/tests/shells/test_zsh.py
@@ -51,6 +51,7 @@ class TestZsh(object):
     def test_app_alias_variables_correctly_set(self, shell):
         alias = shell.app_alias('fuck')
         assert "fuck () {" in alias
+        assert 'TF_SHELL=zsh' in alias
         assert "TF_ALIAS=fuck" in alias
         assert 'PYTHONIOENCODING=utf-8' in alias
         assert 'TF_SHELL_ALIASES=$(alias)' in alias

--- a/thefuck/shells/fish.py
+++ b/thefuck/shells/fish.py
@@ -35,7 +35,7 @@ class Fish(Generic):
         # It is VERY important to have the variables declared WITHIN the alias
         return ('function {0} -d "Correct your previous console command"\n'
                 '  set -l fucked_up_command $history[1]\n'
-                '  env TF_ALIAS={0} PYTHONIOENCODING=utf-8'
+                '  env TF_SHELL=fish TF_ALIAS={0} PYTHONIOENCODING=utf-8'
                 ' thefuck $fucked_up_command | read -l unfucked_command\n'
                 '  if [ "$unfucked_command" != "" ]\n'
                 '    eval $unfucked_command\n{1}'

--- a/thefuck/shells/tcsh.py
+++ b/thefuck/shells/tcsh.py
@@ -7,7 +7,7 @@ from .generic import Generic
 
 class Tcsh(Generic):
     def app_alias(self, alias_name):
-        return ("alias {0} 'setenv TF_ALIAS {0} && "
+        return ("alias {0} 'setenv TF_SHELL tcsh && setenv TF_ALIAS {0} && "
                 "set fucked_cmd=`history -h 2 | head -n 1` && "
                 "eval `thefuck ${{fucked_cmd}}`'").format(alias_name)
 


### PR DESCRIPTION
Tests are failing because, [since 3.3.0](https://docs.pytest.org/en/latest/changelog.html#pytest-3-3-0-2017-11-23), pytest no longer supports Python 3.3. Please, stand by for another pull request that discusses ways to solve this.