### PR TITLE
Add apt_upgrade rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Enabled by default only on specific platforms:
 * `apt_get_search` &ndash; changes trying to search using `apt-get` with searching using `apt-cache`;
 * `apt_invalid_operation` &ndash; fixes invalid `apt` and `apt-get` calls, like `apt-get isntall vim`;
 * `apt_list_upgradable` &ndash; helps you run `apt list --upgradable` after `apt update`;
+* `apt_upgrade` &ndash; helps you run `apt upgrade` after `apt list --upgradable`;
 * `brew_cask_dependency` &ndash; installs cask dependencies;
 * `brew_install` &ndash; fixes formula name for `brew install`;
 * `brew_link` &ndash; adds `--overwrite --dry-run` if linking fails;

--- a/tests/rules/test_apt_list_upgradable.py
+++ b/tests/rules/test_apt_list_upgradable.py
@@ -69,4 +69,7 @@ def test_not_match(command):
 
 def test_get_new_command():
     new_command = get_new_command(Command('sudo apt update', match_output))
+    assert new_command == 'sudo apt list --upgradable'
+
+    new_command = get_new_command(Command('apt update', match_output))
     assert new_command == 'apt list --upgradable'

--- a/tests/rules/test_apt_upgrade.py
+++ b/tests/rules/test_apt_upgrade.py
@@ -1,0 +1,36 @@
+import pytest
+from thefuck.rules.apt_upgrade import get_new_command, match
+from thefuck.types import Command
+
+match_output = '''
+Listing... Done
+heroku/stable 6.15.2-1 amd64 [upgradable from: 6.14.43-1]
+resolvconf/zesty-updates,zesty-updates 1.79ubuntu4.1 all [upgradable from: 1.79ubuntu4]
+squashfs-tools/zesty-updates 1:4.3-3ubuntu2.17.04.1 amd64 [upgradable from: 1:4.3-3ubuntu2]
+unattended-upgrades/zesty-updates,zesty-updates 0.93.1ubuntu2.4 all [upgradable from: 0.93.1ubuntu2.3]
+'''
+
+no_match_output = '''
+Listing... Done
+'''
+
+
+def test_match():
+    assert match(Command('apt list --upgradable', match_output))
+    assert match(Command('sudo apt list --upgradable', match_output))
+
+
+@pytest.mark.parametrize('command', [
+    Command('apt list --upgradable', no_match_output),
+    Command('sudo apt list --upgradable', no_match_output)
+])
+def test_not_match(command):
+    assert not match(command)
+
+
+def test_get_new_command():
+    new_command = get_new_command(Command('apt list --upgradable', match_output))
+    assert new_command == 'apt upgrade'
+
+    new_command = get_new_command(Command('sudo apt list --upgradable', match_output))
+    assert new_command == 'sudo apt upgrade'

--- a/thefuck/rules/apt_list_upgradable.py
+++ b/thefuck/rules/apt_list_upgradable.py
@@ -11,5 +11,6 @@ def match(command):
     return "Run 'apt list --upgradable' to see them." in command.output
 
 
+@sudo_support
 def get_new_command(command):
     return 'apt list --upgradable'

--- a/thefuck/rules/apt_upgrade.py
+++ b/thefuck/rules/apt_upgrade.py
@@ -1,0 +1,16 @@
+from thefuck.specific.apt import apt_available
+from thefuck.specific.sudo import sudo_support
+from thefuck.utils import for_app
+
+enabled_by_default = apt_available
+
+
+@sudo_support
+@for_app('apt')
+def match(command):
+    return command.script == "apt list --upgradable" and len(command.output.strip().split('\n')) > 1
+
+
+@sudo_support
+def get_new_command(command):
+    return 'apt upgrade'


### PR DESCRIPTION
This suggests `apt upgrade` after `apt list --upgradable` if there are
packages to upgrade. It pairs well with the `apt_list_upgradable` rule,
which suggests `apt list --upgradable` after `apt update` if there are
packages to upgrade.