### PR TITLE
fix $PATH problem when using cmder(git-bash) on windows.

### DIFF
--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -4,6 +4,7 @@ import pickle
 import re
 import shelve
 import six
+import sys
 from decorator import decorator
 from difflib import get_close_matches
 from functools import wraps
@@ -108,15 +109,22 @@ def get_all_executables():
 
     tf_alias = get_alias()
     tf_entry_points = ['thefuck', 'fuck']
-
+    
+    win32 = sys.platform.startswith('win')
+    paths = os.environ.get('PATH', '')
+    paths = paths.split(';') if win32 else paths.split(':')
+    
     bins = [exe.name.decode('utf8') if six.PY2 else exe.name
-            for path in os.environ.get('PATH', '').split(':')
+            for path in paths
             for exe in _safe(lambda: list(Path(path).iterdir()), [])
             if not _safe(exe.is_dir, True)
             and exe.name not in tf_entry_points]
     aliases = [alias.decode('utf8') if six.PY2 else alias
                for alias in shell.get_aliases() if alias != tf_alias]
-
+    
+    if win32:
+        bins += [exe[:-4] for exe in bins if exe.endswith(".exe")]
+    
     return bins + aliases
 
 


### PR DESCRIPTION
thefuck is a awesome tools mainly for linux shell. And in windows,powershell is supported too.
But when I try to using it in the cmder's bash(powerfull linux-like shell in windows), 
the code section in ```thefuck/utils.py``` didn't work well:
```
@memoize
def get_all_executables():
    ...

    bins = [exe.name.decode('utf8') if six.PY2 else exe.name
            for path in os.environ.get('PATH', '').split(':')
            for exe in _safe(lambda: list(Path(path).iterdir()), [])
            if not _safe(exe.is_dir, True)
            and exe.name not in tf_entry_points]
    
    ...
```
This is due to the python i installed is exactly the windows binary.In the cmder shell, you can call window executable like python and it will automatically parse the PATH to linux format, while, the python interpreter does not. ```os.environ.get("PATH", "")``` returns PATH still in windows format, like:
```
'E:\\Anaconda3\\Library\\bin;C:\\Users\\BurdenBear\\bin;'
```
So i add some code to check if the python interpreter is windows binary by call  ```sys.platform == "win32"```. If so, parse the PATH in windows format , and then replace the .exe suffix in bins found in path.

---
Before:
```
$ puthon
bash: puthon: command not found
$fuck
No fucks given
```
After:
```
$ puthon
bash: puthon: command not found
$ fuck
python [enter/↑/↓/ctrl+c]
```
---
I know this may be a devious and strange use case,but as far as i know, these are many people using cmder on windows like me, this may help them.
Thanks for review it.