### PR TITLE
Change sudo.py pattern to lowercase

### DIFF
--- a/thefuck/rules/sudo.py
+++ b/thefuck/rules/sudo.py
@@ -21,7 +21,7 @@ patterns = ['permission denied',
             'edspermissionerror',
             'you don\'t have write permissions',
             'use `sudo`',
-            'SudoRequiredError',
+            'sudorequirederror',
             'error: insufficient privileges']
 
 


### PR DESCRIPTION
The patterns in sudo.py should be in lowercase.