### PR TITLE
N/A: Remove deprecated python 3.4 support + fix tests in 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
     - python: "3.6-dev"
     - python: "3.6"
     - python: "3.5"
-    - python: "3.4"
     - python: "2.7"
     - os: osx
       language: generic

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ build: false
 environment:
   matrix:
     - PYTHON: "C:/Python27"
-    - PYTHON: "C:/Python34"
     - PYTHON: "C:/Python35"
     - PYTHON: "C:/Python36"
     - PYTHON: "C:/Python37"

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ if version < (2, 7):
     print('thefuck requires Python version 2.7 or later' +
           ' ({}.{} detected).'.format(*version))
     sys.exit(-1)
-elif (3, 0) < version < (3, 4):
-    print('thefuck requires Python version 3.4 or later' +
+elif (3, 0) < version < (3, 5):
+    print('thefuck requires Python version 3.5 or later' +
           ' ({}.{} detected).'.format(*version))
     sys.exit(-1)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -225,9 +225,12 @@ class TestGetValidHistoryWithoutCurrent(object):
 
     @pytest.fixture(autouse=True)
     def history(self, mocker):
-        return mocker.patch('thefuck.shells.shell.get_history',
-                            return_value=['le cat', 'fuck', 'ls cat',
-                                          'diff x', 'nocommand x', u'café ô'])
+        mock = mocker.patch('thefuck.shells.shell.get_history')
+        #  Passing as an argument causes `UnicodeDecodeError`
+        #  with newer py.test and python 2.7
+        mock.return_value = ['le cat', 'fuck', 'ls cat',
+                             'diff x', 'nocommand x', u'café ô']
+        return mock
 
     @pytest.fixture(autouse=True)
     def alias(self, mocker):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38
+envlist = py27,py35,py36,py37,py38
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
I think it should be fine to remove Python 3.4 support as:
* [Python 3.4 has reached its end of life](https://www.python.org/downloads/release/python-3410/)
* one of dependencies - colorama, [no longer supports 3.4](https://github.com/tartley/colorama/pull/228)
* I wasn't able to find a still supported and popular os with it, even [ubuntu 16.04 has 3.5](https://packages.ubuntu.com/xenial/python3)
* it broke our ci

I'm going to merge that, will be possible to revert and come up with a workaround in case of a demand of 3.4.