### PR TITLE
Only consider raw command in output

### DIFF
--- a/tests/rules/test_apt_list_upgradable.py
+++ b/tests/rules/test_apt_list_upgradable.py
@@ -4,7 +4,7 @@ import pytest
 from thefuck.rules.apt_list_upgradable import get_new_command, match
 from thefuck.types import Command
 
-match_output = ['''
+full_english_output = '''
 Hit:1 http://us.archive.ubuntu.com/ubuntu zesty InRelease
 Hit:2 http://us.archive.ubuntu.com/ubuntu zesty-updates InRelease
 Get:3 http://us.archive.ubuntu.com/ubuntu zesty-backports InRelease [89.2 kB]
@@ -17,8 +17,11 @@ Reading package lists... Done
 Building dependency tree
 Reading state information... Done
 8 packages can be upgraded. Run 'apt list --upgradable' to see them.
-''',
-'Führen Sie »apt list --upgradable« aus, um sie anzuzeigen.'
+'''
+
+match_output = [
+    full_english_output,
+    'Führen Sie »apt list --upgradable« aus, um sie anzuzeigen.'  # German
 ]
 
 no_match_output = '''

--- a/tests/rules/test_apt_list_upgradable.py
+++ b/tests/rules/test_apt_list_upgradable.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 from thefuck.rules.apt_list_upgradable import get_new_command, match
 from thefuck.types import Command
 
-match_output = '''
+match_output = ['''
 Hit:1 http://us.archive.ubuntu.com/ubuntu zesty InRelease
 Hit:2 http://us.archive.ubuntu.com/ubuntu zesty-updates InRelease
 Get:3 http://us.archive.ubuntu.com/ubuntu zesty-backports InRelease [89.2 kB]
@@ -15,7 +17,9 @@ Reading package lists... Done
 Building dependency tree
 Reading state information... Done
 8 packages can be upgraded. Run 'apt list --upgradable' to see them.
-'''
+''',
+'Führen Sie »apt list --upgradable« aus, um sie anzuzeigen.'
+]
 
 no_match_output = '''
 Hit:1 http://us.archive.ubuntu.com/ubuntu zesty InRelease
@@ -48,8 +52,9 @@ All packages are up to date.
 '''
 
 
-def test_match():
-    assert match(Command('sudo apt update', match_output))
+@pytest.mark.parametrize('output', match_output)
+def test_match(output):
+    assert match(Command('sudo apt update', output))
 
 
 @pytest.mark.parametrize('command', [
@@ -67,9 +72,10 @@ def test_not_match(command):
     assert not match(command)
 
 
-def test_get_new_command():
-    new_command = get_new_command(Command('sudo apt update', match_output))
+@pytest.mark.parametrize('output', match_output)
+def test_get_new_command(output):
+    new_command = get_new_command(Command('sudo apt update', output))
     assert new_command == 'sudo apt list --upgradable'
 
-    new_command = get_new_command(Command('apt update', match_output))
+    new_command = get_new_command(Command('apt update', output))
     assert new_command == 'apt list --upgradable'

--- a/thefuck/rules/apt_list_upgradable.py
+++ b/thefuck/rules/apt_list_upgradable.py
@@ -8,7 +8,7 @@ enabled_by_default = apt_available
 @sudo_support
 @for_app('apt')
 def match(command):
-    return "Run 'apt list --upgradable' to see them." in command.output
+    return 'apt list --upgradable' in command.output
 
 
 @sudo_support


### PR DESCRIPTION
... else it will not work for localized messages.

Example German output:
```
Führen Sie »apt list --upgradable« aus, um sie anzuzeigen.
```