### PR TITLE
Fix Issue #959: breaks after composer require with single package, revamp composer rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ following rules are enabled by default:
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;
 * `chmod_x` &ndash; add execution bit;
 * `composer_not_command` &ndash; fixes composer command name;
+* `composer_not_package` &ndash; fixes composer misspelled package names;
 * `cp_omitting_directory` &ndash; adds `-a` when you `cp` directory;
 * `cpp11` &ndash; adds missing `-std=c++11` to `g++` or `clang++`;
 * `dirty_untar` &ndash; fixes `tar x` command that untarred in the current directory;

--- a/tests/rules/test_composer_not_command.py
+++ b/tests/rules/test_composer_not_command.py
@@ -2,55 +2,48 @@ import pytest
 from thefuck.rules.composer_not_command import match, get_new_command
 from thefuck.types import Command
 
+# tested with composer version 1.9.0
 
-@pytest.fixture
-def composer_not_command():
-    # that weird spacing is part of the actual command output
-    return (
-        '\n'
-        '\n'
-        '                                    \n'
-        '  [InvalidArgumentException]        \n'
-        '  Command "udpate" is not defined.  \n'
-        '  Did you mean this?                \n'
-        '      update                        \n'
-        '                                    \n'
-        '\n'
-        '\n'
-    )
+# command: composer udpate
+case_single_command_with_one_suggestion = ("composer udpate", r'\n'
+                                           '                                                                  ''\n'
+                                           r'  [Symfony\Component\Console\Exception\CommandNotFoundException]  ''\n'
+                                           '  Command "udpate" is not defined.                                ''\n'
+                                           '                                                                  ''\n'
+                                           '  Did you mean this?                                              ''\n'
+                                           '      update                                                      ''\n'
+                                           '                                                                  ''\n'
+                                           '\n'
+                                           )
+case_single_command_with_one_suggestion_expected = "composer update"
 
