### PR TITLE
[WIP] -Draft PR: Edit commands using the default editor

### DIFF
--- a/tests/shells/test_fish.py
+++ b/tests/shells/test_fish.py
@@ -88,10 +88,8 @@ class TestFish(object):
     def test_app_alias_alter_history(self, settings, shell):
         settings.alter_history = True
         assert 'builtin history delete' in shell.app_alias('FUCK')
-        assert 'builtin history merge' in shell.app_alias('FUCK')
         settings.alter_history = False
         assert 'builtin history delete' not in shell.app_alias('FUCK')
-        assert 'builtin history merge' not in shell.app_alias('FUCK')
 
     def test_get_history(self, history_lines, shell):
         history_lines(['- cmd: ls', '  when: 1432613911',

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -22,6 +22,8 @@ def test_read_actions(patch_get_key):
         '\n',
         # Enter:
         '\r',
+        # Edit:
+        const.KEY_BACKSPACE, 'd',
         # Ignored:
         'x', 'y',
         # Up:
@@ -30,8 +32,9 @@ def test_read_actions(patch_get_key):
         const.KEY_DOWN, 'j',
         # Ctrl+C:
         const.KEY_CTRL_C, 'q'])
-    assert (list(islice(ui.read_actions(), 8))
+    assert (list(islice(ui.read_actions(True), 10))
             == [const.ACTION_SELECT, const.ACTION_SELECT,
+                const.ACTION_EDIT, const.ACTION_EDIT,
                 const.ACTION_PREVIOUS, const.ACTION_PREVIOUS,
                 const.ACTION_NEXT, const.ACTION_NEXT,
                 const.ACTION_ABORT, const.ACTION_ABORT])

--- a/thefuck/const.py
+++ b/thefuck/const.py
@@ -14,15 +14,18 @@ KEY_DOWN = _GenConst('↓')
 KEY_CTRL_C = _GenConst('Ctrl+C')
 KEY_CTRL_N = _GenConst('Ctrl+N')
 KEY_CTRL_P = _GenConst('Ctrl+P')
+KEY_BACKSPACE = _GenConst('Backspace')
 
 KEY_MAPPING = {'\x0e': KEY_CTRL_N,
                '\x03': KEY_CTRL_C,
-               '\x10': KEY_CTRL_P}
+               '\x10': KEY_CTRL_P,
+               '\x7f': KEY_BACKSPACE}
 
 ACTION_SELECT = _GenConst('select')
 ACTION_ABORT = _GenConst('abort')
 ACTION_PREVIOUS = _GenConst('previous')
 ACTION_NEXT = _GenConst('next')
+ACTION_EDIT = _GenConst('edit')
 
 ALL_ENABLED = _GenConst('All rules enabled')
 DEFAULT_RULES = [ALL_ENABLED]

--- a/thefuck/logs.py
+++ b/thefuck/logs.py
@@ -56,10 +56,19 @@ def show_corrected_command(corrected_command):
         reset=color(colorama.Style.RESET_ALL)))
 
 
-def confirm_text(corrected_command):
+def edit_part(show_edit):
+    if show_edit:
+        return '/{yellow}e{bold}d{normal}it'.format(
+            yellow=color(colorama.Fore.YELLOW),
+            bold=color(colorama.Style.BRIGHT),
+            normal=color(colorama.Style.NORMAL))
+    return ''
+
+
+def confirm_text(corrected_command, show_edit):
     sys.stderr.write(
         (u'{prefix}{clear}{bold}{script}{reset}{side_effect} '
-         u'[{green}enter{reset}/{blue}↑{reset}/{blue}↓{reset}'
+         u'[{green}enter{reset}{edit}{reset}/{blue}↑{reset}/{blue}↓{reset}'
          u'/{red}ctrl+c{reset}]').format(
             prefix=const.USER_COMMAND_MARK,
             script=corrected_command.script,
@@ -69,7 +78,8 @@ def confirm_text(corrected_command):
             green=color(colorama.Fore.GREEN),
             red=color(colorama.Fore.RED),
             reset=color(colorama.Style.RESET_ALL),
-            blue=color(colorama.Fore.BLUE)))
+            blue=color(colorama.Fore.BLUE),
+            edit=edit_part(show_edit)))
 
 
 def debug(msg):

--- a/thefuck/shells/bash.py
+++ b/thefuck/shells/bash.py
@@ -65,6 +65,9 @@ class Bash(Generic):
         return dict(self._parse_alias(alias)
                     for alias in raw_aliases if alias and '=' in alias)
 
+    def can_edit(self):
+        return True
+
     def _get_history_file_name(self):
         return os.environ.get("HISTFILE",
                               os.path.expanduser('~/.bash_history'))

