### PR TITLE
#1047: Fix pip_unknown_command by using a less restrictive regex

### DIFF
--- a/tests/rules/test_pip_unknown_command.py
+++ b/tests/rules/test_pip_unknown_command.py
@@ -4,13 +4,23 @@ from thefuck.types import Command
 
 
 @pytest.fixture
-def pip_unknown_cmd():
-    return '''ERROR: unknown command "instatl" - maybe you meant "install"'''
+def pip_unknown_cmd_without_recommend():
+    return '''ERROR: unknown command "i"'''
 
 
 @pytest.fixture
-def pip_unknown_cmd_without_recommend():
-    return '''ERROR: unknown command "i"'''
+def broken():
+    return 'instatl'
+
+
+@pytest.fixture
+def suggested():
+    return 'install'
+
+
+@pytest.fixture
+def pip_unknown_cmd(broken, suggested):
+    return 'ERROR: unknown command "{}" - maybe you meant "{}"'.format(broken, suggested)
 
 
 def test_match(pip_unknown_cmd, pip_unknown_cmd_without_recommend):
@@ -19,6 +29,9 @@ def test_match(pip_unknown_cmd, pip_unknown_cmd_without_recommend):
                              pip_unknown_cmd_without_recommend))
 
 
-def test_get_new_command(pip_unknown_cmd):
-    assert get_new_command(Command('pip instatl',
-                                   pip_unknown_cmd)) == 'pip install'
+@pytest.mark.parametrize('script, broken, suggested, new_cmd', [
+    ('pip un+install thefuck', 'un+install', 'uninstall', 'pip uninstall thefuck'),
+    ('pip instatl', 'instatl', 'install', 'pip install')])
+def test_get_new_command(script, new_cmd, pip_unknown_cmd):
+    assert get_new_command(Command(script,
+                                   pip_unknown_cmd)) == new_cmd

--- a/thefuck/rules/pip_unknown_command.py
+++ b/thefuck/rules/pip_unknown_command.py
@@ -12,8 +12,8 @@ def match(command):
 
 
 def get_new_command(command):
-    broken_cmd = re.findall(r'ERROR: unknown command \"([a-z]+)\"',
+    broken_cmd = re.findall(r'ERROR: unknown command "([^"]+)"',
                             command.output)[0]
-    new_cmd = re.findall(r'maybe you meant \"([a-z]+)\"', command.output)[0]
+    new_cmd = re.findall(r'maybe you meant "([^"]+)"', command.output)[0]
 
     return replace_argument(command.script, broken_cmd, new_cmd)


### PR DESCRIPTION
Fix #1047