### PR TITLE
Add choco_install rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ following rules are enabled by default:
 * `cd_mkdir` &ndash; creates directories before cd'ing into them;
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;
 * `chmod_x` &ndash; add execution bit;
+* `choco_install` &ndash; append common suffixes for chocolatey packages;
 * `composer_not_command` &ndash; fixes composer command name;
 * `cp_omitting_directory` &ndash; adds `-a` when you `cp` directory;
 * `cpp11` &ndash; adds missing `-std=c++11` to `g++` or `clang++`;

--- a/tests/rules/test_choco_install.py
+++ b/tests/rules/test_choco_install.py
@@ -1,0 +1,12 @@
+import pytest
+from thefuck.rules.choco_install import get_new_command
+from thefuck.types import Command
+
+
+@pytest.mark.parametrize('before, after', [
+    ('choco install logstitcher', 'choco install logstitcher.install'),
+    ('cinst logstitcher', 'cinst logstitcher.install'),
+    ('choco install logstitcher -y', 'choco install logstitcher.install -y'),
+    ('cinst logstitcher -y', 'cinst logstitcher.install -y')])
+def test_get_new_command(before, after):
+    assert (get_new_command(Command(before, '')) == after)

--- a/tests/rules/test_choco_install.py
+++ b/tests/rules/test_choco_install.py
@@ -1,6 +1,74 @@
 import pytest
-from thefuck.rules.choco_install import get_new_command
+from thefuck.rules.choco_install import match, get_new_command
 from thefuck.types import Command
+
+
+package_not_found_error = (
+    'Chocolatey v0.10.15\n'
+    'Installing the following packages:\n'
+    'logstitcher\n'
+    'By installing you accept licenses for the packages.\n'
+    'logstitcher not installed. The package was not found with the source(s) listed.\n'
+    ' Source(s): \'https://chocolatey.org/api/v2/\'\n'
+    ' NOTE: When you specify explicit sources, it overrides default sources.\n'
+    'If the package version is a prerelease and you didn\'t specify `--pre`,\n'
+    ' the package may not be found.\n'
+    'Please see https://chocolatey.org/docs/troubleshooting for more\n'
+    ' assistance.\n'
+    '\n'
+    'Chocolatey installed 0/1 packages. 1 packages failed.\n'
+    ' See the log for details (C:\\ProgramData\\chocolatey\\logs\\chocolatey.log).\n'
+    '\n'
+    'Failures\n'
+    ' - logstitcher - logstitcher not installed. The package was not found with the source(s) listed.\n'
+    ' Source(s): \'https://chocolatey.org/api/v2/\'\n'
+    ' NOTE: When you specify explicit sources, it overrides default sources.\n'
+    'If the package version is a prerelease and you didn\'t specify `--pre`,\n'
+    ' the package may not be found.\n'
+    'Please see https://chocolatey.org/docs/troubleshooting for more\n'
+    ' assistance.\n'
+)
+
+
+@pytest.mark.parametrize('command', [
+    Command('choco install logstitcher', package_not_found_error),
+    Command('cinst logstitcher', package_not_found_error),
+    Command('choco install logstitcher -y', package_not_found_error),
+    Command('cinst logstitcher -y', package_not_found_error),
+    Command('choco install logstitcher -y -n=test', package_not_found_error),
+    Command('cinst logstitcher -y -n=test', package_not_found_error),
+    Command('choco install logstitcher -y -n=test /env', package_not_found_error),
+    Command('cinst logstitcher -y -n=test /env', package_not_found_error),
+    Command('choco install chocolatey -y', package_not_found_error),
+    Command('cinst chocolatey -y', package_not_found_error)])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command', [
+    Command('choco /?', ''),
+    Command('choco upgrade logstitcher', ''),
+    Command('cup logstitcher', ''),
+    Command('choco upgrade logstitcher -y', ''),
+    Command('cup logstitcher -y', ''),
+    Command('choco upgrade logstitcher -y -n=test', ''),
+    Command('cup logstitcher -y -n=test', ''),
+    Command('choco upgrade logstitcher -y -n=test /env', ''),
+    Command('cup logstitcher -y -n=test /env', ''),
+    Command('choco upgrade chocolatey -y', ''),
+    Command('cup chocolatey -y', ''),
+    Command('choco uninstall logstitcher', ''),
+    Command('cuninst logstitcher', ''),
+    Command('choco uninstall logstitcher -y', ''),
+    Command('cuninst logstitcher -y', ''),
+    Command('choco uninstall logstitcher -y -n=test', ''),
+    Command('cuninst logstitcher -y -n=test', ''),
+    Command('choco uninstall logstitcher -y -n=test /env', ''),
+    Command('cuninst logstitcher -y -n=test /env', ''),
+    Command('choco uninstall chocolatey -y', ''),
+    Command('cuninst chocolatey -y', '')])
+def not_test_match(command):
+    assert not match(command)
 
 
 @pytest.mark.parametrize('before, after', [

--- a/tests/rules/test_choco_install.py
+++ b/tests/rules/test_choco_install.py
@@ -7,6 +7,12 @@ from thefuck.types import Command
     ('choco install logstitcher', 'choco install logstitcher.install'),
     ('cinst logstitcher', 'cinst logstitcher.install'),
     ('choco install logstitcher -y', 'choco install logstitcher.install -y'),
-    ('cinst logstitcher -y', 'cinst logstitcher.install -y')])
+    ('cinst logstitcher -y', 'cinst logstitcher.install -y'),
+    ('choco install logstitcher -y -n=test', 'choco install logstitcher.install -y -n=test'),
+    ('cinst logstitcher -y -n=test', 'cinst logstitcher.install -y -n=test'),
+    ('choco install logstitcher -y -n=test /env', 'choco install logstitcher.install -y -n=test /env'),
+    ('cinst logstitcher -y -n=test /env', 'cinst logstitcher.install -y -n=test /env'),
+    ('choco install chocolatey -y', 'choco install chocolatey.install -y'),
+    ('cinst chocolatey -y', 'cinst chocolatey.install -y'),])
 def test_get_new_command(before, after):
     assert (get_new_command(Command(before, '')) == after)

