### PR TITLE
Add new `long_form_help` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ following rules are enabled by default:
 * `java` &ndash; removes `.java` extension when running Java programs;
 * `javac` &ndash; appends missing `.java` when compiling Java files;
 * `lein_not_task` &ndash; fixes wrong `lein` tasks like `lein rpl`;
+* `long_form_help` &ndash; changes `-h` to `--help` when the short form version is not supported
 * `ln_no_hard_link` &ndash; catches hard link creation on directories, suggest symbolic link;
 * `ln_s_order` &ndash; fixes `ln -s` arguments order;
 * `ls_all` &ndash; adds `-A` to `ls` when output is empty;

--- a/tests/rules/test_long_form_help.py
+++ b/tests/rules/test_long_form_help.py
@@ -1,0 +1,22 @@
+import pytest
+from thefuck.rules.long_form_help import match, get_new_command
+from thefuck.types import Command
+
+
+@pytest.mark.parametrize('output', [
+    'Try \'grep --help\' for more information.'])
+def test_match(output):
+    assert match(Command('grep -h', output))
+
+
+def test_not_match():
+    assert not match(Command('', ''))
+
+
+@pytest.mark.parametrize('before, after', [
+    ('grep -h', 'grep --help'),
+    ('tar -h', 'tar --help'),
+    ('docker run -h', 'docker run --help'),
+    ('cut -h', 'cut --help')])
+def test_get_new_command(before, after):
+    assert get_new_command(Command(before, '')) == after

--- a/thefuck/rules/long_form_help.py
+++ b/thefuck/rules/long_form_help.py
@@ -1,0 +1,27 @@
+from thefuck.utils import replace_argument
+import re
+
+# regex to match a suggested help command from the tool output
+helpRegex = r"(?:Run|Try) '([^']+)'(?: or '[^']+')? for (?:details|more information)."
+
+
+def match(command):
+    if re.search(helpRegex, command.output, re.I) is not None:
+        return True
+
+    if '--help' in command.output:
+        return True
+
+    return False
+
+
+def get_new_command(command):
+    if re.search(helpRegex, command.output) is not None:
+        matchObj = re.search(helpRegex, command.output, re.I)
+        return matchObj.group(1)
+
+    return replace_argument(command.script, '-h', '--help')
+
+
+enabled_by_default = True
+priority = 5000


### PR DESCRIPTION
Adds a new rule to help deal with programs that don't understand the `-h` short form of `--help`. Also attempts to determine the proper help command suggested by the tool (such as with `go build -h` -> `go help build`). 

I don't work with Python much and this is my first time using pytest so I am open to suggestions.