-
-@pytest.fixture
-def composer_not_command_one_of_this():
-    # that weird spacing is part of the actual command output
-    return (
-        '\n'
-        '\n'
-        '                                   \n'
-        '  [InvalidArgumentException]       \n'
-        '  Command "pdate" is not defined.  \n'
-        '  Did you mean one of these?       \n'
-        '      selfupdate                   \n'
-        '      self-update                  \n'
-        '      update                       \n'
-        '                                   \n'
-        '\n'
-        '\n'
-    )
+# command: composer selupdate
+case_single_command_with_many_suggestions = ("composer selupdate", r'\n'
+                                             '                                                                  ''\n'
+                                             r'  [Symfony\Component\Console\Exception\CommandNotFoundException]  ''\n'
+                                             '  Command "selupdate" is not defined.                             ''\n'
+                                             '                                                                  ''\n'
+                                             '  Did you mean one of these?                                      ''\n'
+                                             '      update                                                      ''\n'
+                                             '      self-update                                                 ''\n'
+                                             '      selfupdate                                                  ''\n'
+                                             '                                                                  ''\n'
+                                             '\n'
+                                             )
+case_single_command_with_many_suggesitons_expected = ["composer update", "composer self-update", "composer selfupdate"]
 
 
-def test_match(composer_not_command, composer_not_command_one_of_this):
-    assert match(Command('composer udpate',
-                         composer_not_command))
-    assert match(Command('composer pdate',
-                         composer_not_command_one_of_this))
-    assert not match(Command('ls update', composer_not_command))
+@pytest.mark.parametrize('command', [Command(*v) for v in [
+    case_single_command_with_one_suggestion,
+    case_single_command_with_many_suggestions
+]])
+def test_match(command):
+    assert match(command)
 
 
-def test_get_new_command(composer_not_command, composer_not_command_one_of_this):
-    assert (get_new_command(Command('composer udpate',
-                                    composer_not_command))
-            == 'composer update')
-    assert (get_new_command(Command('composer pdate',
-                                    composer_not_command_one_of_this))
-            == 'composer selfupdate')
+@pytest.mark.parametrize('command, new_command', [(Command(*t[0]), t[1]) for t in [
+    (case_single_command_with_one_suggestion, case_single_command_with_one_suggestion_expected),
+    (case_single_command_with_many_suggestions, case_single_command_with_many_suggesitons_expected)
+]])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_composer_not_package.py
+++ b/tests/rules/test_composer_not_package.py
@@ -1,0 +1,118 @@
+import pytest
+from thefuck.rules.composer_not_package import match, get_new_command
+from thefuck.types import Command
+
+# tested with composer version 1.9.0
+
+# command:
+# composer require laravel-nova-csv-import
+# the one that started it all
+case_original = ("composer require laravel-nova-csv-import", '\n'
+                 '                                                   ''\n'
+                 '  [InvalidArgumentException]                       ''\n'
+                 '  Could not find package laravel-nova-csv-import.  ''\n'
+                 '                                                   ''\n'
+                 '  Did you mean this?                               ''\n'
+                 '      simonhamp/laravel-nova-csv-import            ''\n'
+                 '                                                   ''\n'
+                 'require [--dev] [--prefer-source] [--prefer-dist] [--no-progress] [--no-suggest] [--no-update] [--no-scripts] [--update-no-dev] [--update-with-dependencies] [--update-with-all-dependencies] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [--sort-packages] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--] [<packages>]...''\n'
+                 '\n')
+case_original_expected = "composer require simonhamp/laravel-nova-csv-import"
+
+# command:
+# composer require datrack/elasticroute
+case_single_suggestion = ("composer require datrack/elasticroute", '\n'
+                          '                                                ''\n'
+                          '  [InvalidArgumentException]                    ''\n'
+                          '  Could not find package datrack/elasticroute.  ''\n'
+                          '                                                ''\n'
+                          '  Did you mean this?                            ''\n'
+                          '      detrack/elasticroute                      ''\n'
+                          '                                                ''\n'
+                          'require [--dev] [--prefer-source] [--prefer-dist] [--no-progress] [--no-suggest] [--no-update] [--no-scripts] [--update-no-dev] [--update-with-dependencies] [--update-with-all-dependencies] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [--sort-packages] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--] [<packages>]...''\n'
+                          '\n')
+case_single_suggestion_expected = "composer require detrack/elasticroute"
+
+# command:
+# composer require potato
+case_many_suggestions = ("composer require potato", '\n'
+                         '                                  ''\n'
+                         '  [InvalidArgumentException]      ''\n'
+                         '  Could not find package potato.  ''\n'
+                         '                                  ''\n'
+                         '  Did you mean one of these?      ''\n'
+                         '      drteam/potato               ''\n'
+                         '      florence/potato             ''\n'
+                         '      kola/potato-orm             ''\n'
+                         '      jsyqw/potato-bot            ''\n'
+                         '      vundi/potato-orm            ''\n'
+                         '                                  ''\n\n'
+                         'require [--dev] [--prefer-source] [--prefer-dist] [--no-progress] [--no-suggest] [--no-update] [--no-scripts] [--update-no-dev] [--update-with-dependencies] [--update-with-all-dependencies] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [--sort-packages] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--] [<packages>]...''\n'
+                         '\n')
+case_many_suggestions_expected = ["composer require drteam/potato",
+                                  "composer require florence/potato",
+                                  "composer require kola/potato-orm",
+                                  "composer require jsyqw/potato-bot",
+                                  "composer require vundi/potato-orm"]
+
+# command:
+# composer require datrack/elasticroute:*
+case_single_package_with_version_constraint = ("composer require datrack/elasticroute:*", '\n'
+                                               '                                                ''\n'
+                                               '  [InvalidArgumentException]                    ''\n'
+                                               '  Could not find package datrack/elasticroute.  ''\n'
+                                               '                                                ''\n'
+                                               '  Did you mean this?                            ''\n'
+                                               '      detrack/elasticroute                      ''\n'
+                                               '                                                ''\n\n'
+                                               'require [--dev] [--prefer-source] [--prefer-dist] [--no-progress] [--no-suggest] [--no-update] [--no-scripts] [--update-no-dev] [--update-with-dependencies] [--update-with-all-dependencies] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [--sort-packages] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--] [<packages>]...''\n'
+                                               '\n')
+case_single_package_with_version_constraint_expected = "composer require detrack/elasticroute:*"
+
+
+# command:
+# composer require potato:*
+case_single_package_with_version_constraint_many_suggestions = ("composer require potato:1.2.3", '\n'
+                                                                '                                  ''\n'
+                                                                '  [InvalidArgumentException]      ''\n'
+                                                                '  Could not find package potato.  ''\n'
+                                                                '                                  ''\n'
+                                                                '  Did you mean one of these?      ''\n'
+                                                                '      drteam/potato               ''\n'
+                                                                '      florence/potato             ''\n'
+                                                                '      kola/potato-orm             ''\n'
+                                                                '      jsyqw/potato-bot            ''\n'
+                                                                '      vundi/potato-orm            ''\n'
+                                                                '                                  ''\n\n'
+                                                                'require [--dev] [--prefer-source] [--prefer-dist] [--no-progress] [--no-suggest] [--no-update] [--no-scripts] [--update-no-dev] [--update-with-dependencies] [--update-with-all-dependencies] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [--sort-packages] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--] [<packages>]...''\n'
+
+                                                                '\n'
+                                                                )
+case_single_package_with_version_constraint_many_suggestions_expected = ["composer require drteam/potato:1.2.3",
+                                                                         "composer require florence/potato:1.2.3",
+                                                                         "composer require kola/potato-orm:1.2.3",
+                                                                         "composer require jsyqw/potato-bot:1.2.3",
+                                                                         "composer require vundi/potato-orm:1.2.3"]
+
+
+@pytest.mark.parametrize('command', [Command(*v) for v in [
+    case_original,
+    case_single_suggestion,
+    case_many_suggestions,
+    case_single_package_with_version_constraint,
+    case_single_package_with_version_constraint_many_suggestions
+]])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [(Command(*t[0]), t[1]) for t in [
+    (case_original, case_original_expected),
+    (case_single_suggestion, case_single_suggestion_expected),
+    (case_many_suggestions, case_many_suggestions_expected),
+    (case_single_package_with_version_constraint, case_single_package_with_version_constraint_expected),
+    (case_single_package_with_version_constraint_many_suggestions,
+     case_single_package_with_version_constraint_many_suggestions_expected),
+]])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/composer_not_package.py
+++ b/thefuck/rules/composer_not_package.py
@@ -6,19 +6,24 @@ from thefuck.utils import replace_argument, for_app
 def match(command):
     # determine error type
     # matching "did you mean this" is not enough as composer also gives spelling suggestions for mistakes other than mispelled commands
