### PR TITLE
Add GitHub Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!-- If you have any issue with The Fuck, sorry about that, but we will do what we
+can to fix that. Actually, maybe we already have, so first thing to do is to
+update The Fuck and see if the bug is still there. -->
+
+<!-- If it is (sorry again), check if the problem has not already been reported and
+if not, just open an issue on [GitHub](https://github.com/nvbn/thefuck) with
+the following basic information: -->
+
+The output of `thefuck --version` (something like `The Fuck 3.1 using Python 3.5.0`):
+
+    FILL THIS IN
+
+Your shell and its version (`bash`, `zsh`, *Windows PowerShell*, etc.):
+
+    FILL THIS IN
+
+Your system (Debian 7, ArchLinux, Windows, etc.):
+
+<!-- FILL THIS IN -->
+
+How to reproduce the bug:
+
+    FILL THIS IN
+
+The output of The Fuck with `THEFUCK_DEBUG=true` exported (typically execute `export THEFUCK_DEBUG=true` in your shell before The Fuck):
+
+    FILL THIS IN
+
+If the bug only appears with a specific application, the output of that application and its version:
+
+    FILL THIS IN
+
+Anything else you think is relevant:
+
+<!-- FILL THIS IN -->
+
+<!-- It's only with enough information that we can do something to fix the problem. -->


### PR DESCRIPTION
This prompts the user to include relevant information when reporting
issues. I adapted it from the corresponding section of CONTRIBUTING.md

See here for details: https://github.com/blog/2111-issue-and-pull-request-templates