### PR TITLE
Added Persian letters rule for converting those letters to English

### DIFF
--- a/tests/rules/test_persian_letters.py
+++ b/tests/rules/test_persian_letters.py
@@ -1,0 +1,21 @@
+import pytest
+from thefuck.types import Command
+from thefuck.rules.chmod_x import match, get_new_command
+
+
+@pytest.mark.parametrize('command', [
+    Command('حصی', 'command not found: حصی'),
+    Command('مس -مش', 'command not found: مس'),
+    Command('لهف سفشفعس', 'command not found: لهف'),
+])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('حصی', ''), 'pwd'),
+    (Command('مس -مش', ''), 'ls -la'),
+    (Command('لهف سفشفعس', ''), 'git status'),
+])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/persian_letters.py
+++ b/thefuck/rules/persian_letters.py
@@ -1,0 +1,16 @@
+persian_letters = ('ض', 'ص', 'ث', 'ق', 'ف', 'غ', 'ع', 'ه', 'خ', 'ح', 'ج', 'چ', 'ش', 'س', 'ی', 'ب',
+                    'ل', 'ا', 'ت', 'ن', 'م', 'ک', 'گ', 'ظ', 'ط', 'ز', 'ر', 'ذ', 'د', 'پ', 'و')
+
+english_letters = ('q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', '[', ']', 'a', 's', 'd', 'f',
+                    'g', 'h', 'j', 'k', 'l', ';', "'", 'z', 'x', 'c', 'v', 'b', 'n', 'm', ',')
+
+def match(command):
+    return (command.script.startswith(persian_letters)
+        and 'command not found' in command.output.lower())
+
+
+def get_new_command(command):
+    script = command.script
+    for i, letter in enumerate(persian_letters):
+        script = script.replace(letter, english_letters[i])
+    return script


### PR DESCRIPTION
Sometimes when typing in shell, we're in a wrong keyboard layout (like Persian, in this particular rule). What happens is, the entered command will be something like this:

`لهف سفشفعس`

In which if the keyboard layout was correct (i.e. English), it would be:

`git status`

This rule will fix these mistakes.