### PR TITLE
Create `cat_dir` rule for replacing `cat` with `ls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ following rules are enabled by default:
 * `aws_cli` &ndash; fixes misspelled commands like `aws dynamdb scan`;
 * `cargo` &ndash; runs `cargo build` instead of `cargo`;
 * `cargo_no_command` &ndash; fixes wrongs commands like `cargo buid`;
+* `cat_dir` &ndash; replaces `cat` with `ls` when you try to `cat` a directory
 * `cd_correction` &ndash; spellchecks and correct failed cd commands;
 * `cd_mkdir` &ndash; creates directories before cd'ing into them;
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;

--- a/tests/rules/test_cat_dir.py
+++ b/tests/rules/test_cat_dir.py
@@ -1,0 +1,28 @@
+import pytest
+from thefuck.rules.cat_dir import match, get_new_command
+from thefuck.types import Command
+
+
+@pytest.mark.parametrize('command', [
+    Command('cat foo', 'cat: foo: Is a directory'),
+    Command('cat /foo/bar/', 'cat: /foo/bar/: Is a directory'),
+])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command', [
+    Command('cat foo', 'foo bar baz'),
+    Command('cat foo bar', 'foo bar baz'),
+    Command('', ''),
+])
+def test_not_match(command):
+    assert not match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('cat foo', 'cat: foo: Is a directory'), 'ls foo'),
+    (Command('cat /foo/bar/', 'cat: /foo/bar/: Is a directory'), 'ls /foo/bar/'),
+])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_cat_dir.py
+++ b/tests/rules/test_cat_dir.py
@@ -4,8 +4,9 @@ from thefuck.types import Command
 
 
 @pytest.mark.parametrize('command', [
-    Command('cat foo', 'cat: foo: Is a directory'),
-    Command('cat /foo/bar/', 'cat: /foo/bar/: Is a directory'),
+    Command('cat foo', 'cat: foo: Is a directory\n'),
+    Command('cat /foo/bar/', 'cat: /foo/bar/: Is a directory\n'),
+    Command('cat cat/', 'cat: cat/: Is a directory\n'),
 ])
 def test_match(command):
     assert match(command)
@@ -14,15 +15,15 @@ def test_match(command):
 @pytest.mark.parametrize('command', [
     Command('cat foo', 'foo bar baz'),
     Command('cat foo bar', 'foo bar baz'),
-    Command('', ''),
 ])
 def test_not_match(command):
     assert not match(command)
 
 
 @pytest.mark.parametrize('command, new_command', [
-    (Command('cat foo', 'cat: foo: Is a directory'), 'ls foo'),
-    (Command('cat /foo/bar/', 'cat: /foo/bar/: Is a directory'), 'ls /foo/bar/'),
+    (Command('cat foo', 'cat: foo: Is a directory\n'), 'ls foo'),
+    (Command('cat /foo/bar/', 'cat: /foo/bar/: Is a directory\n'), 'ls /foo/bar/'),
+    (Command('cat cat', 'cat: cat: Is a directory\n'), 'ls cat'),
 ])
 def test_get_new_command(command, new_command):
     assert get_new_command(command) == new_command

--- a/thefuck/rules/cat_dir.py
+++ b/thefuck/rules/cat_dir.py
@@ -1,0 +1,12 @@
+import re
+
+
+def match(command):
+    return (
+        command.script.startswith('cat') and
+        re.match(r'cat: .+: Is a directory', command.output)
+    )
+
+
+def get_new_command(command):
+    return re.sub(r'^cat', 'ls', command.script)

--- a/thefuck/rules/cat_dir.py
+++ b/thefuck/rules/cat_dir.py
@@ -1,12 +1,10 @@
-import re
-
-
 def match(command):
     return (
         command.script.startswith('cat') and
-        re.match(r'cat: .+: Is a directory', command.output)
+        command.output.startswith('cat: ') and
+        command.output.rstrip().endswith(': Is a directory')
     )
 
 
 def get_new_command(command):
-    return re.sub(r'^cat', 'ls', command.script)
+    return command.script.replace('cat', 'ls', 1)


### PR DESCRIPTION
Examples

```sh
$ cat /etc
cat: /etc: Is a directory
$ fuck
ls /etc  [enter/↑/↓/ctrl+c]
*snip*
$ cat tests
cat: tests: Is a directory
$ fuck
ls tests [enter/↑/↓/ctrl+c]
*snip*
```