### PR TITLE
Move Developing instructions from README to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,6 @@ fixes, etc.
 
 # Developing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md)
-
 Install `The Fuck` for development:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,39 @@ It's only with enough information that we can do something to fix the problem.
 We gladly accept pull request on the [official
 repository](https://github.com/nvbn/thefuck) for new rules, new features, bug
 fixes, etc.
+
+# Developing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md)
+
+Install `The Fuck` for development:
+
+```bash
+pip install -r requirements.txt
+python setup.py develop
+```
+
+Run code style checks:
+
+```bash
+flake8
+```
+
+Run unit tests:
+
+```bash
+py.test
+```
+
+Run unit and functional tests (requires docker):
+
+```bash
+py.test --enable-functional
+```
+
+For sending package to pypi:
+
+```bash
+sudo apt-get install pandoc
+./release.py
+```

--- a/README.md
+++ b/README.md
@@ -443,37 +443,7 @@ eval $(thefuck --alias --enable-experimental-instant-mode)
 
 ## Developing
 
-Install `The Fuck` for development:
-
-```bash
-pip install -r requirements.txt
-python setup.py develop
-```
-
-Run code style checks:
-
-```bash
-flake8
-```
-
-Run unit tests:
-
-```bash
-py.test
-```
-
-Run unit and functional tests (requires docker):
-
-```bash
-py.test --enable-functional
-```
-
-For sending package to pypi:
-
-```bash
-sudo apt-get install pandoc
-./release.py
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## License MIT
 Project License can be found [here](LICENSE.md).


### PR DESCRIPTION
This makes them easier to find, especially for users opening issues or
pull requests. See here for more details:
https://help.github.com/articles/setting-guidelines-for-repository-contributors/