### PR TITLE
Add rule to remove leading shell prompt literal $

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ following rules are enabled by default:
 * `quotation_marks` &ndash; fixes uneven usage of `'` and `"` when containing args';
 * `path_from_history` &ndash; replaces not found path with similar absolute path from history;
 * `react_native_command_unrecognized` &ndash; fixes unrecognized `react-native` commands;
+* `remove_shell_prompt_literal` &ndash; remove leading shell prompt symbol `$`, common when copying commands from documentations;
 * `remove_trailing_cedilla` &ndash; remove trailling cedillas `ç`, a common typo for european keyboard layouts;
 * `rm_dir` &ndash; adds `-rf` when you try to remove a directory;
 * `scm_correction` &ndash; corrects wrong scm like `hg log` to `git log`;

--- a/tests/rules/test_remove_shell_prompt_literal.py
+++ b/tests/rules/test_remove_shell_prompt_literal.py
@@ -3,30 +3,31 @@ from thefuck.rules.remove_shell_prompt_literal import match, get_new_command
 from thefuck.types import Command
 
 
-@pytest.mark.parametrize('command',
+@pytest.mark.parametrize(
+    "command",
     [
-        Command('$ cd newdir', '$: command not found'),
-        Command(' $ cd newdir', '$: command not found'),
-    ])
+        Command("$ cd newdir", "$: command not found"),
+        Command(" $ cd newdir", "$: command not found"),
+    ],
+)
 def test_match(command):
     assert match(command)
 
 
-@pytest.mark.parametrize('command',
-    [
-        Command('$', ''),
-        Command('$?', ''),
-        Command(' $?', ''),
-        Command('', ''),
-    ])
+@pytest.mark.parametrize(
+    "command",
+    [Command("$", ""), Command("$?", ""), Command(" $?", ""), Command("", "")],
+)
 def test_not_match(command):
     assert not match(command)
 
 
-@pytest.mark.parametrize('command, new_command',
+@pytest.mark.parametrize(
+    "command, new_command",
     [
-        (Command('$ cd newdir', ''), 'cd newdir'),
-        (Command('$ python3 -m virtualenv env', ''), 'python3 -m virtualenv env'),
-    ])
+        (Command("$ cd newdir", ""), "cd newdir"),
+        (Command("$ python3 -m virtualenv env", ""), "python3 -m virtualenv env"),
+    ],
+)
 def test_get_new_command(command, new_command):
     assert get_new_command(command) == new_command

--- a/tests/rules/test_remove_shell_prompt_literal.py
+++ b/tests/rules/test_remove_shell_prompt_literal.py
@@ -1,0 +1,32 @@
+import pytest
+from thefuck.rules.remove_shell_prompt_literal import match, get_new_command
+from thefuck.types import Command
+
+
+@pytest.mark.parametrize('command',
+    [
+        Command('$ cd newdir', '$: command not found'),
+        Command(' $ cd newdir', '$: command not found'),
+    ])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command',
+    [
+        Command('$', ''),
+        Command('$?', ''),
+        Command(' $?', ''),
+        Command('', ''),
+    ])
+def test_not_match(command):
+    assert not match(command)
+
+
+@pytest.mark.parametrize('command, new_command',
+    [
+        (Command('$ cd newdir', ''), 'cd newdir'),
+        (Command('$ python3 -m virtualenv env', ''), 'python3 -m virtualenv env'),
+    ])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_remove_shell_prompt_literal.py
+++ b/tests/rules/test_remove_shell_prompt_literal.py
@@ -3,31 +3,36 @@ from thefuck.rules.remove_shell_prompt_literal import match, get_new_command
 from thefuck.types import Command
 
 
+@pytest.fixture
+def output():
+    return "$: command not found"
+
+
+@pytest.mark.parametrize("script", ["$ cd newdir", " $ cd newdir"])
+def test_match(script, output):
+    assert match(Command(script, output))
+
+
 @pytest.mark.parametrize(
     "command",
     [
-        Command("$ cd newdir", "$: command not found"),
-        Command(" $ cd newdir", "$: command not found"),
+        Command("$", "$: command not found"),
+        Command(" $", "$: command not found"),
+        Command("$?", "127: command not found"),
+        Command(" $?", "127: command not found"),
+        Command("", ""),
     ],
-)
-def test_match(command):
-    assert match(command)
-
-
-@pytest.mark.parametrize(
-    "command",
-    [Command("$", ""), Command("$?", ""), Command(" $?", ""), Command("", "")],
 )
 def test_not_match(command):
     assert not match(command)
 
 
 @pytest.mark.parametrize(
-    "command, new_command",
+    "script, new_command",
     [
-        (Command("$ cd newdir", ""), "cd newdir"),
-        (Command("$ python3 -m virtualenv env", ""), "python3 -m virtualenv env"),
+        ("$ cd newdir", "cd newdir"),
+        ("$ python3 -m virtualenv env", "python3 -m virtualenv env"),
     ],
 )
-def test_get_new_command(command, new_command):
-    assert get_new_command(command) == new_command
+def test_get_new_command(script, new_command, output):
+    assert get_new_command(Command(script, output)) == new_command

--- a/thefuck/rules/remove_shell_prompt_literal.py
+++ b/thefuck/rules/remove_shell_prompt_literal.py
@@ -1,0 +1,20 @@
+"""Fixes error for commands containing the shell prompt symbol '$'.
+
+This usually happens when commands are copied from documentations
+including them in their code blocks.
+
+Example:
+> $ git clone https://github.com/nvbn/thefuck.git
+bash: $: command not found...
+"""
+
+import re
+
+def match(command):
+    return ("$: command not found" in command.output and
+            re.search(r"^[\s]*\$ [\S]+", command.script) is not None)
+
+def get_new_command(command):
+    return command.script.replace("$", "", 1).strip()
+
+requires_output = True

--- a/thefuck/rules/remove_shell_prompt_literal.py
+++ b/thefuck/rules/remove_shell_prompt_literal.py
@@ -20,6 +20,3 @@ def match(command):
 
 def get_new_command(command):
     return command.script.replace("$", "", 1).strip()
-
-
-requires_output = True

--- a/thefuck/rules/remove_shell_prompt_literal.py
+++ b/thefuck/rules/remove_shell_prompt_literal.py
@@ -10,11 +10,16 @@ bash: $: command not found...
 
 import re
 
+
 def match(command):
-    return ("$: command not found" in command.output and
-            re.search(r"^[\s]*\$ [\S]+", command.script) is not None)
+    return (
+        "$: command not found" in command.output
+        and re.search(r"^[\s]*\$ [\S]+", command.script) is not None
+    )
+
 
 def get_new_command(command):
     return command.script.replace("$", "", 1).strip()
+
 
 requires_output = True


### PR DESCRIPTION
Rule added to remove leading shell prompt literals found in the command.

This usually happens when a command is copy pasted from documentations with code blocks that contain it.

```
$ $ echo hello world
bash: $: command not found...
$ fuck
echo hello world [enter/↑/↓/ctrl+c]
hello world
```