### PR TITLE
Add `wrong_hyphen_before_subcommand` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ following rules are enabled by default:
 * `vagrant_up` &ndash; starts up the vagrant instance;
 * `whois` &ndash; fixes `whois` command;
 * `workon_doesnt_exists` &ndash; fixes `virtualenvwrapper` env name os suggests to create new.
-* `wrong_hyphen_before_subcommand` &ndash; adds or omits dashes improperly placed (`ls-la` -> `ls -la`, `git-log` -> `git log`, etc.)
+* `wrong_hyphen_before_subcommand` &ndash; removes an improperly placed hyphen (`apt-install` -> `apt install`, `git-log` -> `git log`, etc.)
 * `yarn_alias` &ndash; fixes aliased `yarn` commands like `yarn ls`;
 * `yarn_command_not_found` &ndash; fixes misspelled `yarn` commands;
 * `yarn_command_replaced` &ndash; fixes replaced `yarn` commands;

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ following rules are enabled by default:
 * `vagrant_up` &ndash; starts up the vagrant instance;
 * `whois` &ndash; fixes `whois` command;
 * `workon_doesnt_exists` &ndash; fixes `virtualenvwrapper` env name os suggests to create new.
+* `wrong_hyphen_before_subcommand` &ndash; adds or omits dashes improperly placed (`ls-la` -> `ls -la`, `git-log` -> `git log`, etc.)
 * `yarn_alias` &ndash; fixes aliased `yarn` commands like `yarn ls`;
 * `yarn_command_not_found` &ndash; fixes misspelled `yarn` commands;
 * `yarn_command_replaced` &ndash; fixes replaced `yarn` commands;

--- a/tests/rules/test_wrong_hyphen_before_subcommand.py
+++ b/tests/rules/test_wrong_hyphen_before_subcommand.py
@@ -3,10 +3,11 @@ import pytest
 from thefuck.rules.wrong_hyphen_before_subcommand import match, get_new_command
 from thefuck.types import Command
 