--- a/thefuck/shells/fish.py
+++ b/thefuck/shells/fish.py
@@ -51,8 +51,7 @@ class Fish(Generic):
     def app_alias(self, alias_name):
         if settings.alter_history:
             alter_history = ('    builtin history delete --exact'
-                             ' --case-sensitive -- $fucked_up_command\n'
-                             '    builtin history merge ^ /dev/null\n')
+                             ' --case-sensitive -- $fucked_up_command')
         else:
             alter_history = ''
         # It is VERY important to have the variables declared WITHIN the alias
@@ -61,7 +60,8 @@ class Fish(Generic):
                 '  env TF_SHELL=fish TF_ALIAS={0} PYTHONIOENCODING=utf-8'
                 ' thefuck $fucked_up_command {2} $argv | read -l unfucked_command\n'
                 '  if [ "$unfucked_command" != "" ]\n'
-                '    eval $unfucked_command\n{1}'
+                '    commandline $unfucked_command\n'
+                '    commandline -f execute\n{1}'
                 '  end\n'
                 'end').format(alias_name, alter_history, ARGUMENT_PLACEHOLDER)
 

--- a/thefuck/shells/fish.py
+++ b/thefuck/shells/fish.py
@@ -127,3 +127,10 @@ class Fish(Generic):
                     history.write(entry.encode('utf-8'))
                 else:
                     history.write(entry)
+
+    def can_edit(self):
+        return True
+
+    def edit_command(self, command):
+        """Return the shell editable command"""
+        return 'commandline -r "' + command + '"'

--- a/thefuck/shells/fish.py
+++ b/thefuck/shells/fish.py
@@ -51,7 +51,7 @@ class Fish(Generic):
     def app_alias(self, alias_name):
         if settings.alter_history:
             alter_history = ('    builtin history delete --exact'
-                             ' --case-sensitive -- $fucked_up_command')
+                             ' --case-sensitive -- $fucked_up_command\n')
         else:
             alter_history = ''
         # It is VERY important to have the variables declared WITHIN the alias

--- a/thefuck/shells/fish.py
+++ b/thefuck/shells/fish.py
@@ -60,8 +60,7 @@ class Fish(Generic):
                 '  env TF_SHELL=fish TF_ALIAS={0} PYTHONIOENCODING=utf-8'
                 ' thefuck $fucked_up_command {2} $argv | read -l unfucked_command\n'
                 '  if [ "$unfucked_command" != "" ]\n'
-                '    commandline $unfucked_command\n'
-                '    commandline -f execute\n{1}'
+                '    eval $unfucked_command\n{1}'
                 '  end\n'
                 'end').format(alias_name, alter_history, ARGUMENT_PLACEHOLDER)
 
@@ -133,4 +132,8 @@ class Fish(Generic):
 
     def edit_command(self, command):
         """Return the shell editable command"""
-        return 'commandline -r "' + command + '"'
+        return ' commandline -r "' + command + '"'
+
+    def commandline_wrap(self, command):
+        """Return the commandline replace and execute commands"""
+        return u'commandline "{}";commandline -f execute'.format(command)

--- a/thefuck/shells/generic.py
+++ b/thefuck/shells/generic.py
@@ -121,6 +121,14 @@ class Generic(object):
 
         """
 
+    def can_edit(self):
+        return False
+
+    # FIXME: this is just an attempt to make it work in bash or zsh
+    def edit_command(self, command):
+        """Return the shell editable command"""
+        return 'export READLINE_LINE="' + command + '"'
+
     def get_builtin_commands(self):
         """Returns shells builtin commands."""
         return ['alias', 'bg', 'bind', 'break', 'builtin', 'case', 'cd',

--- a/thefuck/shells/generic.py
+++ b/thefuck/shells/generic.py
@@ -160,3 +160,7 @@ class Generic(object):
             path=path,
             reload=reload,
             can_configure_automatically=Path(path).expanduser().exists())
+
+    def commandline_wrap(self, command):
+        """Generic implementation of commandline wrapper"""
+        return command

--- a/thefuck/shells/generic.py
+++ b/thefuck/shells/generic.py
@@ -124,10 +124,28 @@ class Generic(object):
     def can_edit(self):
         return False
 
-    # FIXME: this is just an attempt to make it work in bash or zsh
     def edit_command(self, command):
-        """Return the shell editable command"""
-        return 'export READLINE_LINE="' + command + '"'
+        """Spawn default editor (or `vi` if not set) and edit command in a buffer"""
+        # Create a temporary file and write some default text
+        file_path = "The Fuck: Command Edit"
+        file_handle = open(file_path, "w")
+        file_handle.write(command)
+        file_handle.close()
+
+        editor = os.getenv('EDITOR')
+        if editor is None:
+            editor = "vi"
+
+        os.system("{} '{}' >/dev/tty".format(editor, file_path))
+
+        file_handle = open(file_path, 'r')
+        data = file_handle.read()
+        file_handle.close()
+
+        os.remove(file_path)
+
+        return data
+
 
     def get_builtin_commands(self):
         """Returns shells builtin commands."""

--- a/thefuck/shells/zsh.py
+++ b/thefuck/shells/zsh.py
@@ -64,6 +64,9 @@ class Zsh(Generic):
             value = value[1:-1]
         return name, value
 
+    def can_edit(self):
+        return True
+
     @memoize
     def get_aliases(self):
         raw_aliases = os.environ.get('TF_SHELL_ALIASES', '').split('\n')

--- a/thefuck/types.py
+++ b/thefuck/types.py
@@ -234,7 +234,7 @@ class CorrectedCommand(object):
 
         """
         if self.should_edit:
