### PR TITLE
#N/A: Add new `git_branch_delete_checked_out` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ following rules are enabled by default:
 * `git_add_force` &ndash; adds `--force` to `git add <pathspec>...` when paths are .gitignore'd;
 * `git_bisect_usage` &ndash; fixes `git bisect strt`, `git bisect goood`, `git bisect rset`, etc. when bisecting;
 * `git_branch_delete` &ndash; changes `git branch -d` to `git branch -D`;
+* `git_branch_delete_checked_out` &ndash; changes `git branch -d` to `git checkout master && git branch -D` when trying to delete a checked out branch;
 * `git_branch_exists` &ndash; offers `git branch -d foo`, `git branch -D foo` or `git checkout foo` when creating a branch that already exists;
 * `git_branch_list` &ndash; catches `git branch list` in place of `git branch` and removes created branch;
 * `git_checkout` &ndash; fixes branch name or creates new branch;

--- a/tests/rules/test_git_branch_delete_checked_out.py
+++ b/tests/rules/test_git_branch_delete_checked_out.py
@@ -1,0 +1,29 @@
+import pytest
+from thefuck.rules.git_branch_delete_checked_out import match, get_new_command
+from thefuck.types import Command
+
+
+@pytest.fixture
+def output():
+    return "error: Cannot delete branch 'foo' checked out at '/bar/foo'"
+
+
+@pytest.mark.parametrize("script", ["git branch -d foo", "git branch -D foo"])
+def test_match(script, output):
+    assert match(Command(script, output))
+
+
+@pytest.mark.parametrize("script", ["git branch -d foo", "git branch -D foo"])
+def test_not_match(script):
+    assert not match(Command(script, "Deleted branch foo (was a1b2c3d)."))
+
+
+@pytest.mark.parametrize(
+    "script, new_command",
+    [
+        ("git branch -d foo", "git checkout master && git branch -D foo"),
+        ("git branch -D foo", "git checkout master && git branch -D foo"),
+    ],
+)
+def test_get_new_command(script, new_command, output):
+    assert get_new_command(Command(script, output)) == new_command

--- a/thefuck/rules/git_branch_delete_checked_out.py
+++ b/thefuck/rules/git_branch_delete_checked_out.py
@@ -1,0 +1,19 @@
+from thefuck.shells import shell
+from thefuck.specific.git import git_support
+from thefuck.utils import replace_argument
+
+
+@git_support
+def match(command):
+    return (
+        ("branch -d" in command.script or "branch -D" in command.script)
+        and "error: Cannot delete branch '" in command.output
+        and "' checked out at '" in command.output
+    )
+
+
+@git_support
+def get_new_command(command):
+    return shell.and_("git checkout master", "{}").format(
+        replace_argument(command.script, "-d", "-D")
+    )


### PR DESCRIPTION
Add a new rule to delete the currently checked out branch, if so desired:

    $ git checkout -b foo
    Switched to a new branch 'foo'
    $ git branch -d foo
    error: Cannot delete branch 'foo' checked out at '/Users/scorphus/Workspace/thefuck'
    $ fuck
    git checkout master; and git branch -D foo [enter/↑/↓/ctrl+c]
    Switched to branch 'master'
    Your branch is up to date with 'origin/master'.
    Deleted branch foo (was 34872f1).