### PR TITLE
Absolute path feature for cd_correction

### DIFF
--- a/tests/functional/test_cd_correction.py
+++ b/tests/functional/test_cd_correction.py
@@ -1,0 +1,40 @@
+import pytest
+
+dockerfile = u'''
+FROM python:3
+RUN adduser --disabled-password --gecos '' test
+WORKDIR /src
+USER test
+RUN echo 'eval $(thefuck --alias)' > /home/test/.bashrc
+RUN echo > /home/test/.bash_history
+RUN mkdir -p /home/test/some/random/folder
+RUN mkdir -p /home/test/another/random/folder
+USER root
+'''
+
+
+def plot(proc, TIMEOUT):
+    proc.sendline(u'cd /home/test/some/random')
+    proc.sendline(u'fuck')
+    assert proc.expect([TIMEOUT, u'No fucks given'])
+    proc.sendline(u'cd flder')
+    proc.sendline(u'fuck')
+    assert proc.expect([TIMEOUT, u'cd "/home/test/some/random/folder"'])
+    proc.send('\n')
+    proc.sendline(u'pwd')
+    assert proc.expect([TIMEOUT, u'/home/test/some/random/folder'])
+    proc.sendline(u'cd /home/test/another/randm/folder/')
+    proc.sendline(u'fuck')
+    assert proc.expect([TIMEOUT, u'cd "/home/test/another/random/folder"'])
+    proc.send('\n')
+    proc.sendline(u'pwd')
+    assert proc.expect([TIMEOUT, u'/home/test/another/random/folder'])
+
+
+@pytest.mark.functional
+def test_performance(spawnu, TIMEOUT, benchmark):
+    proc = spawnu(u'thefuck/python3-cd_correction-functional',
+                  dockerfile, u'bash')
+    proc.sendline(u'pip install /src')
+    proc.sendline(u'su test')
+    assert benchmark(plot, proc, TIMEOUT) is None

--- a/tests/rules/test_cd_correction.py
+++ b/tests/rules/test_cd_correction.py
@@ -1,5 +1,5 @@
 import pytest
-from thefuck.rules.cd_mkdir import match, get_new_command
+from thefuck.rules.cd_correction import match, get_new_command
 from thefuck.types import Command
 
 
@@ -19,8 +19,5 @@ def test_not_match(command):
     assert not match(command)
 
 
-@pytest.mark.parametrize('command, new_command', [
-    (Command('cd foo', ''), 'mkdir -p foo && cd foo'),
-    (Command('cd foo/bar/baz', ''), 'mkdir -p foo/bar/baz && cd foo/bar/baz')])
-def test_get_new_command(command, new_command):
-    assert get_new_command(command) == new_command
+# Note that get_new_command uses local filesystem, so not testing it here.
+# Instead, see the functional test `functional.test_cd_correction`

--- a/tests/rules/test_cd_correction.py
+++ b/tests/rules/test_cd_correction.py
@@ -1,5 +1,5 @@
 import pytest
-from thefuck.rules.cd_correction import match, get_new_command
+from thefuck.rules.cd_correction import match
 from thefuck.types import Command
 
 

--- a/thefuck/rules/cd_correction.py
+++ b/thefuck/rules/cd_correction.py
@@ -21,9 +21,12 @@ def _get_sub_dirs(parent):
 @for_app('cd')
 def match(command):
     """Match function copied from cd_mkdir.py"""
-    return (command.script.startswith('cd ')
-            and ('no such file or directory' in command.output.lower()
-                 or 'cd: can\'t cd to' in command.output.lower()))
+    return (
+        command.script.startswith('cd ') and any((
+            'no such file or directory' in command.output.lower(),
+            'cd: can\'t cd to' in command.output.lower(),
+            'does not exist' in command.output.lower()
+        )))
 
 
 @sudo_support

--- a/thefuck/rules/cd_correction.py
+++ b/thefuck/rules/cd_correction.py
@@ -37,7 +37,11 @@ def get_new_command(command):
     dest = command.script_parts[1].split(os.sep)
     if dest[-1] == '':
         dest = dest[:-1]
-    if six.PY2:
+
+    if dest[0] == '':
+        cwd = os.sep
+        dest = dest[1:]
+    elif six.PY2:
         cwd = os.getcwdu()
     else:
         cwd = os.getcwd()

--- a/thefuck/rules/cd_mkdir.py
+++ b/thefuck/rules/cd_mkdir.py
@@ -8,10 +8,11 @@ from thefuck.shells import shell
 @for_app('cd')
 def match(command):
     return (
-        'no such file or directory' in command.output.lower()
-        or 'cd: can\'t cd to' in command.output.lower()
-        or 'the system cannot find the path specified.' in command.output.lower()
-    )
+        command.script.startswith('cd ') and any((
+            'no such file or directory' in command.output.lower(),
+            'cd: can\'t cd to' in command.output.lower(),
+            'does not exist' in command.output.lower()
+        )))
 
 
 @sudo_support


### PR DESCRIPTION
This is motivated by #784 

According to my understandment of the code, this should fix the scenario of "`dest` starts with `/`". However, I had some problems with local tests and still I am not sure if I am overlooking some corner case.