### PR TITLE
762 git branch quotes

### DIFF
--- a/tests/rules/test_git_branch_exists.py
+++ b/tests/rules/test_git_branch_exists.py
@@ -4,8 +4,8 @@ from thefuck.types import Command
 
 
 @pytest.fixture
-def output(branch_name):
-    return "fatal: A branch named '{}' already exists.".format(branch_name)
+def output(src_branch_name):
+    return "fatal: A branch named '{}' already exists.".format(src_branch_name)
 
 
 @pytest.fixture
@@ -17,18 +17,25 @@ def new_command(branch_name):
         'git branch -D {0} && git checkout -b {0}', 'git checkout {0}']]
 
 
-@pytest.mark.parametrize('script, branch_name', [
-    ('git branch foo', 'foo'), ('git checkout bar', 'bar')])
+@pytest.mark.parametrize('script, src_branch_name, branch_name', [
+    ('git branch foo', 'foo', 'foo'),
+    ('git checkout bar', 'bar', 'bar'),
+    ('git checkout -b "let\s-push-this"', '"let\s-push-this"', '"let\s-push-this"')])
 def test_match(output, script, branch_name):
     assert match(Command(script, output))
 
 
-@pytest.mark.parametrize('script', ['git branch foo', 'git checkout bar'])
+@pytest.mark.parametrize('script', [
+    'git branch foo',
+    'git checkout bar',
+    'git checkout -b "let\s-push-this"'])
 def test_not_match(script):
     assert not match(Command(script, ''))
 
 
-@pytest.mark.parametrize('script, branch_name, ', [
-    ('git branch foo', 'foo'), ('git checkout bar', 'bar')])
-def test_get_new_command(output, new_command, script, branch_name):
+@pytest.mark.parametrize('script, src_branch_name, branch_name', [
+    ('git branch foo', 'foo', 'foo'),
+    ('git checkout bar', 'bar', 'bar'),
+    ('git checkout -b "let\'s-push-this"', "let's-push-this", "let\\'s-push-this")])
+def test_get_new_command(output, new_command, script, src_branch_name, branch_name):
     assert get_new_command(Command(script, output)) == new_command

--- a/tests/rules/test_git_branch_exists.py
+++ b/tests/rules/test_git_branch_exists.py
@@ -20,7 +20,7 @@ def new_command(branch_name):
 @pytest.mark.parametrize('script, src_branch_name, branch_name', [
     ('git branch foo', 'foo', 'foo'),
     ('git checkout bar', 'bar', 'bar'),
-    ('git checkout -b "let\s-push-this"', '"let\s-push-this"', '"let\s-push-this"')])
+    ('git checkout -b "let\'s-push-this"', '"let\'s-push-this"', '"let\'s-push-this"')])
 def test_match(output, script, branch_name):
     assert match(Command(script, output))
 
@@ -28,7 +28,7 @@ def test_match(output, script, branch_name):
 @pytest.mark.parametrize('script', [
     'git branch foo',
     'git checkout bar',
-    'git checkout -b "let\s-push-this"'])
+    'git checkout -b "let\'s-push-this"'])
 def test_not_match(script):
     assert not match(Command(script, ''))
 

--- a/thefuck/rules/git_branch_exists.py
+++ b/thefuck/rules/git_branch_exists.py
@@ -7,14 +7,14 @@ from thefuck.utils import eager
 @git_support
 def match(command):
     return ("fatal: A branch named '" in command.output
-            and " already exists." in command.output)
+            and "' already exists." in command.output)
 
 
 @git_support
 @eager
 def get_new_command(command):
     branch_name = re.findall(
-        r"fatal: A branch named '([^']*)' already exists.", command.output)[0]
+        r"fatal: A branch named '(.+)' already exists.", command.output)[0].replace("'", r"\'")
     new_command_templates = [['git branch -d {0}', 'git branch {0}'],
                              ['git branch -d {0}', 'git checkout -b {0}'],
                              ['git branch -D {0}', 'git branch {0}'],

--- a/thefuck/rules/git_branch_exists.py
+++ b/thefuck/rules/git_branch_exists.py
@@ -14,7 +14,8 @@ def match(command):
 @eager
 def get_new_command(command):
     branch_name = re.findall(
-        r"fatal: A branch named '(.+)' already exists.", command.output)[0].replace("'", r"\'")
+        r"fatal: A branch named '(.+)' already exists.", command.output)[0]
+    branch_name = branch_name.replace("'", r"\'")
     new_command_templates = [['git branch -d {0}', 'git branch {0}'],
                              ['git branch -d {0}', 'git checkout -b {0}'],
                              ['git branch -D {0}', 'git branch {0}'],


### PR DESCRIPTION
This fixes #762.

Once again, `shell.quote` does not seem appropriate - since it creates a quoted string which neither the shell nor git can comprehend.

I wonder whether a new function is required to translate these instances, since I suspect git also allows for double-quotes (and probably other bizarre characters) in branch names.