### PR TITLE
Avoid masking shell return values in Zsh.app_alias

### DIFF
--- a/thefuck/shells/zsh.py
+++ b/thefuck/shells/zsh.py
@@ -16,8 +16,10 @@ class Zsh(Generic):
                 TF_PYTHONIOENCODING=$PYTHONIOENCODING;
                 export TF_SHELL=zsh;
                 export TF_ALIAS={name};
-                export TF_SHELL_ALIASES=$(alias);
-                export TF_HISTORY="$(fc -ln -10)";
+                TF_SHELL_ALIASES=$(alias);
+                export TF_SHELL_ALIASES;
+                TF_HISTORY="$(fc -ln -10)";
+                export TF_HISTORY;
                 export PYTHONIOENCODING=utf-8;
                 TF_CMD=$(
                     thefuck {argument_placeholder} $@


### PR DESCRIPTION
I discovered that a common shell script issue (https://github.com/koalaman/shellcheck/wiki/SC2155) is present in the script returned by `Zsh.app_alias()`, amongst other `app_alias` methods in thefuck.

In the case of the zsh `app_alias()` script, this common issue is causing the script to error on some versions of Mac OS X. This is  reported in #718.

Unmasking the value of `TF_SHELL_ALIASES` fixes the errors in Mac OS X, but I also unmasked `TF_HISTORY` for consistency.