### PR TITLE
Use `yield from`

### DIFF
--- a/thefuck/corrector.py
+++ b/thefuck/corrector.py
@@ -74,8 +74,7 @@ def organize_commands(corrected_commands):
     logs.debug('Corrected commands: '.format(
         ', '.join(u'{}'.format(cmd) for cmd in [first_command] + sorted_commands)))
 
-    for command in sorted_commands:
-        yield command
+    yield from sorted_commands
 
 
 def get_corrected_commands(command):


### PR DESCRIPTION
Since the requirement is `python (3.4+)` we could use the shortened form of `for item in iterable`. ie, This PR suggest to change

```
 for command in sorted_commands:
       yield command
```
with

```
yield from sorted_commands
```
This is available from `python 3.3` onwards