### PR TITLE
Fix invalid for_app/sudo_support ordering

### DIFF
--- a/thefuck/rules/apt_invalid_operation.py
+++ b/thefuck/rules/apt_invalid_operation.py
@@ -6,8 +6,8 @@ from thefuck.utils import for_app, eager, replace_command
 enabled_by_default = apt_available
 
 
-@for_app('apt', 'apt-get', 'apt-cache')
 @sudo_support
+@for_app('apt', 'apt-get', 'apt-cache')
 def match(command):
     return 'E: Invalid operation' in command.output
 

--- a/thefuck/rules/dnf_no_such_command.py
+++ b/thefuck/rules/dnf_no_such_command.py
@@ -8,8 +8,8 @@ from thefuck.specific.dnf import dnf_available
 regex = re.compile(r'No such command: (.*)\.')
 
 
-@for_app('dnf')
 @sudo_support
+@for_app('dnf')
 def match(command):
     return 'no such command' in command.output.lower()
 


### PR DESCRIPTION
- Fixed incorrect ordering of for_app/sudo_support annotations causing apt_invalid_operation and dnf_no_such_command rules to fail
- The previous ordering meant that `for_app` was on the inside (i.e. called first), so it would fail for commands executed with `sudo` 