### PR TITLE
#N/A: Improve support to Windows in `no_command` rule

### DIFF
--- a/tests/rules/test_no_command.py
+++ b/tests/rules/test_no_command.py
@@ -6,7 +6,7 @@ from thefuck.types import Command
 @pytest.fixture(autouse=True)
 def get_all_executables(mocker):
     mocker.patch('thefuck.rules.no_command.get_all_executables',
-                 return_value=['vim', 'fsck', 'git', 'go'])
+                 return_value=['vim', 'fsck', 'git', 'go', 'python'])
 
 
 @pytest.fixture(autouse=True)
@@ -20,6 +20,7 @@ def history_without_current(mocker):
 @pytest.mark.parametrize('script, output', [
     ('vom file.py', 'vom: not found'),
     ('fucck', 'fucck: not found'),
+    ('puthon', "'puthon' is not recognized as an internal or external command"),
     ('got commit', 'got: command not found')])
 def test_match(mocker, script, output):
     mocker.patch('thefuck.rules.no_command.which', return_value=None)

--- a/thefuck/rules/no_command.py
+++ b/thefuck/rules/no_command.py
@@ -6,7 +6,8 @@ from thefuck.specific.sudo import sudo_support
 @sudo_support
 def match(command):
     return (not which(command.script_parts[0])
-            and 'not found' in command.output
+            and ('not found' in command.output
+                 or 'is not recognized as' in command.output)
             and bool(get_close_matches(command.script_parts[0],
                                        get_all_executables())))
 


### PR DESCRIPTION
Windows “not found” message is quite different from POSIX systems.