-            self.script = shell.edit_command(self.script)
+            return shell.edit_command(self.script)
 
         if settings.repeat:
             repeat_fuck = '{} --repeat {}--force-command {}'.format(
@@ -242,8 +242,8 @@ class CorrectedCommand(object):
                 '--debug ' if settings.debug else '',
                 shell.quote(self.script))
             return shell.or_(self.script, repeat_fuck)
-        else:
-            return self.script
+
+        return shell.commandline_wrap(self.script)
 
     def edit(self):
         self.should_edit = True

--- a/thefuck/types.py
+++ b/thefuck/types.py
@@ -209,6 +209,7 @@ class CorrectedCommand(object):
         self.script = script
         self.side_effect = side_effect
         self.priority = priority
+        self.should_edit = False
 
     def __eq__(self, other):
         """Ignores `priority` field."""
@@ -232,6 +233,9 @@ class CorrectedCommand(object):
         of running fuck in case fixed command fails again.
 
         """
+        if self.should_edit:
+            self.script = shell.edit_command(self.script)
+
         if settings.repeat:
             repeat_fuck = '{} --repeat {}--force-command {}'.format(
                 get_alias(),
@@ -240,6 +244,10 @@ class CorrectedCommand(object):
             return shell.or_(self.script, repeat_fuck)
         else:
             return self.script
+
+    def edit(self):
+        self.should_edit = True
+        return self
 
     def run(self, old_cmd):
         """Runs command from rule for passed command.

--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -3,21 +3,24 @@
 import sys
 from .conf import settings
 from .exceptions import NoRuleMatched
+from .shells import shell
 from .system import get_key
 from .utils import get_alias
 from . import logs, const
 
 
-def read_actions():
+def read_actions(can_edit):
     """Yields actions for pressed keys."""
     while True:
         key = get_key()
 
-        # Handle arrows, j/k (qwerty), and n/e (colemak)
+        # Handle arrows, edit, j/k (qwerty), and n/e (colemak)
         if key in (const.KEY_UP, const.KEY_CTRL_N, 'k', 'e'):
             yield const.ACTION_PREVIOUS
         elif key in (const.KEY_DOWN, const.KEY_CTRL_P, 'j', 'n'):
             yield const.ACTION_NEXT
+        elif can_edit and key in (const.KEY_BACKSPACE, 'd'):
+            yield const.ACTION_EDIT
         elif key in (const.KEY_CTRL_C, 'q'):
             yield const.ACTION_ABORT
         elif key in ('\n', '\r'):
@@ -78,18 +81,21 @@ def select_command(corrected_commands):
         logs.show_corrected_command(selector.value)
         return selector.value
 
-    logs.confirm_text(selector.value)
+    logs.confirm_text(selector.value, shell.can_edit())
 
-    for action in read_actions():
+    for action in read_actions(shell.can_edit()):
         if action == const.ACTION_SELECT:
             sys.stderr.write('\n')
             return selector.value
+        elif action == const.ACTION_EDIT:
+            sys.stderr.write('\n')
+            return selector.value.edit()
         elif action == const.ACTION_ABORT:
             logs.failed('\nAborted')
             return
         elif action == const.ACTION_PREVIOUS:
             selector.previous()
-            logs.confirm_text(selector.value)
+            logs.confirm_text(selector.value, shell.can_edit())
         elif action == const.ACTION_NEXT:
             selector.next()
-            logs.confirm_text(selector.value)
+            logs.confirm_text(selector.value, shell.can_edit())


### PR DESCRIPTION
This PR to implement a feature that would allow you to edit the suggested command in the editor that is set in $EDITOR for terminal other than fish.

Fish natively support line editing, so opening an editor is not need