### PR TITLE
fixed powershell coloring Bug #772

### DIFF
--- a/thefuck/shells/powershell.py
+++ b/thefuck/shells/powershell.py
@@ -12,6 +12,7 @@ class Powershell(Generic):
                '            else { iex "$fuck"; }\n' \
                '        }\n' \
                '    }\n' \
+               '    [Console]::ResetColor() \n' \
                '}\n'
 
     def and_(self, *commands):


### PR DESCRIPTION
The issue was that running theFuck would change the color of the powershell. This was more of a powershell issue than an issue of theFuck. However, by running "[Console]::ResetColor()" at the end of the powershell command to run theFuck we were able to remedy the issue. #772 