### PR TITLE
git_push: Handle command containing force argument

### DIFF
--- a/tests/rules/test_git_push.py
+++ b/tests/rules/test_git_push.py
@@ -66,6 +66,10 @@ def test_not_match(output, script, branch_name):
     ('git -c test=test push --quiet origin', 'master',
      'git -c test=test push --set-upstream origin master --quiet'),
     ('git push', "test's",
-     "git push --set-upstream origin test\\'s")])
+     "git push --set-upstream origin test\\'s"),
+    ('git push --force', 'master',
+     'git push --set-upstream origin master --force'),
+    ('git push --force-with-lease', 'master',
+     'git push --set-upstream origin master --force-with-lease')])
 def test_get_new_command(output, script, branch_name, new_command):
     assert get_new_command(Command(script, output)) == new_command

--- a/thefuck/rules/git_push.py
+++ b/thefuck/rules/git_push.py
@@ -39,6 +39,6 @@ def get_new_command(command):
         while len(command_parts) > push_idx and command_parts[len(command_parts) - 1][0] != '-':
             command_parts.pop(len(command_parts) - 1)
 
-    arguments = re.findall(r'git push (.*)', command.output)[0].replace("'", r"\'").strip()
+    arguments = re.findall(r'git push (.*)', command.output)[-1].replace("'", r"\'").strip()
     return replace_argument(" ".join(command_parts), 'push',
                             'push {}'.format(arguments))


### PR DESCRIPTION
```
git push --force
fatal: The current branch [branch_name] has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin [branch_name]
```

Before:
`git push --force --force`
After:
`git push --set-upstream origin master --force`

command.output:
```
03:32:30.280527 git.c:344               trace: built-in: git push --force
fatal: The current branch [branch_name] has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin [branch_name]
```
Regex stopped at the first `git push` with `--force` argument.
Not sure why the command is part of the output though?