--- a/tests/rules/test_choco_install.py
+++ b/tests/rules/test_choco_install.py
@@ -13,6 +13,6 @@ from thefuck.types import Command
     ('choco install logstitcher -y -n=test /env', 'choco install logstitcher.install -y -n=test /env'),
     ('cinst logstitcher -y -n=test /env', 'cinst logstitcher.install -y -n=test /env'),
     ('choco install chocolatey -y', 'choco install chocolatey.install -y'),
-    ('cinst chocolatey -y', 'cinst chocolatey.install -y'),])
+    ('cinst chocolatey -y', 'cinst chocolatey.install -y'), ])
 def test_get_new_command(before, after):
     assert (get_new_command(Command(before, '')) == after)

--- a/thefuck/rules/choco_install.py
+++ b/thefuck/rules/choco_install.py
@@ -1,14 +1,15 @@
+from thefuck.utils import for_app
+
+
+@for_app("choco", "cinst")
 def match(command):
-    return (('choco install' in command.script_parts or 'cinst' in command.script_parts)
+    return ((command.script.startswith('choco install') or 'cinst' in command.script_parts)
             and 'Installing the following packages' in command.output)
 
 
 def get_new_command(command):
-    cmdList = command.script.split(' ')
-    packageName = ""
     # Find the argument that is the package name
-    for i in cmdList:
-        print(i)
+    for script_part in command.script_parts:
         if "choco" in i:
             continue
         if "cinst" in i:
@@ -27,3 +28,6 @@ def get_new_command(command):
     if not packageName:
         return False
     return(command.script.replace(packageName, packageName + ".install"))
+
+
+enabled_by_default = bool(which("choco")) or bool(which("cinst"))

--- a/thefuck/rules/choco_install.py
+++ b/thefuck/rules/choco_install.py
@@ -1,6 +1,5 @@
 from thefuck.utils import for_app, which
 
-
 @for_app("choco", "cinst")
 def match(command):
     return ((command.script.startswith('choco install') or 'cinst' in command.script_parts)
@@ -10,17 +9,14 @@ def match(command):
 def get_new_command(command):
     # Find the argument that is the package name
     for script_part in command.script_parts:
-        if "choco" in script_part:
+        if script_part in ["choco", "cinst", "install"]:
+            # Need exact match (bc chocolatey is a package)
             continue
-        if "cinst" in script_part:
+        if script_part.startswith('-'):
+            # Leading hyphens are parameters; some packages contain them though
             continue
-        if "install" in script_part:
-            continue
-        if script_part.startswith('-'):   # Some parameters start with hyphens; some packages contain them though
-            continue
-        if '=' in script_part:            # Some paramaters contain '='
-            continue
-        if '/' in script_part:            # Some parameters contain slashes
+        if '=' in script_part or '/' in script_part:
+            # These are certainly parameters
             continue
         else:
             packageName = script_part

--- a/thefuck/rules/choco_install.py
+++ b/thefuck/rules/choco_install.py
@@ -1,0 +1,29 @@
+def match(command):
+    return (('choco install' in command.script_parts or 'cinst' in command.script_parts)
+            and 'Installing the following packages' in command.output)
+
+
+def get_new_command(command):
+    cmdList = command.script.split(' ')
+    packageName = ""
+    # Find the argument that is the package name
+    for i in cmdList:
+        print(i)
+        if "choco" in i:
+            continue
+        if "cinst" in i:
+            continue
+        if "install" in i:
+            continue
+        if i.startswith('-'):   # Some parameters start with hyphens; some packages contain them though
+            continue
+        if '=' in i:            # Some paramaters contain '='
+            continue
+        if '/' in i:            # Some parameters contain slashes
+            continue
+        else:
+            packageName = i
+    # Find the name of the broken package, and append metapackage names
+    if not packageName:
+        return False
+    return(command.script.replace(packageName, packageName + ".install"))

--- a/thefuck/rules/choco_install.py
+++ b/thefuck/rules/choco_install.py
@@ -9,21 +9,16 @@ def match(command):
 def get_new_command(command):
     # Find the argument that is the package name
     for script_part in command.script_parts:
-        if script_part in ["choco", "cinst", "install"]:
-            # Need exact match (bc chocolatey is a package)
-            continue
-        if script_part.startswith('-'):
-            # Leading hyphens are parameters; some packages contain them though
-            continue
-        if '=' in script_part or '/' in script_part:
-            # These are certainly parameters
-            continue
-        else:
-            packageName = script_part
-    # Find the name of the broken package, and append metapackage names
-    if not packageName:
-        return False
-    return(command.script.replace(packageName, packageName + ".install"))
+        if (
+            script_part not in ["choco", "cinst", "install"]
+                # Need exact match (bc chocolatey is a package)
+            and not script_part.startswith('-')
+                # Leading hyphens are parameters; some packages contain them though
+            and '=' not in script_part and '/' not in script_part
+                # These are certainly parameters
+        ):
+            return command.script.replace(script_part, script_part + ".install")
+    return []
 
 
 enabled_by_default = bool(which("choco")) or bool(which("cinst"))

--- a/thefuck/rules/choco_install.py
+++ b/thefuck/rules/choco_install.py
@@ -1,5 +1,6 @@
 from thefuck.utils import for_app, which
 
+
 @for_app("choco", "cinst")
 def match(command):
     return ((command.script.startswith('choco install') or 'cinst' in command.script_parts)
@@ -11,11 +12,11 @@ def get_new_command(command):
     for script_part in command.script_parts:
         if (
             script_part not in ["choco", "cinst", "install"]
-                # Need exact match (bc chocolatey is a package)
+            # Need exact match (bc chocolatey is a package)
             and not script_part.startswith('-')
-                # Leading hyphens are parameters; some packages contain them though
+            # Leading hyphens are parameters; some packages contain them though
             and '=' not in script_part and '/' not in script_part
-                # These are certainly parameters
+            # These are certainly parameters
         ):
             return command.script.replace(script_part, script_part + ".install")
     return []

--- a/thefuck/rules/choco_install.py
+++ b/thefuck/rules/choco_install.py
@@ -1,4 +1,4 @@
-from thefuck.utils import for_app
+from thefuck.utils import for_app, which
 
 
 @for_app("choco", "cinst")
@@ -10,20 +10,20 @@ def match(command):
 def get_new_command(command):
     # Find the argument that is the package name
     for script_part in command.script_parts:
-        if "choco" in i:
+        if "choco" in script_part:
             continue
-        if "cinst" in i:
+        if "cinst" in script_part:
             continue
-        if "install" in i:
+        if "install" in script_part:
             continue
-        if i.startswith('-'):   # Some parameters start with hyphens; some packages contain them though
+        if script_part.startswith('-'):   # Some parameters start with hyphens; some packages contain them though
             continue
-        if '=' in i:            # Some paramaters contain '='
+        if '=' in script_part:            # Some paramaters contain '='
             continue
-        if '/' in i:            # Some parameters contain slashes
+        if '/' in script_part:            # Some parameters contain slashes
             continue
         else:
-            packageName = i
+            packageName = script_part
     # Find the name of the broken package, and append metapackage names
     if not packageName:
         return False


### PR DESCRIPTION
Adds a rule to append '.install' to a chocolatey install command that
failed because of a non-existent package.