### PR TITLE
allow for the mispelling of git and the command

### DIFF
--- a/thefuck/fix_git_and_command_misspell.py
+++ b/thefuck/fix_git_and_command_misspell.py
@@ -1,0 +1,16 @@
+from difflib import get_close_matches
+
+
+def fix_git_command(git_command):
+    git_possible = ['clone', 'init', 'add', 'mv', 'reset', 'rm', 'bisect',
+                    'grep', 'log', 'show', 'status', 'branch', 'checkout',
+                    'commit', 'diff', 'merge', 'rebase', 'tag', 'fetch',
+                    'pull', 'push']
+    if git_command not in git_possible[0]:
+        close_match = get_close_matches(git_command, git_possible)
+        if len(close_match) > 0:
+             return close_match[0]
+        else:
+            return git_command
+    else:
+        return git_command

--- a/thefuck/rules/no_command.py
+++ b/thefuck/rules/no_command.py
@@ -2,6 +2,7 @@ from difflib import get_close_matches
 from thefuck.utils import get_all_executables, \
     get_valid_history_without_current, get_closest, which
 from thefuck.specific.sudo import sudo_support
+from thefuck.fix_git_and_command_misspell import fix_git_command
 
 
 @sudo_support
@@ -34,6 +35,9 @@ def get_new_command(command):
     new_cmds += [cmd for cmd in get_close_matches(old_command,
                                                   get_all_executables())
                  if cmd not in new_cmds]
+
+    if 'git' in new_cmds and len(command.script_parts) > 1:
+        command.script_parts[1] = fix_git_command(command.script_parts[1])
 
     return [' '.join([new_command] + command.script_parts[1:])
             for new_command in new_cmds]


### PR DESCRIPTION
What we essentially did was intercept when we found that the user was trying to make a git request. We then checked if there were any more commands after git. If there were we checked if they were misspelled. If they were we compared them to other git command words and chose the one with the highest match score. resolve #795 