### PR TITLE
Add pyenv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,8 @@ target/
 .env
 .idea
 
+# pyenv
+.python-version/
+
 # vim temporary files
 .*.swp


### PR DESCRIPTION
I have started using `pyenv` to create and manage Python virtual environments. I noticed that there is no config for `pyenv` within the current gitignore so I thought I would add it.