### PR TITLE
Use pytest<3.3 to fix Python 3.3 tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pip
 flake8
-pytest
+pytest<3.3
 mock
 pytest-mock
 wheel


### PR DESCRIPTION
See https://github.com/nvbn/thefuck/pull/744 for context.

I'm personally okay with dropping Python 3.3 support,
but I'd like to at least get the tests working while we decide on that.