### PR TITLE
Remove zsh instant mode log with -f

### DIFF
--- a/thefuck/shells/zsh.py
+++ b/thefuck/shells/zsh.py
@@ -52,7 +52,7 @@ class Zsh(Generic):
                 export THEFUCK_INSTANT_MODE=True;
                 export THEFUCK_OUTPUT_LOG={log};
                 thefuck --shell-logger {log};
-                rm {log};
+                rm -f {log};
                 exit
             '''.format(log=log_path)
 


### PR DESCRIPTION
In some setups, rm might default to interactive promt. This change adds
the -f parameter to force remove the instant mode log on exit to avoid
an interactive prompt.

```
 ~ 
rm: remove regular file
'/tmp/user/1000/thefuck-script-log-bbb81260140c4b3fa18bf2097f15bd77'?
```