### PR TITLE
Skip test instead of failing if go executable is not found.

### DIFF
--- a/tests/rules/test_go_unknown_command.py
+++ b/tests/rules/test_go_unknown_command.py
@@ -1,6 +1,7 @@
 import pytest
 from thefuck.rules.go_unknown_command import match, get_new_command
 from thefuck.types import Command
+from thefuck.utils import which
 
 
 @pytest.fixture
@@ -17,5 +18,6 @@ def test_not_match():
     assert not match(Command('go run', 'go run: no go files listed'))
 
 
+@pytest.mark.skipif(not which('go'), reason='Skip if go executable not found')
 def test_get_new_command(build_misspelled_output):
     assert get_new_command(Command('go bulid', build_misspelled_output)) == 'go build'


### PR DESCRIPTION
This is the error I see after running `py.test`:
```text
================================================================ FAILURES =================================================================
__________________________________________________________ test_get_new_command ___________________________________________________________

build_misspelled_output = "go bulid: unknown command\nRun 'go help' for usage."

    def test_get_new_command(build_misspelled_output):
>       assert get_new_command(Command('go bulid', build_misspelled_output)) == 'go build'

tests\rules\test_go_unknown_command.py:21:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
thefuck\rules\go_unknown_command.py:26: in get_new_command
    closest_subcommand = get_closest(command.script_parts[1], get_golang_commands())
thefuck\rules\go_unknown_command.py:8: in get_golang_commands
    proc = subprocess.Popen('go', stderr=subprocess.PIPE)
subprocess.py:775: in __init__
    restore_signals, start_new_session)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <subprocess.Popen object at 0x04DC3EF0>, args = 'go', executable = None, preexec_fn = None, close_fds = False, pass_fds = ()
cwd = None, env = None, startupinfo = <subprocess.STARTUPINFO object at 0x04DC3710>, creationflags = 0, shell = False, p2cread = Handle(992)
p2cwrite = -1, c2pread = -1, c2pwrite = Handle(216), errread = 14, errwrite = Handle(648), unused_restore_signals = True
unused_start_new_session = False

    def _execute_child(self, args, executable, preexec_fn, close_fds,
                       pass_fds, cwd, env,
                       startupinfo, creationflags, shell,
                       p2cread, p2cwrite,
                       c2pread, c2pwrite,
                       errread, errwrite,
                       unused_restore_signals, unused_start_new_session):
        """Execute program (MS Windows version)"""

        assert not pass_fds, "pass_fds not supported on Windows."

        if not isinstance(args, str):
            args = list2cmdline(args)

        # Process startup details
        if startupinfo is None:
            startupinfo = STARTUPINFO()
        else:
            # bpo-34044: Copy STARTUPINFO since it is modified above,
            # so the caller can reuse it multiple times.
            startupinfo = startupinfo._copy()

        use_std_handles = -1 not in (p2cread, c2pwrite, errwrite)
        if use_std_handles:
            startupinfo.dwFlags |= _winapi.STARTF_USESTDHANDLES
            startupinfo.hStdInput = p2cread
            startupinfo.hStdOutput = c2pwrite
            startupinfo.hStdError = errwrite

        attribute_list = startupinfo.lpAttributeList
        have_handle_list = bool(attribute_list and
                                "handle_list" in attribute_list and
                                attribute_list["handle_list"])

        # If we were given an handle_list or need to create one
        if have_handle_list or (use_std_handles and close_fds):
            if attribute_list is None:
                attribute_list = startupinfo.lpAttributeList = {}
            handle_list = attribute_list["handle_list"] = \
                list(attribute_list.get("handle_list", []))

            if use_std_handles:
                handle_list += [int(p2cread), int(c2pwrite), int(errwrite)]

            handle_list[:] = self._filter_handle_list(handle_list)

            if handle_list:
                if not close_fds:
                    warnings.warn("startupinfo.lpAttributeList['handle_list'] "
                                  "overriding close_fds", RuntimeWarning)

                # When using the handle_list we always request to inherit
                # handles but the only handles that will be inherited are
                # the ones in the handle_list
                close_fds = False

        if shell:
            startupinfo.dwFlags |= _winapi.STARTF_USESHOWWINDOW
            startupinfo.wShowWindow = _winapi.SW_HIDE
            comspec = os.environ.get("COMSPEC", "cmd.exe")
            args = '{} /c "{}"'.format (comspec, args)

        # Start the process
        try:
            hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
                                     # no special security
                                     None, None,
                                     int(not close_fds),
                                     creationflags,
                                     env,
                                     os.fspath(cwd) if cwd is not None else None,
>                                    startupinfo)
E                                    FileNotFoundError: [WinError 2] The system cannot find the file specified

subprocess.py:1178: FileNotFoundError
```

This patch fixes the error.