### PR TITLE
Correct "apt uninstall" -> "apt remove"

### DIFF
--- a/tests/rules/test_apt_invalid_operation.py
+++ b/tests/rules/test_apt_invalid_operation.py
@@ -116,6 +116,8 @@ def test_get_operations(set_help, app, help_text, operations):
      apt_get_help, 'apt-get install vim'),
     ('apt saerch vim', invalid_operation('saerch'),
      apt_help, 'apt search vim'),
+    ('apt uninstall vim', invalid_operation('uninstall'),
+     apt_help, 'apt remove vim'),
 ])
 def test_get_new_command(set_help, output, script, help_text, result):
     set_help(help_text)

--- a/thefuck/rules/apt_invalid_operation.py
+++ b/thefuck/rules/apt_invalid_operation.py
@@ -1,7 +1,7 @@
 import subprocess
 from thefuck.specific.apt import apt_available
 from thefuck.specific.sudo import sudo_support
-from thefuck.utils import for_app, eager, replace_command, replace_argument
+from thefuck.utils import for_app, eager, replace_command
 
 enabled_by_default = apt_available
 

--- a/thefuck/rules/apt_invalid_operation.py
+++ b/thefuck/rules/apt_invalid_operation.py
@@ -1,7 +1,7 @@
 import subprocess
 from thefuck.specific.apt import apt_available
 from thefuck.specific.sudo import sudo_support
-from thefuck.utils import for_app, eager, replace_command
+from thefuck.utils import for_app, eager, replace_command, replace_argument
 
 enabled_by_default = apt_available
 
@@ -53,5 +53,10 @@ def _get_operations(app):
 @sudo_support
 def get_new_command(command):
     invalid_operation = command.output.split()[-1]
-    operations = _get_operations(command.script_parts[0])
-    return replace_command(command, invalid_operation, operations)
+
+    if invalid_operation == 'uninstall':
+        return [command.script.replace('uninstall', 'remove')]
+
+    else:
+        operations = _get_operations(command.script_parts[0])
+        return replace_command(command, invalid_operation, operations)


### PR DESCRIPTION
Previously, `apt uninstall` would correct to `apt install` but this is more of the desired behavior

I considered putting this in a separate rule, `apt_uninstall`, with a higher priority than `apt_invalid_operation` but this seemed like a more straightforward approach. If there's a preference for doing it that way I can do that instead.