### PR TITLE
#367: Support BSD style output in touch rule

### DIFF
--- a/tests/rules/test_touch.py
+++ b/tests/rules/test_touch.py
@@ -4,24 +4,32 @@ from thefuck.types import Command
 
 
 @pytest.fixture
-def output():
-    return "touch: cannot touch '/a/b/c':" \
-           " No such file or directory"
+def output(is_bsd):
+    print(is_bsd)
+    if is_bsd:
+        return "touch: /a/b/c: No such file or directory"
+    return "touch: cannot touch '/a/b/c': No such file or directory"
 
 
-def test_match(output):
-    command = Command('touch /a/b/c', output)
+@pytest.mark.parametrize('script, is_bsd', [
+    ('touch /a/b/c', False),
+    ('touch /a/b/c', True)])
+def test_match(script, is_bsd, output):
+    command = Command(script, output)
     assert match(command)
 
 
 @pytest.mark.parametrize('command', [
     Command('touch /a/b/c', ''),
-    Command('ls /a/b/c', output())])
+    Command('ls /a/b/c', output(False))])
 def test_not_match(command):
     assert not match(command)
 
 
-def test_get_new_command(output):
-    command = Command('touch /a/b/c', output)
+@pytest.mark.parametrize('script, is_bsd', [
+    ('touch /a/b/c', False),
+    ('touch /a/b/c', True)])
+def test_get_new_command(script, is_bsd, output):
+    command = Command(script, output)
     fixed_command = get_new_command(command)
     assert fixed_command == 'mkdir -p /a/b && touch /a/b/c'

--- a/thefuck/rules/touch.py
+++ b/thefuck/rules/touch.py
@@ -9,5 +9,6 @@ def match(command):
 
 
 def get_new_command(command):
-    path = re.findall(r"touch: cannot touch '(.+)/.+':", command.output)[0]
+    path = path = re.findall(
+        r"touch: (?:cannot touch ')?(.+)/.+'?:", command.output)[0]
     return shell.and_(u'mkdir -p {}'.format(path), command.script)


### PR DESCRIPTION
On a Mac, also on NetBSD or OpenBSD, `touch` errs differently:

```
$ uname; touch a/b/c
Darwin
touch: a/b/c: No such file or directory
```

That gets matched by the rule but not fixed by it. Thus the regex pattern is now a bit more tolerant.

Thanks for any review and/or comment