### PR TITLE
Add rule for pip_install permission fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ following rules are enabled by default:
 * `no_command` &ndash; fixes wrong console commands, for example `vom/vim`;
 * `no_such_file` &ndash; creates missing directories with `mv` and `cp` commands;
 * `open` &ndash; either prepends `http://` to address passed to `open` or create a new file or directory and passes it to `open`;
+* `pip_install` &ndash; fixes permission issues with `pip install` commands by adding `--user` or prepending `sudo` if necessary;
 * `pip_unknown_command` &ndash; fixes wrong `pip` commands, for example `pip instatl/pip install`;
 * `php_s` &ndash; replaces `-s` by `-S` when trying to run a local php server;
 * `port_already_in_use` &ndash; kills process that bound port;

--- a/tests/rules/test_pip_install.py
+++ b/tests/rules/test_pip_install.py
@@ -1,0 +1,27 @@
+# -*- coding: UTF-8 -*-
+from thefuck.rules.pip_install import match, get_new_command
+from thefuck.types import Command
+
+
+def test_match():
+    response1 = """
+    Could not install packages due to an EnvironmentError: [Errno 13] Permission denied: '/Library/Python/2.7/site-packages/entrypoints.pyc'
+Consider using the `--user` option or check the permissions.
+"""
+    assert match(Command('pip install -r requirements.txt', response1))
+
+    response2 = """
+Collecting bacon
+  Downloading https://files.pythonhosted.org/packages/b2/81/19fb79139ee71c8bc4e5a444546f318e2b87253b8939ec8a7e10d63b7341/bacon-0.3.1.zip (11.0MB)
+    100% |████████████████████████████████| 11.0MB 3.0MB/s
+Installing collected packages: bacon
+  Running setup.py install for bacon ... done
+Successfully installed bacon-0.3.1
+"""
+    assert not match(Command('pip install bacon', response2))
+
+
+def test_get_new_command():
+    assert get_new_command(Command('pip install -r requirements.txt', '')) == 'pip install --user -r requirements.txt'
+    assert get_new_command(Command('pip install bacon', '')) == 'pip install --user bacon'
+    assert get_new_command(Command('pip install --user -r requirements.txt', '')) == 'sudo pip install -r requirements.txt'

--- a/thefuck/rules/pip_install.py
+++ b/thefuck/rules/pip_install.py
@@ -12,4 +12,4 @@ def get_new_command(command):
     if '--user' not in command.script:  # add --user (attempt 1)
         return command.script.replace(' install ', ' install --user ')
 
-    return 'sudo {}'.format(command.script.replace(' --user', '')) # since --user didn't fix things, let's try sudo (attempt 2)
+    return 'sudo {}'.format(command.script.replace(' --user', ''))  # since --user didn't fix things, let's try sudo (attempt 2)

--- a/thefuck/rules/pip_install.py
+++ b/thefuck/rules/pip_install.py
@@ -11,5 +11,5 @@ def match(command):
 def get_new_command(command):
     if "--user" not in command.script:  # add --user (attempt 1)
         return command.script.replace(" install ", " install --user ")
-    else: # since --user didn't fix things, let's try sudo (attempt 2)
-    	return 'sudo {}'.format(command.script.replace(" --user", ""))        
+    else:  # since --user didn't fix things, let's try sudo (attempt 2)
+        return 'sudo {}'.format(command.script.replace(" --user", ""))

--- a/thefuck/rules/pip_install.py
+++ b/thefuck/rules/pip_install.py
@@ -1,0 +1,15 @@
+from thefuck.utils import for_app
+from thefuck.specific.sudo import sudo_support
+
+
+@sudo_support
+@for_app('pip')
+def match(command):
+    return ('pip install' in command.script and "Permission denied" in command.output)
+
+
+def get_new_command(command):
+    if "--user" not in command.script:  # add --user (attempt 1)
+        return command.script.replace(" install ", " install --user ")
+    else: # since --user didn't fix things, let's try sudo (attempt 2)
+    	return 'sudo {}'.format(command.script.replace(" --user", ""))        

--- a/thefuck/rules/pip_install.py
+++ b/thefuck/rules/pip_install.py
@@ -11,5 +11,5 @@ def match(command):
 def get_new_command(command):
     if '--user' not in command.script:  # add --user (attempt 1)
         return command.script.replace(' install ', ' install --user ')
-    else:  # since --user didn't fix things, let's try sudo (attempt 2)
-        return 'sudo {}'.format(command.script.replace(' --user', ''))
+
+    return 'sudo {}'.format(command.script.replace(' --user', '')) # since --user didn't fix things, let's try sudo (attempt 2)

--- a/thefuck/rules/pip_install.py
+++ b/thefuck/rules/pip_install.py
@@ -5,11 +5,11 @@ from thefuck.specific.sudo import sudo_support
 @sudo_support
 @for_app('pip')
 def match(command):
-    return ('pip install' in command.script and "Permission denied" in command.output)
+    return ('pip install' in command.script and 'Permission denied' in command.output)
 
 
 def get_new_command(command):
-    if "--user" not in command.script:  # add --user (attempt 1)
-        return command.script.replace(" install ", " install --user ")
+    if '--user' not in command.script:  # add --user (attempt 1)
+        return command.script.replace(' install ', ' install --user ')
     else:  # since --user didn't fix things, let's try sudo (attempt 2)
-        return 'sudo {}'.format(command.script.replace(" --user", ""))
+        return 'sudo {}'.format(command.script.replace(' --user', ''))


### PR DESCRIPTION
This PR reacts to `pip install` permission issues by either adding `--user` to the command, or, if `--user` is already in the command, removing the `--user` flag and running the command with sudo.