### PR TITLE
Reset colour for Powershell

### DIFF
--- a/thefuck/shells/powershell.py
+++ b/thefuck/shells/powershell.py
@@ -12,6 +12,7 @@ class Powershell(Generic):
                '            else { iex "$fuck"; }\n' \
                '        }\n' \
                '    }\n' \
+               '    [Console]::ResetColor() \n' \
                '}\n'
 
     def and_(self, *commands):


### PR DESCRIPTION
This was originally fixed in #805 but appears to have been reverted at some point.