### PR TITLE
Version Command

### DIFF
--- a/tests/rules/test_version.py
+++ b/tests/rules/test_version.py
@@ -1,0 +1,20 @@
+import pytest
+from thefuck.rules.version import match, get_new_command
+from thefuck.types import Command
+
+
+@pytest.mark.parametrize('command', [
+    Command('git -v', ''),
+    Command('git -version', ''),
+    Command('git -version', ''),
+    Command('fuck -ver', '')])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('git -v', ''), 'git --version'),
+    (Command('git -version', ''), 'git --version'),
+    (Command('fuck -ver', ''), 'fuck --version')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/version.py
+++ b/thefuck/rules/version.py
@@ -1,0 +1,17 @@
+# Fixes incorrect usage of version commands
+#
+# Example :
+# > git -v
+# Here the correct usage is
+# > git --version
+
+
+def match(command):
+    return ('-v' in command.script)
+
+
+def get_new_command(command):
+    if '--version' in command.script:
+        return command.script_parts[0] + ' -v'
+    else:
+        return command.script_parts[0] + ' --version'


### PR DESCRIPTION
Fixes incorrect usage of version commands

Example :
> git -v
Here the correct usage is
> git --version