### PR TITLE
Only including necessary envs in THEFUCK_DEBUG=true.

### DIFF
--- a/thefuck/output_readers/rerun.py
+++ b/thefuck/output_readers/rerun.py
@@ -52,11 +52,12 @@ def get_output(script, expanded):
     """
     env = dict(os.environ)
     env.update(settings.env)
+    log_env = {key: env[key] for key in ['TF_SHELL', 'TF_ALIAS', 'TF_SHELL_ALIASES'] if key in env}
 
     split_expand = shlex.split(expanded)
     is_slow = split_expand[0] in settings.slow_commands if split_expand else False
     with logs.debug_time(u'Call: {}; with env: {}; is slow: {}'.format(
-            script, env, is_slow)):
+            script, log_env, is_slow)):
         result = Popen(expanded, shell=True, stdin=PIPE,
                        stdout=PIPE, stderr=STDOUT, env=env)
         if _wait_output(result, is_slow):


### PR DESCRIPTION
Issue: #946.

Reason:
`Thefuck shouldn't include all env variables in the debug output. It is not necessary that you have private tokens, ssh connection ips and other personal identifiable information.`

Modifications:
`Kept the following three env variables only:
- TF_SHELL=bash
- TF_ALIAS=c
- TF_SHELL_ALIASES`


