### PR TITLE
fix: incorrect powershell alias instruction

### DIFF
--- a/thefuck/shells/powershell.py
+++ b/thefuck/shells/powershell.py
@@ -26,7 +26,7 @@ class Powershell(Generic):
         return ShellConfiguration(
             content=u'iex "$(thefuck --alias)"',
             path='$profile',
-            reload='& $profile',
+            reload='. $profile',
             can_configure_automatically=False)
 
     def _get_version(self):

--- a/thefuck/shells/powershell.py
+++ b/thefuck/shells/powershell.py
@@ -24,7 +24,7 @@ class Powershell(Generic):
 
     def how_to_configure(self):
         return ShellConfiguration(
-            content=u'iex "thefuck --alias"',
+            content=u'iex "$(thefuck --alias)"',
             path='$profile',
             reload='& $profile',
             can_configure_automatically=False)


### PR DESCRIPTION
Just setup PowerShell on my new MacBook and when I run `fuck` it says:

![image](https://user-images.githubusercontent.com/1330321/67928717-b2b14780-fbf6-11e9-9c60-268efa00bfc7.png)

I tried, but `iex "thefuck --alias"` will only print out the alias script.

The [wiki page](https://github.com/nvbn/thefuck/wiki/Shell-aliases#powershell) is correct.

I'm so confused that the typo is there from the very beginning, and for about 3 years no one had found it.

EDIT: And use `& $PROFILE` to reload profile is also incorrect because the `&` (call operator) execute the script in a child scope, so any function definition will not expose to the outer (main running) scope. We should use the `.` (dot-sourcing) operator instead. See this [StackOverflow answer](https://stackoverflow.com/a/54680512).