### PR TITLE
add support for docker daemon not running

### DIFF
--- a/thefuck/rules/docker_daemon_not_running.py
+++ b/thefuck/rules/docker_daemon_not_running.py
@@ -1,0 +1,16 @@
+from thefuck.shells import shell
+from thefuck.utils import for_app
+from thefuck.specific.sudo import sudo_support
+
+
+@for_app("docker")
+def match(command):
+    return ('docker: Cannot connect to the Docker daemon' in command.output and
+            'Is the docker daemon running?' in command.output)
+
+
+@sudo_support
+def get_new_command(command):
+    cmd = command.script_parts[0]
+    return shell.and_('systemctl start {}'.format(cmd),
+                      command.script)


### PR DESCRIPTION
For patterns like the following:
```sh
$ docker run bash sleep 100
docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.
See 'docker run --help'.

$ fuck
systemctl start docker; and docker run bash sleep 100 [enter/↑/↓/ctrl+c]
```