### PR TITLE
#N/A: Remove `pip` from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pip
 flake8
 pytest
 mock


### PR DESCRIPTION
`pip` is already a prerequisite. Removing it from `requirements.txt` actually his fixes the AppVeyor build, as well as Travis one.