### PR TITLE
Npx: Create npx_add_npx_to_command.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ following rules are enabled by default:
 * `npm_missing_script` &ndash; fixes `npm` custom script name in `npm run-script <script>`;
 * `npm_run_script` &ndash; adds missing `run-script` for custom `npm` scripts;
 * `npm_wrong_command` &ndash; fixes wrong npm commands like `npm urgrade`;
+* `npx_add_npx_to_command` &ndash; adds `npx` for running locally installed `npm` commands, also corrects misspelled commands `jest/npx jest`, `npx jeet/npx jest` and `jeet/npx jest`;
 * `no_command` &ndash; fixes wrong console commands, for example `vom/vim`;
 * `no_such_file` &ndash; creates missing directories with `mv` and `cp` commands;
 * `open` &ndash; either prepends `http://` to address passed to `open` or create a new file or directory and passes it to `open`;

--- a/thefuck/rules/npx_add_npx_to_command.py
+++ b/thefuck/rules/npx_add_npx_to_command.py
@@ -1,0 +1,54 @@
+import os
+from os import path
+from subprocess import Popen, PIPE
+from thefuck.utils import memoize, eager, which, get_close_matches
+
+
+priority = 900
+enabled_by_default = bool(which('npx'))
+
+
+def match(command):
+    return \
+        'not found' in command.output.lower() and \
+        bool(get_matching_npm_executables_in_cd())
+
+
+def get_new_command(command):
+    return [
+        ' '.join(['npx', e, *command.script_parts[1:]])
+        for e in get_matching_npm_executables_in_cd()
+    ]
+
+
+def get_matching_npm_executables_in_cd(command):
+    """Get all matching npm binaries in current npm bin folder."""
+    npm_bin = get_npm_bin_folder()
+    command_name = command.script_parts[0]
+    if command_name == 'npx':
+        command_name = command.script_parts[1]
+    return get_matching_npm_executables(npm_bin, command_name)
+
+
+def get_npm_bin_folder():
+    """Get current npm bin folder."""
+    proc = Popen(['npm', 'bin'], stdout=PIPE)
+    return proc.stdout.readlines()[0].decode('utf-8').strip()
+
+
+@memoize
+@eager
+def get_matching_npm_executables(bin, name):
+    """Get all matching npm binaries."""
+    if not path.isdir(bin):
+        return []
+
+    exact_command_path = path.join(bin, name)
+    if path.isfile(exact_command_path):
+        return [name]
+
+    all_executables = [
+        f for f in os.listdir(bin)
+        if path.isfile(path.join(bin, f))
+    ]
+    return get_close_matches(name, all_executables)


### PR DESCRIPTION
## Add `npx` to command

Prefixes `npx` to command name to run locally installed `npm` commands, also corrects misspelled `npx` commands.
<table>
<thead>
  <tr>
    <th colspan="2">Example</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td><code>jest</code></td>
    <td><code>npx jest</code></td>
  </tr>
  <tr>
    <td><code>npx jeet</code></td>
    <td><code>npx jest</code></td>
  </tr>
  <tr>
    <td><code>jeet</code></td>
    <td><code>npx jest</code></td>
  </tr>
</tbody>
</table>