### PR TITLE
Slow command timeout didn’t work

### DIFF
--- a/thefuck/output_readers/rerun.py
+++ b/thefuck/output_readers/rerun.py
@@ -53,8 +53,8 @@ def get_output(script, expanded):
     env = dict(os.environ)
     env.update(settings.env)
 
-    is_slow = shlex.split(expanded) in settings.slow_commands
-    with logs.debug_time(u'Call: {}; with env: {}; is slow: '.format(
+    is_slow = shlex.split(expanded)[0] in settings.slow_commands
+    with logs.debug_time(u'Call: {}; with env: {}; is slow: {}'.format(
             script, env, is_slow)):
         result = Popen(expanded, shell=True, stdin=PIPE,
                        stdout=PIPE, stderr=STDOUT, env=env)

--- a/thefuck/output_readers/rerun.py
+++ b/thefuck/output_readers/rerun.py
@@ -53,7 +53,8 @@ def get_output(script, expanded):
     env = dict(os.environ)
     env.update(settings.env)
 
-    is_slow = shlex.split(expanded)[0] in settings.slow_commands
+    split_expand = shlex.split(expanded)
+    is_slow = split_expand[0] in settings.slow_commands if split_expand else False
     with logs.debug_time(u'Call: {}; with env: {}; is slow: {}'.format(
             script, env, is_slow)):
         result = Popen(expanded, shell=True, stdin=PIPE,


### PR DESCRIPTION
+ Fixed debug message to include is_slow
* Using only the first word of shlex.split when checking if command is slow.