### PR TITLE
Added missing dependencies for py.test to req.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,7 @@ pypandoc
 pytest-benchmark
 pytest-docker-pexpect
 twine
+psutil
+colorama
+decorator
+pyte

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ elif (3, 0) < version < (3, 4):
           ' ({}.{} detected).'.format(*version))
     sys.exit(-1)
 
-VERSION = '3.29'
+VERSION = '3.30'
 
 install_requires = ['psutil', 'colorama', 'six', 'decorator', 'pyte']
 extras_require = {':python_version<"3.4"': ['pathlib2'],

--- a/thefuck/rules/chmod_x.py
+++ b/thefuck/rules/chmod_x.py
@@ -3,10 +3,11 @@ from thefuck.shells import shell
 
 
 def match(command):
+    file_to_run = os.path.expanduser(command.script_parts[0])
     return (command.script.startswith('./')
             and 'permission denied' in command.output.lower()
-            and os.path.exists(command.script_parts[0])
-            and not os.access(command.script_parts[0], os.X_OK))
+            and os.path.exists(file_to_run)
+            and not os.access(file_to_run, os.X_OK))
 
 
 def get_new_command(command):


### PR DESCRIPTION
Without there dependencies, which are not installed with the original
requirements.txt, on a fresh python 3.8 venv (on GNU/Linux), py.test
will not work.