### PR TITLE
fix missing_space_before_subcommand.py rule for apt-get

### DIFF
--- a/thefuck/rules/missing_space_before_subcommand.py
+++ b/thefuck/rules/missing_space_before_subcommand.py
@@ -7,11 +7,12 @@ def _get_executable(script_part):
         if script_part.startswith(executable):
             if executable.startswith("apt"):
                 if script_part.startswith("apt-get"):
-                    if len(script_part)> len("apt-get"):
+                    if len(script_part) > len("apt-get"):
                         return "apt-get"
                     else:
                         return
             return executable
+
 
 def match(command):
     return (not command.script_parts[0] in get_all_executables()
@@ -24,11 +25,3 @@ def get_new_command(command):
 
 
 priority = 4000
-
-
-
-
-
-
-
-

--- a/thefuck/rules/missing_space_before_subcommand.py
+++ b/thefuck/rules/missing_space_before_subcommand.py
@@ -1,4 +1,3 @@
-
 from thefuck.utils import get_all_executables, memoize
 
 
@@ -8,22 +7,11 @@ def _get_executable(script_part):
         if script_part.startswith(executable):
             if executable.startswith("apt"):
                 if script_part.startswith("apt-get"):
-                    return "apt-get"
-                count = 0
-                if "g" in script_part:
-                    count += 1
-                if "e" in script_part:
-                    count += 1
-                if script_part.find("t", 3, -1) != -1:
-                    count += 1
-                if "-" in script_part:
-                    count += 1
-                if count < 3 or len(script_part) > count + 4:
-                    return executable
-
-            else:
-                return executable
-
+                    if len(script_part)> len("apt-get"):
+                        return "apt-get"
+                    else:
+                        return
+            return executable
 
 def match(command):
     return (not command.script_parts[0] in get_all_executables()
@@ -36,4 +24,11 @@ def get_new_command(command):
 
 
 priority = 4000
+
+
+
+
+
+
+
 

--- a/thefuck/rules/missing_space_before_subcommand.py
+++ b/thefuck/rules/missing_space_before_subcommand.py
@@ -1,3 +1,4 @@
+
 from thefuck.utils import get_all_executables, memoize
 
 
@@ -5,7 +6,23 @@ from thefuck.utils import get_all_executables, memoize
 def _get_executable(script_part):
     for executable in get_all_executables():
         if script_part.startswith(executable):
-            return executable
+            if executable.startswith("apt"):
+                if script_part.startswith("apt-get"):
+                    return "apt-get"
+                count = 0
+                if "g" in script_part:
+                    count += 1
+                if "e" in script_part:
+                    count += 1
+                if script_part.find("t", 3, -1) != -1:
+                    count += 1
+                if "-" in script_part:
+                    count += 1
+                if count < 3 or len(script_part) > count + 4:
+                    return executable
+
+            else:
+                return executable
 
 
 def match(command):
@@ -19,3 +36,4 @@ def get_new_command(command):
 
 
 priority = 4000
+


### PR DESCRIPTION
Prior to my changes, the missing_space_before_subcommands rule looped through the available commands, checked to see if the first portion of the command started with a valid executable, and then returned that executable immediately if it did. Because of this, it always converted **apt-get** commands into **apt     -get** commands, and other rules of the like. I changed it under recommendation of @scorphus that it return all possible matching missing space commands, not just the first one.

Here is a screen shot of this **buggy behavior prior to my changes:**

command: execsnoopcats [incorrect behavior- only returns the first instance: ex ecsnoopcats]
<img width="450" alt="Screen Shot 2019-12-02 at 10 09 19 AM" src="https://user-images.githubusercontent.com/31658599/69970745-c5b48180-14ec-11ea-8b3b-924192cf167b.png">

Here is a screenshot of the **correct behavior after my changes:**

command: execsnoopcats [correct behavior - returning both ex ecsnoopcats and execsnoop cats]
<img width="381" alt="Screen Shot 2019-12-02 at 10 08 04 AM" src="https://user-images.githubusercontent.com/31658599/69970802-debd3280-14ec-11ea-94a4-4434624ae8ff.png">
<img width="466" alt="Screen Shot 2019-12-02 at 10 07 56 AM" src="https://user-images.githubusercontent.com/31658599/69970815-e250b980-14ec-11ea-814d-55df7b1221e7.png">







