### PR TITLE
Adding yay AUR manager to Arch Linux's commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,8 @@ The following rules are enabled by default on specific platforms only:
 * `brew_unknown_command` &ndash; fixes wrong brew commands, for example `brew docto/brew doctor`;
 * `brew_update_formula` &ndash; turns `brew update <formula>` into `brew upgrade <formula>`;
 * `dnf_no_such_command` &ndash; fixes mistyped DNF commands;
-* `pacman` &ndash; installs app with `pacman` if it is not installed (uses `yaourt` if available);
-* `pacman_not_found` &ndash; fixes package name with `pacman` or `yaourt`.
+* `pacman` &ndash; installs app with `pacman` if it is not installed (uses `yay` or `yaourt` if available);
+* `pacman_not_found` &ndash; fixes package name with `pacman`, `yay` or `yaourt`.
 
 The following commands are bundled with *The Fuck*, but are not enabled by
 default:

--- a/tests/rules/test_pacman_not_found.py
+++ b/tests/rules/test_pacman_not_found.py
@@ -11,6 +11,7 @@ extra/llvm35 3.5.2-13/usr/bin/llc'''
 @pytest.mark.skipif(not getattr(pacman_not_found, 'enabled_by_default', True),
                     reason='Skip if pacman is not available')
 @pytest.mark.parametrize('command', [
+    Command('yay -S llc', 'error: target not found: llc'),
     Command('yaourt -S llc', 'error: target not found: llc'),
     Command('pacman llc', 'error: target not found: llc'),
     Command('sudo pacman llc', 'error: target not found: llc')])
@@ -19,6 +20,7 @@ def test_match(command):
 
 
 @pytest.mark.parametrize('command', [
+    Command('yay -S llc', 'error: target not found: llc'),
     Command('yaourt -S llc', 'error: target not found: llc'),
     Command('pacman llc', 'error: target not found: llc'),
     Command('sudo pacman llc', 'error: target not found: llc')])
@@ -31,6 +33,7 @@ def test_match_mocked(subp_mock, command):
 @pytest.mark.skipif(not getattr(pacman_not_found, 'enabled_by_default', True),
                     reason='Skip if pacman is not available')
 @pytest.mark.parametrize('command, fixed', [
+    (Command('yay -S llc', 'error: target not found: llc'), ['yay -S extra/llvm', 'yay -S extra/llvm35']),
     (Command('yaourt -S llc', 'error: target not found: llc'), ['yaourt -S extra/llvm', 'yaourt -S extra/llvm35']),
     (Command('pacman -S llc', 'error: target not found: llc'), ['pacman -S extra/llvm', 'pacman -S extra/llvm35']),
     (Command('sudo pacman -S llc', 'error: target not found: llc'), ['sudo pacman -S extra/llvm', 'sudo pacman -S extra/llvm35'])])
@@ -39,6 +42,7 @@ def test_get_new_command(command, fixed):
 
 
 @pytest.mark.parametrize('command, fixed', [
+    (Command('yay -S llc', 'error: target not found: llc'), ['yay -S extra/llvm', 'yay -S extra/llvm35']),
     (Command('yaourt -S llc', 'error: target not found: llc'), ['yaourt -S extra/llvm', 'yaourt -S extra/llvm35']),
     (Command('pacman -S llc', 'error: target not found: llc'), ['pacman -S extra/llvm', 'pacman -S extra/llvm35']),
     (Command('sudo pacman -S llc', 'error: target not found: llc'), ['sudo pacman -S extra/llvm', 'sudo pacman -S extra/llvm35'])])

--- a/thefuck/rules/pacman_not_found.py
+++ b/thefuck/rules/pacman_not_found.py
@@ -1,9 +1,9 @@
 """ Fixes wrong package names with pacman or yaourt.
 
 For example the `llc` program is in package `llvm` so this:
-    yaourt -S llc
+    yay -S llc
 should be:
-    yaourt -S llvm
+    yay -S llvm
 """
 
 from thefuck.utils import replace_command
@@ -12,7 +12,7 @@ from thefuck.specific.archlinux import get_pkgfile, archlinux_env
 
 def match(command):
     return (command.script_parts
-            and (command.script_parts[0] in ('pacman', 'yaourt')
+            and (command.script_parts[0] in ('pacman', 'yay', 'yaourt')
                  or command.script_parts[0:2] == ['sudo', 'pacman'])
             and 'error: target not found:' in command.output)
 

--- a/thefuck/specific/archlinux.py
+++ b/thefuck/specific/archlinux.py
@@ -32,7 +32,9 @@ def get_pkgfile(command):
 
 
 def archlinux_env():
-    if utils.which('yaourt'):
+    if utils.which('yay'):
+        pacman = 'yay'
+    elif utils.which('yaourt'):
         pacman = 'yaourt'
     elif utils.which('pacman'):
         pacman = 'sudo pacman'


### PR DESCRIPTION
Adding yay AUR manager to Arch Linux's commands since yaourt is unmantained and has some security issues.

Since those issues with yaourt it's recommended to use another AUR manager instead and yay is being the most used alternative.