### PR TITLE
New Rule: Git commit with no added files

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ following rules are enabled by default:
 * `git_branch_0flag` &ndash; fixes commands such as `git branch 0v` and `git branch 0r` removing the created branch;
 * `git_checkout` &ndash; fixes branch name or creates new branch;
 * `git_clone_git_clone` &ndash; replaces `git clone git clone ...` with `git clone ...`
-* `git_commit_add` &ndash; offers `git commit -a ...` after previous commit if it failed because nothing was staged;
+* `git_commit_add` &ndash; offers `git commit -a ...` or `git commit -p ...` after previous commit if it failed because nothing was staged;
 * `git_commit_amend` &ndash; offers `git commit --amend` after previous commit;
 * `git_commit_reset` &ndash; offers `git reset HEAD~` after previous commit;
 * `git_diff_no_index` &ndash; adds `--no-index` to previous `git diff` on untracked files;

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ following rules are enabled by default:
 * `git_branch_0flag` &ndash; fixes commands such as `git branch 0v` and `git branch 0r` removing the created branch;
 * `git_checkout` &ndash; fixes branch name or creates new branch;
 * `git_clone_git_clone` &ndash; replaces `git clone git clone ...` with `git clone ...`
+* `git_commit_add` &ndash; offers `git commit -a ...` after previous commit if it failed because nothing was staged;
 * `git_commit_amend` &ndash; offers `git commit --amend` after previous commit;
 * `git_commit_reset` &ndash; offers `git reset HEAD~` after previous commit;
 * `git_diff_no_index` &ndash; adds `--no-index` to previous `git diff` on untracked files;

--- a/tests/rules/test_git_commit_add.py
+++ b/tests/rules/test_git_commit_add.py
@@ -1,0 +1,36 @@
+import pytest
+from thefuck.rules.git_commit_add import match, get_new_command
+from thefuck.types import Command
+
+
+@pytest.mark.parametrize('script, output', [
+    ('git commit -m "test"', 'no changes added to commit'),
+    ('git commit', 'no changes added to commit')])
+def test_match(output, script):
+    assert match(Command(script, output))
+
+
+@pytest.mark.parametrize('script, output', [
+    ('git commit -m "test"', ' 1 file changed, 15 insertions(+), 14 deletions(-)')])
+def test_not_match(output, script):
+    assert not match(Command(script, output))
+
+
+@pytest.mark.parametrize('script', [
+    'git branch foo',
+    'git checkout feature/test_commit',
+    'git push'])
+def test_not_match_either(script):
+    assert not match(Command(script, ''))
+
+
+@pytest.mark.parametrize('script', [
+    ('git commit')])
+def test_get_new_command_one(script):
+    assert get_new_command(Command(script, '')) == 'git commit -a'
+
+
+@pytest.mark.parametrize('script', [
+    ('git commit -m "test commit"')])
+def test_get_new_command_two(script):
+    assert get_new_command(Command(script, '')) == 'git commit -a -m "test commit"'

--- a/tests/rules/test_git_commit_add.py
+++ b/tests/rules/test_git_commit_add.py
@@ -3,34 +3,36 @@ from thefuck.rules.git_commit_add import match, get_new_command
 from thefuck.types import Command
 
 
-@pytest.mark.parametrize('script, output', [
-    ('git commit -m "test"', 'no changes added to commit'),
-    ('git commit', 'no changes added to commit')])
+@pytest.mark.parametrize(
+    "script, output",
+    [
+        ('git commit -m "test"', "no changes added to commit"),
+        ("git commit", "no changes added to commit"),
+    ],
+)
 def test_match(output, script):
     assert match(Command(script, output))
 
 
-@pytest.mark.parametrize('script, output', [
-    ('git commit -m "test"', ' 1 file changed, 15 insertions(+), 14 deletions(-)')])
+@pytest.mark.parametrize(
+    "script, output",
+    [
+        ('git commit -m "test"', " 1 file changed, 15 insertions(+), 14 deletions(-)"),
+        ("git branch foo", ""),
+        ("git checkout feature/test_commit", ""),
+        ("git push", ""),
+    ],
+)
 def test_not_match(output, script):
     assert not match(Command(script, output))
 
 
-@pytest.mark.parametrize('script', [
-    'git branch foo',
-    'git checkout feature/test_commit',
-    'git push'])
-def test_not_match_either(script):
-    assert not match(Command(script, ''))
-
-
-@pytest.mark.parametrize('script', [
-    ('git commit')])
-def test_get_new_command_one(script):
-    assert get_new_command(Command(script, '')) == 'git commit -a'
-
-
-@pytest.mark.parametrize('script', [
-    ('git commit -m "test commit"')])
-def test_get_new_command_two(script):
-    assert get_new_command(Command(script, '')) == 'git commit -a -m "test commit"'
+@pytest.mark.parametrize(
+    "script, new_command",
+    [
+        ("git commit", ["git commit -a", "git commit -p"]),
+        ('git commit -m "foo"', ['git commit -a -m "foo"', 'git commit -p -m "foo"']),
+    ],
+)
+def test_get_new_command(script, new_command):
+    assert get_new_command(Command(script, "")) == new_command

--- a/thefuck/rules/git_commit_add.py
+++ b/thefuck/rules/git_commit_add.py
@@ -1,0 +1,15 @@
+from thefuck.utils import replace_argument
+from thefuck.specific.git import git_support
+
+priority = 900  # Lower first, default is 1000
+
+
+@git_support
+def match(command):
+    return ('commit' in command.script_parts
+            and 'no changes added to commit' in command.output)
+
+
+@git_support
+def get_new_command(command):
+    return replace_argument(command.script, 'commit', 'commit -a')

--- a/thefuck/rules/git_commit_add.py
+++ b/thefuck/rules/git_commit_add.py
@@ -1,15 +1,17 @@
-from thefuck.utils import replace_argument
+from thefuck.utils import eager, replace_argument
 from thefuck.specific.git import git_support
-
-priority = 900  # Lower first, default is 1000
 
 
 @git_support
 def match(command):
-    return ('commit' in command.script_parts
-            and 'no changes added to commit' in command.output)
+    return (
+        "commit" in command.script_parts
+        and "no changes added to commit" in command.output
+    )
 
 
+@eager
 @git_support
 def get_new_command(command):
-    return replace_argument(command.script, 'commit', 'commit -a')
+    for opt in ("-a", "-p"):
+        yield replace_argument(command.script, "commit", "commit {}".format(opt))


### PR DESCRIPTION
if "git commit" is executed with no staged changes, this will add -a to the command.
e.g. 

- git commit => git commit -a
- git commit -m "blubb" => git commit -a -m "blubb"