### PR TITLE
adding zsh's autocorrect notice to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ then reading the log.
 
 [![gif with instant mode][instant-mode-gif-link]][instant-mode-gif-link]
 
-Currently, instant mode only supports Python 3 with bash or zsh.
+Currently, instant mode only supports Python 3 with bash or zsh. zsh's autocorrect function also needs to be disabled in order for thefuck to work properly.
 
 To enable instant mode, add `--enable-experimental-instant-mode`
 to the alias initialization in `.bashrc`, `.bash_profile` or `.zshrc`.


### PR DESCRIPTION
zsh's autocorrect function disallows script to correctly write output down, so it needs to be disabled in instant mode. I added a proper mention of this to the README. also it's quite pointless to have both zsh's autocorrect and thefuck turned on at the same time, so fixing this is probably not worth the effort.
```
$ puthon
Correct puthon to python? (Yes, No, Abort, Edit) n
zsh: command not found: puthon
$ fuck
[WARN] Script not found in output log
Nothing found
$ unsetopt correctall
$ puthon
zsh: command not found: puthon
$ fuck
python [enter/↑/↓/ctrl+c]
```