### PR TITLE
support nixos command-not-found, closes #912

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ The following rules are enabled by default on specific platforms only:
 * `brew_unknown_command` &ndash; fixes wrong brew commands, for example `brew docto/brew doctor`;
 * `brew_update_formula` &ndash; turns `brew update <formula>` into `brew upgrade <formula>`;
 * `dnf_no_such_command` &ndash; fixes mistyped DNF commands;
+* `nixos_cmd_not_found` &ndash; installs apps on NixOS;
 * `pacman` &ndash; installs app with `pacman` if it is not installed (uses `yay` or `yaourt` if available);
 * `pacman_not_found` &ndash; fixes package name with `pacman`, `yay` or `yaourt`.
 

--- a/tests/rules/test_nixos_cmd_not_found.py
+++ b/tests/rules/test_nixos_cmd_not_found.py
@@ -1,0 +1,25 @@
+import pytest
+from thefuck.rules.nixos_cmd_not_found import match, get_new_command
+from thefuck.types import Command
+
+
+@pytest.mark.parametrize('command', [
+    Command('vim', 'nix-env -iA nixos.vim')])
+def test_match(mocker, command):
+    mocker.patch('thefuck.rules.nixos_cmd_not_found', return_value=None)
+    assert match(command)
+
+
+@pytest.mark.parametrize('command', [
+    Command('vim', ''),
+    Command('', '')])
+def test_not_match(mocker, command):
+    mocker.patch('thefuck.rules.nixos_cmd_not_found', return_value=None)
+    assert not match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('vim', 'nix-env -iA nixos.vim'), 'nix-env -iA nixos.vim && vim'),
+    (Command('pacman', 'nix-env -iA nixos.pacman'), 'nix-env -iA nixos.pacman && pacman')])
+def test_get_new_command(mocker, command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/nixos_cmd_not_found.py
+++ b/thefuck/rules/nixos_cmd_not_found.py
@@ -1,0 +1,15 @@
+import re
+from thefuck.specific.nix import nix_available
+from thefuck.shells import shell
+
+regex = re.compile(r'nix-env -iA ([^\s]*)')
+enabled_by_default = nix_available
+
+
+def match(command):
+    return regex.findall(command.output)
+
+
+def get_new_command(command):
+    name = regex.findall(command.output)[0]
+    return shell.and_('nix-env -iA {}'.format(name), command.script)

--- a/thefuck/specific/nix.py
+++ b/thefuck/specific/nix.py
@@ -1,0 +1,3 @@
+from thefuck.utils import which
+
+nix_available = bool(which('nix'))


### PR DESCRIPTION
This PR adds a rule to suggest package installations in response to NixOS command-not-found errors for uninstalled packages available in the repo, see @anka-213's #912 for the original request.
My implementation was partly inspired by the apt-get rule, and is quite simple, simply judging applicability by the availability of `nix`, and scanning for the `nix-env -iA` line, only to suggest that same command in return.
Feedback welcome!
