### PR TITLE
Add rule to remove a doubled-up "git clone" in a git clone command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ following rules are enabled by default:
 * `git_branch_exists` &ndash; offers `git branch -d foo`, `git branch -D foo` or `git checkout foo` when creating a branch that already exists;
 * `git_branch_list` &ndash; catches `git branch list` in place of `git branch` and removes created branch;
 * `git_checkout` &ndash; fixes branch name or creates new branch;
+* `git_clone_git_clone` &ndash; replaces `git clone git clone ...` with `git clone ...`
 * `git_commit_amend` &ndash; offers `git commit --amend` after previous commit;
 * `git_commit_reset` &ndash; offers `git reset HEAD~` after previous commit;
 * `git_diff_no_index` &ndash; adds `--no-index` to previous `git diff` on untracked files;

--- a/tests/rules/test_git_clone_git_clone.py
+++ b/tests/rules/test_git_clone_git_clone.py
@@ -1,0 +1,24 @@
+from thefuck.rules.git_clone_git_clone import match, get_new_command
+from thefuck.types import Command
+
+
+output_clean = """
+fatal: Too many arguments.
+
+usage: git clone [<options>] [--] <repo> [<dir>]
+"""
+
+
+def test_match():
+    assert match(Command('git clone git clone foo', output_clean))
+
+
+def test_not_match():
+    assert not match(Command('', ''))
+    assert not match(Command('git branch', ''))
+    assert not match(Command('git clone foo', ''))
+    assert not match(Command('git clone foo bar baz', output_clean))
+
+
+def test_get_new_command():
+    assert get_new_command(Command('git clone git clone foo', output_clean)) == 'git clone foo'

--- a/thefuck/rules/git_clone_git_clone.py
+++ b/thefuck/rules/git_clone_git_clone.py
@@ -1,0 +1,12 @@
+from thefuck.specific.git import git_support
+
+
+@git_support
+def match(command):
+    return (' git clone ' in command.script
+            and 'fatal: Too many arguments.' in command.output)
+
+
+@git_support
+def get_new_command(command):
+    return command.script.replace(' git clone ', ' ', 1)


### PR DESCRIPTION
Some git hosts will copy the entire clone command, while others just copy the url, so typing "git clone ", then pasting a git url that already has a "git clone " on the front is a somewhat common issue.