### PR TITLE
Add: rules/go_unknown_command for misspelled go commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ following rules are enabled by default:
 * `git_tag_force` &ndash; adds `--force` to `git tag <tagname>` when the tag already exists;
 * `git_two_dashes` &ndash; adds a missing dash to commands like `git commit -amend` or `git rebase -continue`;
 * `go_run` &ndash; appends `.go` extension when compiling/running Go programs;
+* `go_unknown_command` &ndash; fixes wrong `go` commands, for example `go bulid`;
 * `gradle_no_task` &ndash; fixes not found or ambiguous `gradle` task;
 * `gradle_wrapper` &ndash; replaces `gradle` with `./gradlew`;
 * `grep_arguments_order` &ndash; fixes `grep` arguments order for situations like `grep -lir . test`;

--- a/tests/rules/test_go_unknown_command.py
+++ b/tests/rules/test_go_unknown_command.py
@@ -1,0 +1,13 @@
+from thefuck.rules.go_unknown_command import match
+from thefuck.types import Command
+
+_GO_BUILD_MISSPELLED_OUTPUT = """go bulid: unknown command
+Run 'go help' for usage."""
+
+
+def test_match():
+    assert match(Command('go bulid', _GO_BUILD_MISSPELLED_OUTPUT))
+
+
+def test_not_match():
+    assert not match(Command('go run', 'go run: no go files listed'))

--- a/tests/rules/test_go_unknown_command.py
+++ b/tests/rules/test_go_unknown_command.py
@@ -1,13 +1,21 @@
-from thefuck.rules.go_unknown_command import match
+import pytest
+from thefuck.rules.go_unknown_command import match, get_new_command
 from thefuck.types import Command
 
-_GO_BUILD_MISSPELLED_OUTPUT = """go bulid: unknown command
-Run 'go help' for usage."""
+
+@pytest.fixture
+def build_misspelled_output():
+    return '''go bulid: unknown command
+Run 'go help' for usage.'''
 
 
-def test_match():
-    assert match(Command('go bulid', _GO_BUILD_MISSPELLED_OUTPUT))
+def test_match(build_misspelled_output):
+    assert match(Command('go bulid', build_misspelled_output))
 
 
 def test_not_match():
     assert not match(Command('go run', 'go run: no go files listed'))
+
+
+def test_get_new_command(build_misspelled_output):
+    assert get_new_command(Command('go bulid', build_misspelled_output)) == 'go build'

--- a/thefuck/rules/go_unknown_command.py
+++ b/thefuck/rules/go_unknown_command.py
@@ -1,14 +1,13 @@
-from thefuck.utils import get_closest, replace_argument
+from thefuck.utils import get_closest, replace_argument, for_app
 
 _GOLANG_COMMANDS = (
     "bug", "build", "clean", "doc", "env", "fix", "fmt", "generate", "get",
     "install", "list", "mod", "run", "test", "tool", "version", "vet")
 
 
+@for_app('go')
 def match(command):
-    return (command.script_parts
-            and command.script_parts[0] == "go"
-            and 'unknown command' in command.output)
+    return 'unknown command' in command.output
 
 
 def get_new_command(command):

--- a/thefuck/rules/go_unknown_command.py
+++ b/thefuck/rules/go_unknown_command.py
@@ -1,0 +1,18 @@
+from thefuck.utils import get_closest, replace_argument
+
+_GOLANG_COMMANDS = (
+    "bug", "build", "clean", "doc", "env", "fix", "fmt", "generate", "get",
+    "install", "list", "mod", "run", "test", "tool", "version", "vet")
+
+
+def match(command):
+    return (command.script_parts
+            and command.script_parts[0] == "go"
+            and 'unknown command' in command.output)
+
+
+def get_new_command(command):
+    closest_subcommand = get_closest(command.script_parts[1],
+                                     _GOLANG_COMMANDS)
+    return replace_argument(command.script, command.script_parts[1],
+                            closest_subcommand)

--- a/thefuck/rules/go_unknown_command.py
+++ b/thefuck/rules/go_unknown_command.py
@@ -14,7 +14,7 @@ def get_golang_commands():
 
 
 if which('go'):
-    get_docker_commands = cache(which('go'))(get_golang_commands())
+    get_docker_commands = cache(which('go'))(get_golang_commands)
 
 
 @for_app('go')


### PR DESCRIPTION
- Add: rules/go_unknown_command for misspelled go commands.
- Add: tests/test_go_unknown_command which tests match and mismatch case of rules/go_unknown_command.
- Change: Added description of go_unknown_command to README.md.