### PR TITLE
added rule for drmemory commands missing --

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ following rules are enabled by default:
 * `docker_login` &ndash; executes a `docker login` and repeats the previous command;
 * `docker_not_command` &ndash; fixes wrong docker commands like `docker tags`;
 * `docker_image_being_used_by_container` &dash; removes the container that is using the image before removing the image;
+* `drmemory_no_dashdash` &ndash; adds `--` to drmemory commands;
 * `dry` &ndash; fixes repetitions like `git git push`;
 * `fab_command_not_found` &ndash; fix misspelled fabric commands;
 * `fix_alt_space` &ndash; replaces Alt+Space with Space character;
@@ -352,8 +353,8 @@ Your rule should not change `Command`.
 
 **Rules api changed in 3.0:** To access a rule's settings, import it with
  `from thefuck.conf import settings`
-  
-`settings` is a special object assembled from `~/.config/thefuck/settings.py`, 
+
+`settings` is a special object assembled from `~/.config/thefuck/settings.py`,
 and values from env ([see more below](#settings)).
 
 A simple example rule for running a script with `sudo`:

--- a/README.md
+++ b/README.md
@@ -353,8 +353,8 @@ Your rule should not change `Command`.
 
 **Rules api changed in 3.0:** To access a rule's settings, import it with
  `from thefuck.conf import settings`
-
-`settings` is a special object assembled from `~/.config/thefuck/settings.py`,
+  
+`settings` is a special object assembled from `~/.config/thefuck/settings.py`, 
 and values from env ([see more below](#settings)).
 
 A simple example rule for running a script with `sudo`:

--- a/tests/rules/test_drmemory_no_app_specified.py
+++ b/tests/rules/test_drmemory_no_app_specified.py
@@ -1,0 +1,27 @@
+import pytest
+from thefuck.rules.drmemory_no_dashdash import match, get_new_command
+from thefuck.types import Command
+
+
+@pytest.mark.parametrize('command', [
+    Command('drmemory a.out', 'Usage: drmemory [options] --'),
+    Command('/etc/bin/drmemory test.exe', 'Usage: drmemory [options] --'),
+])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command', [
+    Command('drmemory -- a.out', ''),
+    Command('/etc/bin/drmemory -- test.exe', ''),
+])
+def test_not_match(command):
+    assert not match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('drmemory a.out', ''), 'drmemory -- a.out'),
+    (Command('/etc/bin/drmemory test.exe', ''), '/etc/bin/drmemory -- test.exe'),
+])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/drmemory_no_dashdash.py
+++ b/thefuck/rules/drmemory_no_dashdash.py
@@ -1,0 +1,19 @@
+from thefuck.specific.sudo import sudo_support
+
+
+@sudo_support
+def match(command):
+    return (
+        "drmemory" in command.script
+        and len(command.script.split()) >= 2
+        and "Usage: drmemory [options] --" in command.output
+    )
+
+
+@sudo_support
+def get_new_command(command):
+    return(
+        command.script.split()[0]
+        + " -- "
+        + " ".join(command.script.split()[1:])
+    )


### PR DESCRIPTION
When running drmemory you need to add a `--` to the command. This rule helps add that.

so for example: `drmemory a.out` should be `drmemory -- a.out`

[http://www.drmemory.org/](http://www.drmemory.org/)
