### PR TITLE
#960: Improve pacman_invalid_option rule

### DIFF
--- a/tests/rules/test_pacman_invalid_option.py
+++ b/tests/rules/test_pacman_invalid_option.py
@@ -1,21 +1,30 @@
+import pytest
 from thefuck.rules.pacman_invalid_option import get_new_command, match
 from thefuck.types import Command
 
-good_output = "community/shared_meataxe 1.0-3\n    A set of programs for working with matrix representations over finite fields\n    "
+good_output = """community/shared_meataxe 1.0-3
+    A set of programs for working with matrix representations over finite fields
+"""
 
-bad_output = "error: invalid option '-s'"
-
-
-def test_match():
-    assert not match(Command('pacman -Ss meat', good_output))
-    assert not match(Command('sudo pacman -Ss meat', good_output))
-    assert match(Command('pacman -ss meat', bad_output))
-    assert match(Command('sudo pacman -ss meat', bad_output))
+bad_output = "error: invalid option '-"
 
 
-def test_get_new_command():
-    new_command = get_new_command(Command('pacman -ss meat', bad_output))
-    assert new_command == 'pacman -Ss meat'
+@pytest.mark.parametrize("option", "SURQFDVT")
+def test_not_match_good_output(option):
+    assert not match(Command("pacman -{}s meat".format(option), good_output))
 
-    new_command = get_new_command(Command('sudo pacman -s meat', bad_output))
-    assert new_command == 'sudo pacman -S meat'
+
+@pytest.mark.parametrize("option", "azxcbnm")
+def test_not_match_bad_output(option):
+    assert not match(Command("pacman -{}v meat".format(option), bad_output))
+
+
+@pytest.mark.parametrize("option", "surqfdvt")
+def test_match(option):
+    assert match(Command("pacman -{}v meat".format(option), bad_output))
+
+
+@pytest.mark.parametrize("option", "surqfdvt")
+def test_get_new_command(option):
+    new_command = get_new_command(Command("pacman -{}v meat".format(option), ""))
+    assert new_command == "pacman -{}v meat".format(option.upper())

--- a/thefuck/rules/pacman_invalid_option.py
+++ b/thefuck/rules/pacman_invalid_option.py
@@ -1,14 +1,20 @@
 from thefuck.specific.archlinux import archlinux_env
+from thefuck.specific.sudo import sudo_support
+from thefuck.utils import for_app
 import re
 
 
+@sudo_support
+@for_app("pacman")
 def match(command):
-    return "error: invalid option '-s'" in command.output
+    return command.output.startswith("error: invalid option '-") and any(
+        " -{}".format(option) in command.script for option in "surqfdvt"
+    )
 
 
 def get_new_command(command):
-    opt = re.findall(r" -[dqrstuf]", command.script)[0]
-    return re.sub(opt, opt.upper(), command.script)
+    option = re.findall(r" -[dfqrstuv]", command.script)[0]
+    return re.sub(option, option.upper(), command.script)
 
 
 enabled_by_default = archlinux_env()


### PR DESCRIPTION
The rule now matches all possible lower case options and only those, not failing for those that cannot be fixed.