### PR TITLE
#869: Use `fish --version` instead of an interactive shell for info()

### DIFF
--- a/tests/shells/test_fish.py
+++ b/tests/shells/test_fish.py
@@ -114,5 +114,6 @@ class TestFish(object):
         assert not shell.how_to_configure().can_configure_automatically
 
     def test_info(self, shell, Popen):
-        Popen.return_value.stdout.read.side_effect = [b'3.5.9']
+        Popen.return_value.stdout.read.side_effect = [b'fish, version 3.5.9\n']
         assert shell.info() == 'Fish Shell 3.5.9'
+        assert Popen.call_args[0][0] == ['fish', '--version']

--- a/thefuck/shells/fish.py
+++ b/thefuck/shells/fish.py
@@ -105,9 +105,9 @@ class Fish(Generic):
 
     def info(self):
         """Returns the name and version of the current shell"""
-        proc = Popen(['fish', '-c', 'echo $FISH_VERSION'],
+        proc = Popen(['fish', '--version'],
                      stdout=PIPE, stderr=DEVNULL)
-        version = proc.stdout.read().decode('utf-8').strip()
+        version = proc.stdout.read().decode('utf-8').split()[-1]
         return u'Fish Shell {}'.format(version)
 
     def put_to_history(self, command):


### PR DESCRIPTION
This prevents initialisation and consequentially a recursive loop.

Fix #869
Ref oh-my-fish/plugin-thefuck#11