### PR TITLE
Stop parsing language-variable cat output to make cat_dir more reliable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ following rules are enabled by default:
 * `aws_cli` &ndash; fixes misspelled commands like `aws dynamdb scan`;
 * `cargo` &ndash; runs `cargo build` instead of `cargo`;
 * `cargo_no_command` &ndash; fixes wrongs commands like `cargo buid`;
-* `cat_dir` &ndash; replaces `cat` with `ls` when you try to `cat` a directory
+* `cat_dir` &ndash; replaces `cat` with `ls` when you try to `cat` a directory;
 * `cd_correction` &ndash; spellchecks and correct failed cd commands;
 * `cd_mkdir` &ndash; creates directories before cd'ing into them;
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;

--- a/tests/rules/test_cat_dir.py
+++ b/tests/rules/test_cat_dir.py
@@ -3,20 +3,29 @@ from thefuck.rules.cat_dir import match, get_new_command
 from thefuck.types import Command
 
 
+@pytest.fixture
+def isdir(mocker):
+    return mocker.patch('thefuck.rules.cat_dir'
+                        '.os.path.isdir')
+
+
 @pytest.mark.parametrize('command', [
     Command('cat foo', 'cat: foo: Is a directory\n'),
     Command('cat /foo/bar/', 'cat: /foo/bar/: Is a directory\n'),
     Command('cat cat/', 'cat: cat/: Is a directory\n'),
 ])
-def test_match(command):
+def test_match(command, isdir):
+    isdir.return_value = True
     assert match(command)
 
 
 @pytest.mark.parametrize('command', [
     Command('cat foo', 'foo bar baz'),
     Command('cat foo bar', 'foo bar baz'),
+    Command('notcat foo bar', 'some output'),
 ])
-def test_not_match(command):
+def test_not_match(command, isdir):
+    isdir.return_value = False
     assert not match(command)
 
 
@@ -26,4 +35,5 @@ def test_not_match(command):
     (Command('cat cat', 'cat: cat: Is a directory\n'), 'ls cat'),
 ])
 def test_get_new_command(command, new_command):
+    isdir.return_value = True
     assert get_new_command(command) == new_command

--- a/thefuck/rules/cat_dir.py
+++ b/thefuck/rules/cat_dir.py
@@ -1,8 +1,13 @@
+import os
+
+from thefuck.utils import for_app
+
+
+@for_app('cat')
 def match(command):
     return (
-        command.script.startswith('cat') and
         command.output.startswith('cat: ') and
-        command.output.rstrip().endswith(': Is a directory')
+        os.path.isdir(command.script_parts[1])
     )
 
 


### PR DESCRIPTION
Supersedes #826