### PR TITLE
Fix get_key on Windows

### DIFF
--- a/thefuck/system/win32.py
+++ b/thefuck/system/win32.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import msvcrt
 import win_unicode_console
 from .. import const
@@ -12,20 +11,18 @@ def init_output():
 
 
 def get_key():
-    ch = msvcrt.getch()
-    if ch in (b'\x00', b'\xe0'):  # arrow or function key prefix?
-        ch = msvcrt.getch()  # second call returns the actual key code
+    ch = msvcrt.getwch()
+    if ch in ('\x00', '\xe0'):  # arrow or function key prefix?
+        ch = msvcrt.getwch()  # second call returns the actual key code
 
     if ch in const.KEY_MAPPING:
         return const.KEY_MAPPING[ch]
-    if ch == b'H':
+    if ch == 'H':
         return const.KEY_UP
-    if ch == b'P':
+    if ch == 'P':
         return const.KEY_DOWN
 
-    encoding = (sys.stdout.encoding
-                or os.environ.get('PYTHONIOENCODING', 'utf-8'))
-    return ch.decode(encoding)
+    return ch
 
 
 def open_command(arg):


### PR DESCRIPTION
PR #711 moved the arrow and cancel key codes to `const.py`. However, the move also changed the codes from byte arrays to strings, which broke the use of `msvcrt.getch()` for Windows. This resulted in PowerShell users being unable to cancel with `Ctrl+C` (pressing `q` still worked).

The fix is to use `msvcrt.getwch()` so the key is a Unicode character, matching the Unix implementation.