### PR TITLE
#N/A: Return an ordered list from set of overridden aliases

### DIFF
--- a/tests/shells/test_fish.py
+++ b/tests/shells/test_fish.py
@@ -28,8 +28,9 @@ class TestFish(object):
         ('THEFUCK_OVERRIDDEN_ALIASES', '\ncut,\n\ngit,\tsed\r')])
     def test_get_overridden_aliases(self, shell, os_environ, key, value):
         os_environ[key] = value
-        assert shell._get_overridden_aliases() == {'cd', 'cut', 'git', 'grep',
-                                                   'ls', 'man', 'open', 'sed'}
+        overridden = shell._get_overridden_aliases()
+        assert set(overridden) == {'cd', 'cut', 'git', 'grep',
+                                   'ls', 'man', 'open', 'sed'}
 
     @pytest.mark.parametrize('before, after', [
         ('cd', 'cd'),

--- a/thefuck/shells/fish.py
+++ b/thefuck/shells/fish.py
@@ -43,7 +43,7 @@ class Fish(Generic):
         default = {'cd', 'grep', 'ls', 'man', 'open'}
         for alias in overridden.split(','):
             default.add(alias.strip())
-        return default
+        return sorted(default)
 
     def app_alias(self, alias_name):
         if settings.alter_history:


### PR DESCRIPTION
This way it's ensured that whatever is used as cache key is always ordered. Sets are unordered collections.