### PR TITLE
Added a rule to delete sudo for pacaur.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Magnificent app which corrects your previous console command,
 inspired by a [@liamosaur](https://twitter.com/liamosaur/)
 [tweet](https://twitter.com/liamosaur/status/506975850596536320).
 
-The Fuck is too slow? [Try experimental instant mode!](#experimental-instant-mode) 
+The Fuck is too slow? [Try experimental instant mode!](#experimental-instant-mode)
 
 [![gif with examples][examples-link]][examples-link]
 
@@ -278,6 +278,7 @@ using the matched rule and runs it. Rules enabled by default are as follows:
 * `tsuru_not_command` &ndash; fixes wrong `tsuru` commands like `tsuru shell`;
 * `tmux` &ndash; fixes `tmux` commands;
 * `unknown_command` &ndash; fixes hadoop hdfs-style "unknown command", for example adds missing '-' to the command on `hdfs dfs ls`;
+* `unsudo` &ndash; removes `sudo` from previous command if a process refuses to run on super user privilege.
 * `vagrant_up` &ndash; starts up the vagrant instance;
 * `whois` &ndash; fixes `whois` command;
 * `workon_doesnt_exists` &ndash; fixes `virtualenvwrapper` env name os suggests to create new.

--- a/tests/rules/test_unsudo.py
+++ b/tests/rules/test_unsudo.py
@@ -1,0 +1,22 @@
+import pytest
+from thefuck.rules.unsudo import match, get_new_command
+from thefuck.types import Command
+
+
+@pytest.mark.parametrize('output', [
+    'you cannot perform this operation as root'])
+def test_match(output):
+    assert match(Command('sudo ls', output))
+
+
+def test_not_match():
+    assert not match(Command('', ''))
+    assert not match(Command('sudo ls', 'Permission denied'))
+    assert not match(Command('ls', 'you cannot perform this operation as root'))
+
+
+@pytest.mark.parametrize('before, after', [
+    ('sudo ls', 'ls'),
+    ('sudo pacaur -S helloworld', 'pacaur -S helloworld')])
+def test_get_new_command(before, after):
+    assert get_new_command(Command(before, '')) == after

--- a/thefuck/rules/unsudo.py
+++ b/thefuck/rules/unsudo.py
@@ -1,0 +1,15 @@
+patterns = ['you cannot perform this operation as root']
+
+
+def match(command):
+    if command.script_parts and command.script_parts[0] != 'sudo':
+        return False
+
+    for pattern in patterns:
+        if pattern in command.output.lower():
+            return True
+    return False
+
+
+def get_new_command(command):
+    return ' '.join(command.script_parts[1:])


### PR DESCRIPTION
Thank you for this great tool. I really enjoy typing `fuck` everyday.
I found a common pattern of mistake I make and added a corresponding rule to `thefuck`. I wonder if this change can be pulled into the main repository. Here is a sample command I tested on my computer.

```
$ sudo pacaur -S tmuxinator
:: you cannot perform this operation as root
 
$ fuck
pacaur -S tmuxinator [enter/↑/↓/ctrl+c]
:: Package tmuxinator not found in repositories, trying AUR...
:: resolving dependencies...
:: looking for inter-conflicts...
:: ruby-erubis-2.7.0-1 has been flagged out of date on Thu 08 Feb 2018 01:40:16 PM PST

AUR Packages  (2) ruby-erubis-2.7.0-1  tmuxinator-0.10.1-2  
Repo Packages (1) ruby-thor-0.20.0-2  

Repo Download Size:   0.09 MiB
Repo Installed Size:  0.36 MiB

:: Proceed with installation? [Y/n]
``` 

Thank you for your time reviewing this.

 - JunYoung Gwak