+
 @pytest.fixture(autouse=True)
 def get_all_executables(mocker):
     mocker.patch('thefuck.rules.wrong_hyphen_before_subcommand.get_all_executables',
-        return_value=['git', 'apt', 'apt-get', 'ls', 'pwd'])
+                 return_value=['git', 'apt', 'apt-get', 'ls', 'pwd'])
 
 
 @pytest.mark.parametrize('script', [

--- a/tests/rules/test_wrong_hyphen_before_subcommand.py
+++ b/tests/rules/test_wrong_hyphen_before_subcommand.py
@@ -1,0 +1,33 @@
+import pytest
+
+from thefuck.rules.wrong_hyphen_before_subcommand import match, get_new_command
+from thefuck.types import Command
+
+@pytest.fixture(autouse=True)
+def get_all_executables(mocker):
+    mocker.patch('thefuck.rules.wrong_hyphen_before_subcommand.get_all_executables',
+        return_value=['git', 'apt', 'apt-get', 'ls', 'pwd'])
+
+
+@pytest.mark.parametrize('script', [
+    'ls-la',
+    'git-log',
+    'apt-install python'])
+def test_match(mocker, script):
+    assert match(Command(script, ""))
+
+
+@pytest.mark.parametrize('script, result', [
+    ('ls-la', 'ls -la'),
+    ('git-log', 'git log'),
+    ('apt-install python', 'apt install python')])
+def test_get_new_command(mocker, script, result):
+    assert get_new_command(Command(script, "")) == result
+
+
+@pytest.mark.parametrize('script', [
+    'ls la',
+    'git-make',
+    'apt-get python'])
+def test_not_match(mocker, script):
+    assert not match(Command(script, ""))

--- a/tests/rules/test_wrong_hyphen_before_subcommand.py
+++ b/tests/rules/test_wrong_hyphen_before_subcommand.py
@@ -11,7 +11,6 @@ def get_all_executables(mocker):
 
 
 @pytest.mark.parametrize('script', [
-    'ls-la',
     'git-log',
     'apt-install python'])
 def test_match(mocker, script):
@@ -19,7 +18,6 @@ def test_match(mocker, script):
 
 
 @pytest.mark.parametrize('script, result', [
-    ('ls-la', 'ls -la'),
     ('git-log', 'git log'),
     ('apt-install python', 'apt install python')])
 def test_get_new_command(mocker, script, result):
@@ -27,8 +25,8 @@ def test_get_new_command(mocker, script, result):
 
 
 @pytest.mark.parametrize('script', [
-    'ls la',
-    'git-make',
+    'ls -la',
+    'git2-make',
     'apt-get python'])
 def test_not_match(mocker, script):
     assert not match(Command(script, ""))

--- a/tests/rules/test_wrong_hyphen_before_subcommand.py
+++ b/tests/rules/test_wrong_hyphen_before_subcommand.py
@@ -6,27 +6,25 @@ from thefuck.types import Command
 
 @pytest.fixture(autouse=True)
 def get_all_executables(mocker):
-    mocker.patch('thefuck.rules.wrong_hyphen_before_subcommand.get_all_executables',
-                 return_value=['git', 'apt', 'apt-get', 'ls', 'pwd'])
+    mocker.patch(
+        "thefuck.rules.wrong_hyphen_before_subcommand.get_all_executables",
+        return_value=["git", "apt", "apt-get", "ls", "pwd"],
+    )
 
 
-@pytest.mark.parametrize('script', [
-    'git-log',
-    'apt-install python'])
-def test_match(mocker, script):
+@pytest.mark.parametrize("script", ["git-log", "apt-install python"])
+def test_match(script):
     assert match(Command(script, ""))
 
 
-@pytest.mark.parametrize('script, result', [
-    ('git-log', 'git log'),
-    ('apt-install python', 'apt install python')])
-def test_get_new_command(mocker, script, result):
-    assert get_new_command(Command(script, "")) == result
-
-
-@pytest.mark.parametrize('script', [
-    'ls -la',
-    'git2-make',
-    'apt-get python'])
-def test_not_match(mocker, script):
+@pytest.mark.parametrize("script", ["ls -la", "git2-make", "apt-get install python"])
+def test_not_match(script):
     assert not match(Command(script, ""))
+
+
+@pytest.mark.parametrize(
+    "script, new_command",
+    [("git-log", "git log"), ("apt-install python", "apt install python")],
+)
+def test_get_new_command(script, new_command):
+    assert get_new_command(Command(script, "")) == new_command

--- a/thefuck/rules/wrong_hyphen_before_subcommand.py
+++ b/thefuck/rules/wrong_hyphen_before_subcommand.py
@@ -90,7 +90,7 @@ def get_flags(man):
 
 def find_at_start(word, line):
     return line.startswith(word) and\
-        (len(line) == len(word) or line[len(word)] in ', ')
+        (len(line) == len(word) or line[len(word)] in ', (:')
 
 
 def find_subcommand(manpage, command, subcommand):
@@ -98,8 +98,8 @@ def find_subcommand(manpage, command, subcommand):
         any(map(partial(find_at_start, "%s-%s" % (command, subcommand)), manpage))
 
 
-def find_flag(manpage, flag):
-    return any(map(partial(find_at_start, flag), manpage))
+def find_flag(flags, flag):
+    return any(map(partial(find_at_start, '-' + flag), flags))
 
 
 @sudo_support

--- a/thefuck/rules/wrong_hyphen_before_subcommand.py
+++ b/thefuck/rules/wrong_hyphen_before_subcommand.py
@@ -110,7 +110,7 @@ def match(command):
     if '-' not in command.script_parts[0]:
         return False
 
-    cmd, subcmd, *_ = command.script_parts[0].split('-')
+    cmd, subcmd = command.script_parts[0].split('-')[:2]
     if cmd not in get_all_executables():
         return False
 
@@ -135,7 +135,7 @@ def match(command):
 
 @sudo_support
 def get_new_command(command):
-    cmd, subcmd, *_ = command.script_parts[0].split('-')
+    cmd, subcmd = command.script_parts[0].split('-')[:2]
     manpage = get_manpage(cmd)
     synopsis = get_synopsis(manpage)
 

--- a/thefuck/rules/wrong_hyphen_before_subcommand.py
+++ b/thefuck/rules/wrong_hyphen_before_subcommand.py
@@ -2,150 +2,21 @@ from thefuck.utils import get_all_executables
 from thefuck.specific.sudo import sudo_support
 
 
-import re
-import gzip
-import os.path
-from functools import partial
-
-
-def get_manpage_dir():
-    """Returns the manpage directory for the system.
-
-    :rtype: str
-
-    Currently returns the default directory. On systems on which the manpage directory is configured
-    otherwise, this rule will not function. TODO: Dynamically find the directory.
-    """
-    return "/usr/share/man"
-
-
-def get_manpage_path(command, number=None):
-    """Finds the specific manpage path inside the manpages directory for a given command.
-
-    :type command: str
-    :type number: int (optional, if not provided the number will be auto detected)
-    :rtype: str (the path of the manpage for the command)
-    """
-    if number is None:
-        return get_manpage_path(command, 1) or\
-            get_manpage_path(command, 8) or\
-            get_manpage_path(command, 7)
-
-    path = os.path.join(get_manpage_dir(), "man%d" % (number,), "%s.%d.gz" % (command, number))
-    return path if os.path.exists(path) else None
-
-
-def get_manpage(command, number=None):
-    """Returns the manpage for a command - a list of parsed lines
-
-    :type command: str
-    :type number: int (optional)
-    :rtype: [str]
-    """
-    path = get_manpage_path(command, number)
-    if path:
-        with gzip.open(path, "r") as f:
-            return list(filter(None, (textify(line) for line in f.readlines())))
-    else:
-        return []
-
-
-def textify(manline):
-    """Stringifies a manpage line (strips markdown instructions, unescapes characters and removes quotes)
-
-    :type manline: bytes
-    :rtype: str
-    """
-    # Stripping line headers .SH, .B
-    manline = re.sub(r"^\.[A-Za-z]+( |$)", "", str(manline, "utf-8").strip())
-
-    # Stripping format
-    manline = re.sub(r"\\f.", "", manline)
-    manline = re.sub(r"\\(.)", r"\1", manline)
-
-    # Stripping quotes
-    return manline.replace('"', '').replace('\'', '')
-
-
-def get_synopsis(man):
-    """Given a parsed manpage entry (as returned from get_manpage), returns the synopsis line from the manpage
-
-    :type man: [str]
-    :rtype: str
-    """
-    try:
-        return " ".join(line for line in man[man.index("SYNOPSIS") + 1: man.index("DESCRIPTION")])
-    except ValueError:
-        return ""
-
-
-def get_flags(man):
-    """Given a parsed manpage entry (as returned from get_manpage), returns a list of lines which contain flag information
-
-    :type man: [str]
-    :rtype: [str]
-    """
-    return [x for x in man if x[0] == '-']
-
-
-def find_at_start(word, line):
-    return line.startswith(word) and\
-        (len(line) == len(word) or line[len(word)] in ', (:')
-
-
-def find_subcommand(manpage, command, subcommand):
-    return any(map(partial(find_at_start, subcommand), manpage)) or\
-        any(map(partial(find_at_start, "%s-%s" % (command, subcommand)), manpage))
-
-
-def find_flag(flags, flag):
-    return any(map(partial(find_at_start, '-' + flag), flags))
-
-
 @sudo_support
 def match(command):
-    if command.script_parts[0] in get_all_executables():
-        return False
-
-    if '-' not in command.script_parts[0]:
+    if '-' not in command.script_parts[0] or command.script_parts[0] in get_all_executables():
         return False
 
     cmd, subcmd = command.script_parts[0].split('-')[:2]
     if cmd not in get_all_executables():
         return False
 
-    manpage = get_manpage(cmd)
-    if not manpage:
-        return False
-
-    synopsis = get_synopsis(manpage)
-    if subcmd in synopsis:
-        return True
-
-    if find_subcommand(manpage, cmd, subcmd):
-        return True
-
-    flags = get_flags(manpage)
-    for flag in subcmd:
-        if not find_flag(flags, flag):
-            return False
-
     return True
 
 
 @sudo_support
 def get_new_command(command):
-    cmd, subcmd = command.script_parts[0].split('-')[:2]
-    manpage = get_manpage(cmd)
-    synopsis = get_synopsis(manpage)
-
-    if subcmd in synopsis or find_subcommand(manpage, cmd, subcmd):
-        # We are dealing with an accidentally added hyphen
-        return command.script.replace('-', ' ', 1)
-
-    else:
-        # We are dealing with a missing space
-        return command.script.replace('-', ' -', 1)
+    return command.script.replace("-", " ", 1)
 
 
-priority = 2500
+priority = 2900

--- a/thefuck/rules/wrong_hyphen_before_subcommand.py
+++ b/thefuck/rules/wrong_hyphen_before_subcommand.py
@@ -1,0 +1,43 @@
+from thefuck.utils import get_all_executables, get_close_matches, \
+    get_valid_history_without_current, get_closest, which
+from thefuck.specific.sudo import sudo_support
+from thefuck import logs
+
+import os.path
+import subprocess
+import gzip
+
+def get_manpage_dir():
+    return "/usr/share/man"
+
+
+def get_manpage_path(command, number = None):
+    if number == None:
+        return get_manpage_path(command, 1) or
+            get_manpage_path(command, 8) or
+            get_manpage_path(command, 7)
+    
+    path = os.path.join(get_manpage_dir(), "man%d" % (number,), "%s.%d.gz" % (command, number))
+    return path if os.path.exists(path) else None
+
+
+def get_manpage(command, number = None):
+    path = get_manpage_path(command, number)
+    if path:
+        with gzip.open(path, "r") as f:
+            return [line.strip() for line in f.readlines()]
+    else:
+        return []
+
+
+@sudo_support
+def match(command):
+    return False
+
+
+@sudo_support
+def get_new_command(command):
+    return ""
+
+
+priority = 1 # For debugging purposes only

--- a/thefuck/rules/wrong_hyphen_before_subcommand.py
+++ b/thefuck/rules/wrong_hyphen_before_subcommand.py
@@ -3,9 +3,12 @@ from thefuck.utils import get_all_executables, get_close_matches, \
 from thefuck.specific.sudo import sudo_support
 from thefuck import logs
 
+
 import os.path
 import subprocess
 import gzip
+import re
+
 
 def get_manpage_dir():
     return "/usr/share/man"
@@ -13,8 +16,8 @@ def get_manpage_dir():
 
 def get_manpage_path(command, number = None):
     if number == None:
-        return get_manpage_path(command, 1) or
-            get_manpage_path(command, 8) or
+        return get_manpage_path(command, 1) or\
+            get_manpage_path(command, 8) or\
             get_manpage_path(command, 7)
     
     path = os.path.join(get_manpage_dir(), "man%d" % (number,), "%s.%d.gz" % (command, number))
@@ -25,9 +28,27 @@ def get_manpage(command, number = None):
     path = get_manpage_path(command, number)
     if path:
         with gzip.open(path, "r") as f:
-            return [line.strip() for line in f.readlines()]
+            return list(filter(None, (textify(line) for line in f.readlines())))
     else:
         return []
+
+
+def textify(manline):
+    manline = re.sub(r"^\.[A-Za-z]+( |$)", "", str(manline, "utf-8").strip()) # Stripping line headers .SH, .B
+    manline = re.sub(r"\\f.", "", manline) # Stripping format
+    manline = re.sub(r"\\(.)", r"\1", manline)
+    return manline.replace('"', '').replace('\'', '')
+
+
+def get_synopsis(man):
+    try:
+        return " ".join(line for line in man[man.index("SYNOPSIS") + 1: man.index("DESCRIPTION")])
+    except ValueError:
+        return []
+
+
+def get_flags(man):
+    return [x for x in man if x[0] == '-']
 
 
 @sudo_support

--- a/thefuck/rules/wrong_hyphen_before_subcommand.py
+++ b/thefuck/rules/wrong_hyphen_before_subcommand.py
@@ -87,6 +87,11 @@ def get_flags(man):
     return [x for x in man if x[0] == '-']
 
 
+def find_subcommand(manpage, command, subcommand):
+    return any(map(lambda x: x.startswith(subcommand), manpage)) or\
+        any(map(lambda x: x.startswith("%s-%s" % (command, subcommand)), manpage))
+
+
 @sudo_support
 def match(command):
     if '-' not in command.script_parts[0]:
@@ -104,6 +109,9 @@ def match(command):
     if subcmd in synopsis:
         return True
 
+    if find_subcommand(manpage, cmd, subcmd):
+        return True
+
     flags = "".join(get_flags(manpage))
     for flag in subcmd:
         if "-%s" % (flag,) not in flags:
@@ -118,7 +126,7 @@ def get_new_command(command):
     manpage = get_manpage(cmd)
     synopsis = get_synopsis(manpage)
 
-    if subcmd in synopsis:
+    if subcmd in synopsis or find_subcommand(manpage, cmd, subcmd):
         # We are dealing with an accidentally added hyphen
         return command.script.replace('-', ' ', 1)
 

--- a/thefuck/rules/wrong_hyphen_before_subcommand.py
+++ b/thefuck/rules/wrong_hyphen_before_subcommand.py
@@ -1,30 +1,46 @@
-from thefuck.utils import get_all_executables, get_close_matches, \
-    get_valid_history_without_current, get_closest, which
+from thefuck.utils import get_all_executables
 from thefuck.specific.sudo import sudo_support
-from thefuck import logs
 
 
-import os.path
-import subprocess
-import gzip
 import re
+import gzip
+import os.path
 
 
 def get_manpage_dir():
+    """Returns the manpage directory for the system.
+
+    :rtype: str
+
+    Currently returns the default directory. On systems on which the manpage directory is configured
+    otherwise, this rule will not function. TODO: Dynamically find the directory.
+    """
     return "/usr/share/man"
 
 
-def get_manpage_path(command, number = None):
-    if number == None:
+def get_manpage_path(command, number=None):
+    """Finds the specific manpage path inside the manpages directory for a given command.
+
+    :type command: str
+    :type number: int (optional, if not provided the number will be auto detected)
+    :rtype: str (the path of the manpage for the command)
+    """
+    if number is None:
         return get_manpage_path(command, 1) or\
             get_manpage_path(command, 8) or\
             get_manpage_path(command, 7)
-    
+
     path = os.path.join(get_manpage_dir(), "man%d" % (number,), "%s.%d.gz" % (command, number))
     return path if os.path.exists(path) else None
 
 
-def get_manpage(command, number = None):
+def get_manpage(command, number=None):
+    """Returns the manpage for a command - a list of parsed lines
+
+    :type command: str
+    :type number: int (optional)
+    :rtype: [str]
+    """
     path = get_manpage_path(command, number)
     if path:
         with gzip.open(path, "r") as f:
@@ -34,20 +50,40 @@ def get_manpage(command, number = None):
 
 
 def textify(manline):
-    manline = re.sub(r"^\.[A-Za-z]+( |$)", "", str(manline, "utf-8").strip()) # Stripping line headers .SH, .B
-    manline = re.sub(r"\\f.", "", manline) # Stripping format
+    """Stringifies a manpage line (strips markdown instructions, unescapes characters and removes quotes)
+
+    :type manline: bytes
+    :rtype: str
+    """
+    # Stripping line headers .SH, .B
+    manline = re.sub(r"^\.[A-Za-z]+( |$)", "", str(manline, "utf-8").strip())
+
+    # Stripping format
+    manline = re.sub(r"\\f.", "", manline)
     manline = re.sub(r"\\(.)", r"\1", manline)
+
+    # Stripping quotes
     return manline.replace('"', '').replace('\'', '')
 
 
 def get_synopsis(man):
+    """Given a parsed manpage entry (as returned from get_manpage), returns the synopsis line from the manpage
+
+    :type man: [str]
+    :rtype: str
+    """
     try:
         return " ".join(line for line in man[man.index("SYNOPSIS") + 1: man.index("DESCRIPTION")])
     except ValueError:
-        return []
+        return ""
 
 
 def get_flags(man):
+    """Given a parsed manpage entry (as returned from get_manpage), returns a list of lines which contain flag information
+
+    :type man: [str]
+    :rtype: [str]
+    """
     return [x for x in man if x[0] == '-']
 
 
@@ -75,16 +111,19 @@ def match(command):
 
     return True
 
+
 @sudo_support
 def get_new_command(command):
     cmd, subcmd, *_ = command.script_parts[0].split('-')
     manpage = get_manpage(cmd)
     synopsis = get_synopsis(manpage)
 
-    if subcmd in synopsis: # We are dealing with an accidentally added hyphen
+    if subcmd in synopsis:
+        # We are dealing with an accidentally added hyphen
         return command.script.replace('-', ' ', 1)
 
-    else: # We are dealing with a missing space
+    else:
+        # We are dealing with a missing space
         return command.script.replace('-', ' -', 1)
 
 

--- a/thefuck/rules/wrong_hyphen_before_subcommand.py
+++ b/thefuck/rules/wrong_hyphen_before_subcommand.py
@@ -53,12 +53,39 @@ def get_flags(man):
 
 @sudo_support
 def match(command):
-    return False
+    if '-' not in command.script_parts[0]:
+        return False
 
+    cmd, subcmd, *_ = command.script_parts[0].split('-')
+    if cmd not in get_all_executables():
+        return False
+
+    manpage = get_manpage(cmd)
+    if not manpage:
+        return False
+
+    synopsis = get_synopsis(manpage)
+    if subcmd in synopsis:
+        return True
+
+    flags = "".join(get_flags(manpage))
+    for flag in subcmd:
+        if "-%s" % (flag,) not in flags:
+            return False
+
+    return True
 
 @sudo_support
 def get_new_command(command):
-    return ""
+    cmd, subcmd, *_ = command.script_parts[0].split('-')
+    manpage = get_manpage(cmd)
+    synopsis = get_synopsis(manpage)
+
+    if subcmd in synopsis: # We are dealing with an accidentally added hyphen
+        return command.script.replace('-', ' ', 1)
+
+    else: # We are dealing with a missing space
+        return command.script.replace('-', ' -', 1)
 
 
-priority = 1 # For debugging purposes only
+priority = 2500

--- a/thefuck/rules/wrong_hyphen_before_subcommand.py
+++ b/thefuck/rules/wrong_hyphen_before_subcommand.py
@@ -4,13 +4,10 @@ from thefuck.specific.sudo import sudo_support
 
 @sudo_support
 def match(command):
-    if (
-        "-" not in command.script_parts[0]
-        or command.script_parts[0] in get_all_executables()
-    ):
+    first_part = command.script_parts[0]
+    if "-" not in first_part or first_part in get_all_executables():
         return False
-
-    cmd, _ = command.script_parts[0].split("-", 1)
+    cmd, _ = first_part.split("-", 1)
     return cmd in get_all_executables()
 
 
@@ -19,5 +16,5 @@ def get_new_command(command):
     return command.script.replace("-", " ", 1)
 
 
-priority = 2900
+priority = 4500
 requires_output = False

--- a/thefuck/rules/wrong_hyphen_before_subcommand.py
+++ b/thefuck/rules/wrong_hyphen_before_subcommand.py
@@ -4,14 +4,14 @@ from thefuck.specific.sudo import sudo_support
 
 @sudo_support
 def match(command):
-    if '-' not in command.script_parts[0] or command.script_parts[0] in get_all_executables():
+    if (
+        "-" not in command.script_parts[0]
+        or command.script_parts[0] in get_all_executables()
+    ):
         return False
 
-    cmd, subcmd = command.script_parts[0].split('-')[:2]
-    if cmd not in get_all_executables():
-        return False
-
-    return True
+    cmd, _ = command.script_parts[0].split("-", 1)
+    return cmd in get_all_executables()
 
 
 @sudo_support
@@ -20,3 +20,4 @@ def get_new_command(command):
 
 
 priority = 2900
+requires_output = False


### PR DESCRIPTION
This rule corrects two common mistakes:

1. Omitting the space between the command and its flag arguments (e.g. `ls-la` instead of `ls -la`)
2. Placing a hyphen rather than a space between a command and its subcommand (e.g. `apt-install` and not `apt install`)

Regarding issue #975 