### PR TITLE
Drop Python 3.3 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ matrix:
       python: "3.4"
     - os: linux
       dist: trusty
-      python: "3.3"
-    - os: linux
-      dist: trusty
       python: "2.7"
     - os: osx
       env: FORMULA="python"

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Reading package lists... Done
 
 ## Requirements
 
-- python (3.3+)
+- python (3.4+)
 - pip
 - python-dev
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ build: false
 environment:
   matrix:
     - PYTHON: "C:/Python27"
-    - PYTHON: "C:/Python33"
     - PYTHON: "C:/Python34"
     - PYTHON: "C:/Python35"
     - PYTHON: "C:/Python36"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pip
 flake8
-pytest<3.3
+pytest
 mock
 pytest-mock
 wheel

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ if version < (2, 7):
     print('thefuck requires Python version 2.7 or later' +
           ' ({}.{} detected).'.format(*version))
     sys.exit(-1)
-elif (3, 0) < version < (3, 3):
-    print('thefuck requires Python version 3.3 or later' +
+elif (3, 0) < version < (3, 4):
+    print('thefuck requires Python version 3.4 or later' +
           ' ({}.{} detected).'.format(*version))
     sys.exit(-1)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36
+envlist = py27,py34,py35,py36
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
It's reached end-of-life, and our dependencies have started to drop it.
See https://github.com/nvbn/thefuck/pull/744#issuecomment-353244371