### PR TITLE
Added quoting to ZSH `eval` parameters

### DIFF
--- a/thefuck/shells/zsh.py
+++ b/thefuck/shells/zsh.py
@@ -26,7 +26,7 @@ class Zsh(Generic):
                 export PYTHONIOENCODING=utf-8;
                 TF_CMD=$(
                     thefuck {argument_placeholder} $@
-                ) && eval $TF_CMD;
+                ) && eval "${{TF_CMD}}";
                 unset TF_HISTORY;
                 export PYTHONIOENCODING=$TF_PYTHONIOENCODING;
                 {alter_history}


### PR DESCRIPTION
This fixes a ZSH-specific issue with filenames containing spaces (the other shells already had similar precautions taken).

No unit tests, sorry - flake8 reported >190,000 issues & py.test >460, so I don't see any value in unit-testing the addition of something this trivial