### PR TITLE
Fix pytest warnings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,10 @@ from thefuck.system import Path
 shells.shell = shells.Generic()
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "functional: mark test as functional")
+
+
 def pytest_addoption(parser):
     """Adds `--enable-functional` argument."""
     group = parser.getgroup("thefuck")

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -43,7 +43,7 @@ class TestSettingsFromFile(object):
         assert settings.rules == const.DEFAULT_RULES + ['test']
 
 
-@pytest.mark.usefixture('load_source')
+@pytest.mark.usefixtures('load_source')
 class TestSettingsFromEnv(object):
     def test_from_env(self, os_environ, settings):
         os_environ.update({'THEFUCK_RULES': 'bash:lisp',


### PR DESCRIPTION
Adds custom mark (`functional`) as per the [pytest documentation](https://docs.pytest.org/en/latest/mark.html#registering-marks).
Fixes typo in `tests/test_conf.py`
`@pytest.mark.usefixture('load_source')` to `@pytest.mark.usefixtures('load_source')`