### PR TITLE
Docker login

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ following rules are enabled by default:
 * `dirty_unzip` &ndash; fixes `unzip` command that unzipped in the current directory;
 * `django_south_ghost` &ndash; adds `--delete-ghost-migrations` to failed because ghosts django south migration;
 * `django_south_merge` &ndash; adds `--merge` to inconsistent django south migration;
+* `docker_login` &ndash; executes a `docker login` and repeats the previous command;
 * `docker_not_command` &ndash; fixes wrong docker commands like `docker tags`;
 * `dry` &ndash; fixes repetitions like `git git push`;
 * `fab_command_not_found` &ndash; fix misspelled fabric commands;

--- a/tests/rules/test_docker_login.py
+++ b/tests/rules/test_docker_login.py
@@ -5,8 +5,8 @@ from thefuck.types import Command
 def test_match():
     err_response = """
     Sending build context to Docker daemon  118.8kB
-Step 1/6 : FROM baz/baz:nightly
-pull access denied for baz/baz, repository does not exist or may require 'docker login'
+Step 1/6 : FROM foo/bar:nightly
+pull access denied for foo/bar, repository does not exist or may require 'docker login'
 """
     assert match(Command('docker build -t artifactory:9090/foo/bar:fdb7c6d .', err_response))
     assert not match(Command('', ''))

--- a/tests/rules/test_docker_login.py
+++ b/tests/rules/test_docker_login.py
@@ -5,7 +5,7 @@ from thefuck.types import Command
 def test_match():
     err_response = """
     Sending build context to Docker daemon  118.8kB
-Step 1/6 : FROM foo/bar:nightly
+Step 1/6 : FROM foo/bar:fdb7c6d
 pull access denied for foo/bar, repository does not exist or may require 'docker login'
 """
     assert match(Command('docker build -t artifactory:9090/foo/bar:fdb7c6d .', err_response))

--- a/tests/rules/test_docker_login.py
+++ b/tests/rules/test_docker_login.py
@@ -3,8 +3,8 @@ from thefuck.types import Command
 
 
 def test_match():
-	err_response = """
-	Sending build context to Docker daemon  118.8kB
+    err_response = """
+    Sending build context to Docker daemon  118.8kB
 Step 1/6 : FROM baz/baz:nightly
 pull access denied for baz/baz, repository does not exist or may require 'docker login'
 """

--- a/tests/rules/test_docker_login.py
+++ b/tests/rules/test_docker_login.py
@@ -3,14 +3,35 @@ from thefuck.types import Command
 
 
 def test_match():
-    err_response = """
+    err_response1 = """
     Sending build context to Docker daemon  118.8kB
 Step 1/6 : FROM foo/bar:fdb7c6d
 pull access denied for foo/bar, repository does not exist or may require 'docker login'
 """
-    assert match(Command('docker build -t artifactory:9090/foo/bar:fdb7c6d .', err_response))
-    assert not match(Command('', ''))
+    assert match(Command('docker build -t artifactory:9090/foo/bar:fdb7c6d .', err_response1))
+
+    err_response2 = """
+    The push refers to repository [artifactory:9090/foo/bar]
+push access denied for foo/bar, repository does not exist or may require 'docker login'
+"""
+    assert match(Command('docker push artifactory:9090/foo/bar:fdb7c6d', err_response2))
+
+    err_response3 = """
+    docker push artifactory:9090/foo/bar:fdb7c6d
+The push refers to repository [artifactory:9090/foo/bar]
+9c29c7ad209d: Preparing
+71f3ad53dfe0: Preparing
+f58ee068224c: Preparing
+aeddc924d0f7: Preparing
+c2040e5d6363: Preparing
+4d42df4f350f: Preparing
+35723dab26f9: Preparing
+71f3ad53dfe0: Pushed
+cb95fa0faeb1: Layer already exists
+"""
+    assert not match(Command('docker push artifactory:9090/foo/bar:fdb7c6d', err_response3))
 
 
 def test_get_new_command():
     assert get_new_command(Command('docker build -t artifactory:9090/foo/bar:fdb7c6d .', '')) == 'docker login && docker build -t artifactory:9090/foo/bar:fdb7c6d .'
+    assert get_new_command(Command('docker push artifactory:9090/foo/bar:fdb7c6d', '')) == 'docker login && docker push artifactory:9090/foo/bar:fdb7c6d'

--- a/tests/rules/test_docker_login.py
+++ b/tests/rules/test_docker_login.py
@@ -1,0 +1,16 @@
+from thefuck.rules.docker_login import match, get_new_command
+from thefuck.types import Command
+
+
+def test_match():
+	err_response = """
+	Sending build context to Docker daemon  118.8kB
+Step 1/6 : FROM baz/baz:nightly
+pull access denied for baz/baz, repository does not exist or may require 'docker login'
+"""
+    assert match(Command('docker build -t artifactory:9090/foo/bar:fdb7c6d .', err_response))
+    assert not match(Command('', ''))
+
+
+def test_get_new_command():
+    assert get_new_command(Command('docker build -t artifactory:9090/foo/bar:fdb7c6d .', '')) == 'docker login && docker build -t artifactory:9090/foo/bar:fdb7c6d .'

--- a/thefuck/rules/docker_login.py
+++ b/thefuck/rules/docker_login.py
@@ -9,4 +9,4 @@ def match(command):
 
 
 def get_new_command(command):
-    return "docker login && %s" % command.script
+    return 'docker login && {}'.format(command.script)

--- a/thefuck/rules/docker_login.py
+++ b/thefuck/rules/docker_login.py
@@ -1,0 +1,12 @@
+from thefuck.utils import for_app
+
+
+@for_app('docker')
+def match(command):
+    return ('docker' in command.script
+            and "access denied" in command.output
+            and "may require 'docker login'" in command.output)
+
+
+def get_new_command(command):
+    return "docker login && %s" % command.script


### PR DESCRIPTION
Hi! This PR will react to failures when pushing to/pulling anything that requires a docker login, for lack of authentication, by executing a `docker login` followed by repeating the previous command. 
