### PR TITLE
Add fuck --hard as alternative to fuck --yeah

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ eval $(thefuck --alias FUCK)
 Changes are only available in a new shell session. To make changes immediately
 available, run `source ~/.bashrc` (or your shell config file like `.zshrc`).
 
-To run fixed commands without confirmation, use the `--yeah` option (or just `-y` for short):
+To run fixed commands without confirmation, use the `--yeah` option (or just `-y` for short, or `--hard` if you're especially frustrated):
 
 ```bash
 fuck --yeah

--- a/thefuck/argument_parser.py
+++ b/thefuck/argument_parser.py
@@ -55,7 +55,7 @@ class Parser(object):
         """It's too dangerous to use `-y` and `-r` together."""
         group = self._parser.add_mutually_exclusive_group()
         group.add_argument(
-            '-y', '--yes', '--yeah', '--hard'
+            '-y', '--yes', '--yeah', '--hard',
             action='store_true',
             help='execute fixed command without confirmation')
         group.add_argument(

--- a/thefuck/argument_parser.py
+++ b/thefuck/argument_parser.py
@@ -55,7 +55,7 @@ class Parser(object):
         """It's too dangerous to use `-y` and `-r` together."""
         group = self._parser.add_mutually_exclusive_group()
         group.add_argument(
-            '-y', '--yes', '--yeah',
+            '-y', '--yes', '--yeah', '--hard'
             action='store_true',
             help='execute fixed command without confirmation')
         group.add_argument(


### PR DESCRIPTION
The one thing I always found counterintuitive to 'fuck --yeah' is that it is an option that I normally use when I get very frustrated. 'fuck --yeah' sounds much too positive for those occasions, which is why I think it would be great to be able to use 'fuck --hard'.