### PR TITLE
Support aliases with equal sign

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pip
 flake8
 pytest
 mock

--- a/tests/shells/test_fish.py
+++ b/tests/shells/test_fish.py
@@ -16,7 +16,8 @@ class TestFish(object):
         mock.return_value.stdout.read.side_effect = [(
             b'cd\nfish_config\nfuck\nfunced\nfuncsave\ngrep\nhistory\nll\nls\n'
             b'man\nmath\npopd\npushd\nruby'),
-            b'alias fish_key_reader /usr/bin/fish_key_reader\nalias g git']
+            (b'alias fish_key_reader /usr/bin/fish_key_reader\nalias g git\n'
+             b'alias alias_with_equal_sign=echo\ninvalid_alias'), b'func1\nfunc2', b'']
         return mock
 
     @pytest.mark.parametrize('key, value', [
@@ -69,7 +70,9 @@ class TestFish(object):
                                        'pushd': 'pushd',
                                        'ruby': 'ruby',
                                        'g': 'git',
-                                       'fish_key_reader': '/usr/bin/fish_key_reader'}
+                                       'fish_key_reader': '/usr/bin/fish_key_reader',
+                                       'alias_with_equal_sign': 'echo'}
+        assert shell.get_aliases() == {'func1': 'func1', 'func2': 'func2'}
 
     def test_app_alias(self, shell):
         assert 'function fuck' in shell.app_alias('fuck')

--- a/thefuck/shells/fish.py
+++ b/thefuck/shells/fish.py
@@ -20,9 +20,17 @@ def _get_functions(overridden):
 def _get_aliases(overridden):
     aliases = {}
     proc = Popen(['fish', '-ic', 'alias'], stdout=PIPE, stderr=DEVNULL)
-    alias_out = proc.stdout.read().decode('utf-8').strip().split('\n')
-    for alias in alias_out:
-        name, value = alias.replace('alias ', '', 1).split(' ', 1)
+    alias_out = proc.stdout.read().decode('utf-8').strip()
+    if not alias_out:
+        return aliases
+    for alias in alias_out.split('\n'):
+        for separator in (' ', '='):
+            split_alias = alias.replace('alias ', '', 1).split(separator, 1)
+            if len(split_alias) == 2:
+                name, value = split_alias
+                break
+        else:
+            continue
         if name not in overridden:
             aliases[name] = value
     return aliases


### PR DESCRIPTION
Support aliases declared like the following:

```fish
alias fish_key_reader=/usr/local/bin/fish_key_reader
```

This PR fixes #807.