-    is_undefined_command_error = r"[Symfony\Component\Console\Exception\CommandNotFoundException]" in command.output
+    is_invalid_argument_exception = r"[InvalidArgumentException]" in command.output
+    is_unable_to_find_package = re.search(r"Could not find package (.*)\.", command.output) is not None
     suggestions_present = (('did you mean this?' in command.output.lower()
                             or 'did you mean one of these?' in command.output.lower()))
-    return is_undefined_command_error and suggestions_present
+    return is_invalid_argument_exception and is_unable_to_find_package and suggestions_present
 
 
 def get_new_command(command):
-    # since the command class already tells us the original argument, we need not resort to regex
-    broken_cmd = command.script_parts[1]
+    # because composer lets you install many packages at once, must look at output to determine the erroneous package name
+    wrong_package_name = re.search(r"Could not find package (.*)\.", command.output).group(1)
+    offending_script_param = wrong_package_name if (wrong_package_name in command.script_parts) else re.findall(
+        r"{}:[^ ]+".format(wrong_package_name), command.script)[0]
+    version_constraint = offending_script_param[len(wrong_package_name):]
     one_suggestion_only = 'did you mean this?' in command.output.lower()
     if one_suggestion_only:
+        # wrong regex??
         new_cmd = re.findall(r'Did you mean this\?[^\n]*\n\s*([^\n]*)', command.output)
