### PR TITLE
Comment correction on ui.py

### DIFF
--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -52,7 +52,7 @@ class CommandSelector(object):
 
     @property
     def value(self):
-        """:rtype hefuck.types.CorrectedCommand"""
+        """:rtype thefuck.types.CorrectedCommand"""
         return self._commands[self._index]
 
 


### PR DESCRIPTION
As there was minor spelling error in ui.py: line 55( """:rtype hefuck.types.CorrectedCommand"""),
corrected the same line to "thefuck" from "hefuck".
