### PR TITLE
Add `git_merge_unrelated` rule for `git merge --allow-unrelated-histories`

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `git_flag_after_filename` &ndash; fixes `fatal: bad flag '...' after filename`
 * `git_help_aliased` &ndash; fixes `git help <alias>` commands replacing <alias> with the aliased command;
 * `git_merge` &ndash; adds remote to branch names;
+* `git_merge_unrelated` &ndash; adds `--allow-unrelated-histories` when required
 * `git_not_command` &ndash; fixes wrong git commands like `git brnch`;
 * `git_pull` &ndash; sets upstream before executing previous `git pull`;
 * `git_pull_clone` &ndash; clones instead of pulling when the repo does not exist;

--- a/tests/rules/test_git_merge_unrelated.py
+++ b/tests/rules/test_git_merge_unrelated.py
@@ -1,0 +1,25 @@
+import pytest
+from thefuck.rules.git_merge_unrelated import match, get_new_command
+from thefuck.types import Command
+
+
+@pytest.fixture
+def output():
+    return 'fatal: refusing to merge unrelated histories'
+
+
+def test_match(output):
+    assert match(Command('git merge test', output))
+    assert not match(Command('git merge master', ''))
+    assert not match(Command('ls', output))
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('git merge local', output()),
+     'git merge local --allow-unrelated-histories'),
+    (Command('git merge -m "test" local', output()),
+     'git merge -m "test" local --allow-unrelated-histories'),
+    (Command('git merge -m "test local" local', output()),
+     'git merge -m "test local" local --allow-unrelated-histories')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/git_merge_unrelated.py
+++ b/thefuck/rules/git_merge_unrelated.py
@@ -1,4 +1,3 @@
-import re
 from thefuck.specific.git import git_support
 
 

--- a/thefuck/rules/git_merge_unrelated.py
+++ b/thefuck/rules/git_merge_unrelated.py
@@ -1,0 +1,13 @@
+import re
+from thefuck.specific.git import git_support
+
+
+@git_support
+def match(command):
+    return ('merge' in command.script
+            and 'fatal: refusing to merge unrelated histories' in command.output)
+
+
+@git_support
+def get_new_command(command):
+    return command.script + ' --allow-unrelated-histories'


### PR DESCRIPTION
From https://git-scm.com/docs/merge-options#merge-options---allow-unrelated-histories

> By default, `git merge` command refuses to merge histories that do not
share a common ancestor. This option can be used to override this safety
when merging histories of two projects that started their lives
independently.