### PR TITLE
#N/A: Add rule for `git commit` that reverts previous commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ following rules are enabled by default:
 * `git_branch_list` &ndash; catches `git branch list` in place of `git branch` and removes created branch;
 * `git_checkout` &ndash; fixes branch name or creates new branch;
 * `git_commit_amend` &ndash; offers `git commit --amend` after previous commit;
+* `git_commit_reset` &ndash; offers `git reset HEAD~` after previous commit;
 * `git_diff_no_index` &ndash; adds `--no-index` to previous `git diff` on untracked files;
 * `git_diff_staged` &ndash; adds `--staged` to previous `git diff` with unexpected output;
 * `git_fix_stash` &ndash; fixes `git stash` commands (misspelled subcommand and missing `save`);

--- a/tests/rules/test_git_commit_reset.py
+++ b/tests/rules/test_git_commit_reset.py
@@ -1,0 +1,25 @@
+import pytest
+from thefuck.rules.git_commit_reset import match, get_new_command
+from thefuck.types import Command
+
+
+@pytest.mark.parametrize('script, output', [
+    ('git commit -m "test"', 'test output'),
+    ('git commit', '')])
+def test_match(output, script):
+    assert match(Command(script, output))
+
+
+@pytest.mark.parametrize('script', [
+    'git branch foo',
+    'git checkout feature/test_commit',
+    'git push'])
+def test_not_match(script):
+    assert not match(Command(script, ''))
+
+
+@pytest.mark.parametrize('script', [
+    ('git commit -m "test commit"'),
+    ('git commit')])
+def test_get_new_command(script):
+    assert get_new_command(Command(script, '')) == 'git reset HEAD~'

--- a/thefuck/rules/git_commit_reset.py
+++ b/thefuck/rules/git_commit_reset.py
@@ -1,0 +1,11 @@
+from thefuck.specific.git import git_support
+
+
+@git_support
+def match(command):
+    return ('commit' in command.script_parts)
+
+
+@git_support
+def get_new_command(command):
+    return 'git reset HEAD~'


### PR DESCRIPTION
If you git commit but decide that you want to revert back to the last commit, the fuck will help you roll back to the last commit.