### PR TITLE
#1066 - Fix rule for brew cask

### DIFF
--- a/thefuck/rules/brew_unknown_command.py
+++ b/thefuck/rules/brew_unknown_command.py
@@ -62,7 +62,7 @@ def _brew_commands():
     # Failback commands for testing (Based on Homebrew 0.9.5)
     return ['info', 'home', 'options', 'install', 'uninstall',
             'search', 'list', 'update', 'upgrade', 'pin', 'unpin',
-            'doctor', 'create', 'edit']
+            'doctor', 'create', 'edit', 'cask']
 
 
 def match(command):

--- a/thefuck/rules/brew_unknown_command.py
+++ b/thefuck/rules/brew_unknown_command.py
@@ -3,8 +3,8 @@ import re
 from thefuck.utils import get_closest, replace_command
 from thefuck.specific.brew import get_brew_path_prefix, brew_available
 
-BREW_CMD_PATH = '/Library/Homebrew/cmd'
-TAP_PATH = '/Library/Taps'
+BREW_CMD_PATH = '/Homebrew/Library/Homebrew/cmd'
+TAP_PATH = '/Homebrew/Library/Taps'
 TAP_CMD_PATH = '/%s/%s/cmd'
 
 enabled_by_default = brew_available


### PR DESCRIPTION
Fix for [#1066](https://github.com/nvbn/thefuck/issues/1066)
- Added cask to the list of fallback brew commands
- Changed `BREW_CMD_PATH` and `TAP_PATH` to have `/Homebrew` prefix. The commands are normally located at `/usr/local/Homebrew/Library/Homebrew/cmd`. Verified it on macOS Catalina and Mojave.

Tested on:
- macOS Catalina 10.15.5