### PR TITLE
Suggest git checkout -b

### DIFF
--- a/tests/rules/test_git_checkout.py
+++ b/tests/rules/test_git_checkout.py
@@ -52,7 +52,7 @@ def test_get_branches(branches, branch_list, git_branch):
 @pytest.mark.parametrize('branches, command, new_command', [
     (b'',
      Command('git checkout unknown', did_not_match('unknown')),
-     'git branch unknown && git checkout unknown'),
+     'git checkout -b unknown'),
     (b'',
      Command('git commit unknown', did_not_match('unknown')),
      'git branch unknown && git commit unknown'),

--- a/thefuck/rules/git_checkout.py
+++ b/thefuck/rules/git_checkout.py
@@ -34,6 +34,8 @@ def get_new_command(command):
                                        fallback_to_first=False)
     if closest_branch:
         return replace_argument(command.script, missing_file, closest_branch)
+    elif command.script.startswith('git checkout'):
+        return replace_argument(command.script, 'checkout', 'checkout -b')
     else:
         return shell.and_('git branch {}', '{}').format(
             missing_file, command.script)

--- a/thefuck/rules/git_checkout.py
+++ b/thefuck/rules/git_checkout.py
@@ -34,7 +34,7 @@ def get_new_command(command):
                                        fallback_to_first=False)
     if closest_branch:
         return replace_argument(command.script, missing_file, closest_branch)
-    elif command.script.startswith('git checkout'):
+    elif command.script_parts[1] == 'checkout':
         return replace_argument(command.script, 'checkout', 'checkout -b')
     else:
         return shell.and_('git branch {}', '{}').format(


### PR DESCRIPTION
This should fix #632.

While playing with this fix, it wasn't obvious to me why git_checkout.py is suggesting changes for `git commit`; the suggestions don't seem sensible.