### PR TITLE
removed extra whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,8 +352,8 @@ Your rule should not change `Command`.
 
 **Rules api changed in 3.0:** To access a rule's settings, import it with
  `from thefuck.conf import settings`
-  
-`settings` is a special object assembled from `~/.config/thefuck/settings.py`, 
+
+`settings` is a special object assembled from `~/.config/thefuck/settings.py`,
 and values from env ([see more below](#settings)).
 
 A simple example rule for running a script with `sudo`:


### PR DESCRIPTION
In the readme file there are 2 lines with extra whitespace. This is not a huge problem however many text editors (such as Atom which I use) remove this whitespace automatically when you save your files. This causes many people who want to change something else in the readme to have to go in and undo the automatic whitespace removal.

Here is an [example](https://github.com/nvbn/thefuck/pull/960#discussion_r331371333) of that happening.

I also had the same issue when I made my first commit to a pull request and you can see [here](https://github.com/nvbn/thefuck/pull/966/commits/2efa918e8777f4e26f614ceabcf72f885376d0b8) where I had to go back an undo the change.

While this is not something that needs to be fixed, it would be nice to removed the whitespace to reduce any future issues.