### PR TITLE
Fix pacman tests

### DIFF
--- a/tests/rules/test_pacman.py
+++ b/tests/rules/test_pacman.py
@@ -4,17 +4,12 @@ from thefuck.rules import pacman
 from thefuck.rules.pacman import match, get_new_command
 from thefuck.types import Command
 
-
 pacman_cmd = getattr(pacman, 'pacman', 'pacman')
 
 PKGFILE_OUTPUT_SUDO = 'core/sudo 1.8.13-13/usr/bin/sudo'
 PKGFILE_OUTPUT_CONVERT = 'extra/imagemagick 6.9.1.0-1\t/usr/bin/convert'
-
 PKGFILE_OUTPUT_VIM = '''extra/gvim 7.4.712-1        \t/usr/bin/vim
-extra/gvim-python3 7.4.712-1\t/usr/bin/vim
-extra/vim 7.4.712-1         \t/usr/bin/vim
-extra/vim-minimal 7.4.712-1 \t/usr/bin/vim
-extra/vim-python3 7.4.712-1 \t/usr/bin/vim'''
+extra/vim 7.4.712-1         \t/usr/bin/vim'''
 
 
 @pytest.mark.skipif(not getattr(pacman, 'enabled_by_default', True),
@@ -43,18 +38,16 @@ def test_not_match(command):
     assert not match(command)
 
 
-sudo_vim_possibilities = ['{} -S extra/gvim && sudo vim',
-                          '{} -S extra/gvim-python3 && sudo vim',
-                          '{} -S extra/vim && sudo vim',
-                          '{} -S extra/vim-minimal && sudo vim',
-                          '{} -S extra/vim-python3 && sudo vim']
+sudo_vim_possibilities = [
+    '{} -S extra/gvim && sudo vim',
+    '{} -S extra/vim && sudo vim',
+]
 sudo_vim_possibilities = [s.format(pacman_cmd) for s in sudo_vim_possibilities]
 
-vim_possibilities = ['{} -S extra/gvim && vim',
-                     '{} -S extra/gvim-python3 && vim',
-                     '{} -S extra/vim && vim',
-                     '{} -S extra/vim-minimal && vim',
-                     '{} -S extra/vim-python3 && vim']
+vim_possibilities = [
+    '{} -S extra/gvim && vim',
+    '{} -S extra/vim && vim',
+]
 vim_possibilities = [s.format(pacman_cmd) for s in vim_possibilities]
 
 

--- a/tests/rules/test_pacman_not_found.py
+++ b/tests/rules/test_pacman_not_found.py
@@ -4,8 +4,7 @@ from thefuck.rules import pacman_not_found
 from thefuck.rules.pacman_not_found import match, get_new_command
 from thefuck.types import Command
 
-PKGFILE_OUTPUT_LLC = '''extra/llvm 3.6.0-5      /usr/bin/llc
-extra/llvm35 3.5.2-13/usr/bin/llc'''
+PKGFILE_OUTPUT_LLC = 'extra/llvm 3.6.0-5      /usr/bin/llc'
 
 
 @pytest.mark.skipif(not getattr(pacman_not_found, 'enabled_by_default', True),
@@ -33,19 +32,19 @@ def test_match_mocked(subp_mock, command):
 @pytest.mark.skipif(not getattr(pacman_not_found, 'enabled_by_default', True),
                     reason='Skip if pacman is not available')
 @pytest.mark.parametrize('command, fixed', [
-    (Command('yay -S llc', 'error: target not found: llc'), ['yay -S extra/llvm', 'yay -S extra/llvm35']),
-    (Command('yaourt -S llc', 'error: target not found: llc'), ['yaourt -S extra/llvm', 'yaourt -S extra/llvm35']),
-    (Command('pacman -S llc', 'error: target not found: llc'), ['pacman -S extra/llvm', 'pacman -S extra/llvm35']),
-    (Command('sudo pacman -S llc', 'error: target not found: llc'), ['sudo pacman -S extra/llvm', 'sudo pacman -S extra/llvm35'])])
+    (Command('yay -S llc', 'error: target not found: llc'), ['yay -S extra/llvm']),
+    (Command('yaourt -S llc', 'error: target not found: llc'), ['yaourt -S extra/llvm']),
+    (Command('pacman -S llc', 'error: target not found: llc'), ['pacman -S extra/llvm']),
+    (Command('sudo pacman -S llc', 'error: target not found: llc'), ['sudo pacman -S extra/llvm'])])
 def test_get_new_command(command, fixed):
     assert get_new_command(command) == fixed
 
 
 @pytest.mark.parametrize('command, fixed', [
-    (Command('yay -S llc', 'error: target not found: llc'), ['yay -S extra/llvm', 'yay -S extra/llvm35']),
-    (Command('yaourt -S llc', 'error: target not found: llc'), ['yaourt -S extra/llvm', 'yaourt -S extra/llvm35']),
-    (Command('pacman -S llc', 'error: target not found: llc'), ['pacman -S extra/llvm', 'pacman -S extra/llvm35']),
-    (Command('sudo pacman -S llc', 'error: target not found: llc'), ['sudo pacman -S extra/llvm', 'sudo pacman -S extra/llvm35'])])
+    (Command('yay -S llc', 'error: target not found: llc'), ['yay -S extra/llvm']),
+    (Command('yaourt -S llc', 'error: target not found: llc'), ['yaourt -S extra/llvm']),
+    (Command('pacman -S llc', 'error: target not found: llc'), ['pacman -S extra/llvm']),
+    (Command('sudo pacman -S llc', 'error: target not found: llc'), ['sudo pacman -S extra/llvm'])])
 @patch('thefuck.specific.archlinux.subprocess')
 def test_get_new_command_mocked(subp_mock, command, fixed):
     subp_mock.check_output.return_value = PKGFILE_OUTPUT_LLC


### PR DESCRIPTION
Removing some old vim and llvm packages that no longer exist which were causing pacman tests to fail.

The mock tests using the `PKGFILE_OUTPUT_VIM` constant ran fine before editing, but figured it would be better to stay consistent so I removed old vim packages from there too.