### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ eval $(thefuck --alias FUCK)
 Changes are only available in a new shell session. To make changes immediately
 available, run `source ~/.bashrc` (or your shell config file like `.zshrc`).
 
-To run fixed commands without confirmation, use the `--yeah` option (or just `-y` for short):
+To run fixed commands without confirmation, use the `--yes` option (or just `-y` for short):
 
 ```bash
-fuck --yeah
+fuck --yes
 ```
 
 To fix commands recursively until succeeding, use the `-r` option:


### PR DESCRIPTION
rename the --yeah argument to --yes
if you run fuck --help it doesn't output a --yeah flag, I believe it has been renamed to --yes
``` fuck --yeah ``` sounded cooler though