### PR TITLE
Comply to new flake8 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ addons:
       - python-commandnotfound
       - python3-commandnotfound
 before_install:
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then rm /usr/local/include/c++ ; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update ; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew upgrade python; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then pip3 install virtualenv; fi

--- a/tests/rules/test_ag_literal.py
+++ b/tests/rules/test_ag_literal.py
@@ -9,7 +9,7 @@ def output():
             'If you meant to search for a literal string, run ag with -Q\n')
 
 
-@pytest.mark.parametrize('script', ['ag \('])
+@pytest.mark.parametrize('script', ['ag \\('])
 def test_match(script, output):
     assert match(Command(script, output))
 
@@ -20,6 +20,6 @@ def test_not_match(script):
 
 
 @pytest.mark.parametrize('script, new_cmd', [
-    ('ag \(', 'ag -Q \(')])
+    ('ag \\(', 'ag -Q \\(')])
 def test_get_new_command(script, new_cmd, output):
     assert get_new_command((Command(script, output))) == new_cmd

--- a/thefuck/rules/aws_cli.py
+++ b/thefuck/rules/aws_cli.py
@@ -3,7 +3,7 @@ import re
 from thefuck.utils import for_app, replace_argument
 
 INVALID_CHOICE = "(?<=Invalid choice: ')(.*)(?=', maybe you meant:)"
-OPTIONS = "^\s*\*\s(.*)"
+OPTIONS = "^\\s*\\*\\s(.*)"
 
 
 @for_app('aws')

--- a/thefuck/rules/az_cli.py
+++ b/thefuck/rules/az_cli.py
@@ -3,7 +3,7 @@ import re
 from thefuck.utils import for_app, replace_argument
 
 INVALID_CHOICE = "(?=az)(?:.*): '(.*)' is not in the '.*' command group."
-OPTIONS = "^The most similar choice to '.*' is:\n\s*(.*)$"
+OPTIONS = "^The most similar choice to '.*' is:\n\\s*(.*)$"
 
 
 @for_app('az')

--- a/thefuck/rules/heroku_multiple_apps.py
+++ b/thefuck/rules/heroku_multiple_apps.py
@@ -8,5 +8,5 @@ def match(command):
 
 
 def get_new_command(command):
-    apps = re.findall('([^ ]*) \([^)]*\)', command.output)
+    apps = re.findall('([^ ]*) \\([^)]*\\)', command.output)
     return [command.script + ' --app ' + app for app in apps]

--- a/thefuck/shells/generic.py
+++ b/thefuck/shells/generic.py
@@ -82,7 +82,7 @@ class Generic(object):
         encoded = self.encode_utf8(command)
 
         try:
-            splitted = [s.replace("??", "\ ") for s in shlex.split(encoded.replace('\ ', '??'))]
+            splitted = [s.replace("??", "\\ ") for s in shlex.split(encoded.replace('\\ ', '??'))]
         except ValueError:
             splitted = encoded.split(' ')
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,5 @@ deps = -rrequirements.txt
 commands = py.test -v --capture=sys
 
 [flake8]
-ignore = E501,W503
+ignore = E501,W503,W504
 exclude = venv,build,.tox,setup.py,fastentrypoints.py


### PR DESCRIPTION
With new flake8 version 3.6 comes new errors, `W504` and `W605`. They didn't exist before the new version. `W504` is ignored along with `W503`. Fixes regarding `W605` are included.

Remember not to squash the commits ‒ for some good reasons. :-) Just rebase them.