### PR TITLE
Fix: rules.git_checkout not working with git 2.22.0

### DIFF
--- a/thefuck/rules/git_checkout.py
+++ b/thefuck/rules/git_checkout.py
@@ -8,7 +8,7 @@ from thefuck.shells import shell
 
 @git_support
 def match(command):
-    return ('did not match any file(s) known to git.' in command.output
+    return ('did not match any file(s) known to git' in command.output
             and "Did you forget to 'git add'?" not in command.output)
 
 

--- a/thefuck/rules/git_checkout.py
+++ b/thefuck/rules/git_checkout.py
@@ -29,7 +29,7 @@ def get_branches():
 def get_new_command(command):
     missing_file = re.findall(
         r"error: pathspec '([^']*)' "
-        r"did not match any file\(s\) known to git.", command.output)[0]
+        r"did not match any file\(s\) known to git", command.output)[0]
     closest_branch = utils.get_closest(missing_file, get_branches(),
                                        fallback_to_first=False)
     if closest_branch:


### PR DESCRIPTION
```zsh
(.env) ik1nes-MacBook-Pro:~/Sources/thefuck ik1ne % git --version
git version 2.22.0
hub version 2.12.2
(.env) ik1nes-MacBook-Pro:~/Sources/thefuck ik1ne % thefuck --version
The Fuck 3.29 using Python 3.7.4 and ZSH 5.3
(.env) ik1nes-MacBook-Pro:~/Sources/thefuck ik1ne % git checkout mastr
error: pathspec 'mastr' did not match any file(s) known to git
(.env) ik1nes-MacBook-Pro:~/Sources/thefuck ik1ne % thefuck
Nothing found
```

As shown above, `git 2.22.0` does not print period in its output so `rules.git_checkout.match` does not work with `git 2.22.0`.
So I removed the period in the string search.
Since it uses `'string' in command.output`, previous version of git which prints period shouldn't be affected by this change. (tested the same command above inside `git 2.17.2` and it works fine)