-        return replace_argument(command.script, broken_cmd, new_cmd[0].strip())
+        return replace_argument(command.script, offending_script_param, new_cmd[0].strip() + version_constraint)
     else:
         # there are multiple suggestions
         # trim output text to make it more digestable by regex
@@ -32,6 +37,6 @@ def get_new_command(command):
             end_index = None
         suggested_commands = stripped_lines[1:end_index]
         return [
-            replace_argument(command.script, broken_cmd, cmd.strip())
+            replace_argument(command.script, offending_script_param, cmd + version_constraint)
             for cmd in suggested_commands
         ]


### PR DESCRIPTION
Hello! I'm a day late for Hacktoberfest but I hope you find this PR useful.

This pull request aims to fix #959 and add better integration with the [composer](https://getcomposer.org) tool. It turns out the issue of the crash was not because "there was only one suggestion" as suggested in the Issue, but rather that the matcher erroneously matches __package not found__ errors instead of just __command not found__ errors. Since the output of the two varies significantly, I have created two separate rules (and tests) for this functionality.

In addition, the old tests used outdated test cases from more than 2 years ago (the output has changed in newer versions). I have tested it on newer versions of composer, notably the latest version of composer (`1.7.0`).

##### Behaviour of issue #959 before fix:
![composer single package old](https://thumbs.gfycat.com/SlimOffbeatBonobo-size_restricted.gif)

##### After fix:
![composer single package new](https://thumbs.gfycat.com/ScaryForsakenLemur-size_restricted.gif)

The original `composer-not-command` was also not comprehensive enough: when multiple suggestions are offered, only one is passed to `thefuck`. This is fixed:

##### Before
![composer not command multiple old](https://thumbs.gfycat.com/MisguidedForcefulAfghanhound-size_restricted.gif)

##### After
![composer not command multiple new](https://thumbs.gfycat.com/EachDependentBittern-size_restricted.gif)

(the stray `composer require potato` appears to be a framework issue outside my domain, as my unit tests that tests the suggested commands pass)

With the addition of the `composer-not-package` rule, `thefuck` is now alot more accommodating of various user mistakes:

#### Attempting to `require` an erronous package name with multiple suggestions lets `thefuck` cycle through all suggestions

##### Before
![composer many package old](https://thumbs.gfycat.com/PossibleSpryFreshwatereel-size_restricted.gif)

##### After
![composer many package new](https://thumbs.gfycat.com/CarefulMindlessAfricanbushviper-size_restricted.gif)

#### `thefuck` now also respects version constraints, as reflected in the generated suggestions:

##### Single suggestion + version constraint
![composer single package version constraint](https://thumbs.gfycat.com/DescriptiveCourteousBeardedcollie-size_restricted.gif)

##### Multiple suggestions + version constraint
![composer multiple package version constraint](https://thumbs.gfycat.com/TiredWaterloggedFunnelweaverspider-size_restricted.gif)

#### Finally, `thefuck` is able to do consecutive `fuck`s with `composer`, such as in the case where the user attempts to `require` several erroneous package names at once:

![composer consecutive fucks](https://thumbs.gfycat.com/NecessaryWellgroomedAbyssiniancat-size_restricted.gif)

### Tests & Documentation

I have revamped the tests with updated output from recent versions of composer. It looks messy but it contains all the different possible scenarios that can result from botched user input. I have tried my best with making the code self documenting with sensible variable names and comments.

`flake8` does not produce any visible warnings. All tests pass except `test_go_unknown_command.py`, but that test also fails on a fresh clone of the upstream repository so I guess it's not related to my commits.