### PR TITLE
#921: Try printing alias before trying to fix a command

### DIFF
--- a/thefuck/entrypoints/main.py
+++ b/thefuck/entrypoints/main.py
@@ -22,10 +22,13 @@ def main():
     elif known_args.version:
         logs.version(get_installation_info().version,
                      sys.version.split()[0], shell.info())
-    elif known_args.command or 'TF_HISTORY' in os.environ:
-        fix_command(known_args)
+    # It's important to check if an alias is being requested before checking if
+    # `TF_HISTORY` is in `os.environ`, otherwise it might mess with subshells.
+    # Check https://github.com/nvbn/thefuck/issues/921 for reference
     elif known_args.alias:
         print_alias(known_args)
+    elif known_args.command or 'TF_HISTORY' in os.environ:
+        fix_command(known_args)
     elif known_args.shell_logger:
         try:
             from .shell_logger import shell_logger  # noqa: E402


### PR DESCRIPTION
The shell functions could be changed in a way to unset `TF_HISTORY` before firing the subprocess. But it would be prone to regressions. So, changing the order of `if` statements and adding a comment should suffice.