### PR TITLE
Match commands with path prefixes in @for_app decorations

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -146,6 +146,8 @@ def test_get_all_matched_commands(stderr, result):
 
 @pytest.mark.usefixtures('no_memoize')
 @pytest.mark.parametrize('script, names, result', [
+    ('/usr/bin/git diff', ['git', 'hub'], True),
+    ('/bin/hdfs dfs -rm foo', ['hdfs'], True),
     ('git diff', ['git', 'hub'], True),
     ('hub diff', ['git', 'hub'], True),
     ('hg diff', ['git', 'hub'], False)])
@@ -155,6 +157,8 @@ def test_is_app(script, names, result):
 
 @pytest.mark.usefixtures('no_memoize')
 @pytest.mark.parametrize('script, names, result', [
+    ('/usr/bin/git diff', ['git', 'hub'], True),
+    ('/bin/hdfs dfs -rm foo', ['hdfs'], True),
     ('git diff', ['git', 'hub'], True),
     ('hub diff', ['git', 'hub'], True),
     ('hg diff', ['git', 'hub'], False)])

--- a/thefuck/rules/gradle_no_task.py
+++ b/thefuck/rules/gradle_no_task.py
@@ -5,7 +5,7 @@ from thefuck.utils import for_app, eager, replace_command
 regex = re.compile(r"Task '(.*)' (is ambiguous|not found)")
 
 
-@for_app('gradle', './gradlew')
+@for_app('gradle', 'gradlew')
 def match(command):
     return regex.findall(command.output)
 

--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -180,7 +180,7 @@ def is_app(command, *app_names, **kwargs):
         raise TypeError("got an unexpected keyword argument '{}'".format(kwargs.keys()))
 
     if len(command.script_parts) > at_least:
-        return command.script_parts[0] in app_names
+        return os.path.basename(command.script_parts[0]) in app_names
 
     return False
 


### PR DESCRIPTION
I was working on an extension to the `rm_dir` rule (to try `rmdir` before `rm -r`, since it's safer) and discovered that I could not switch to using the `@for_app` decorator because then the rule loses its match from `/bin/hdfs dfs -rm` to `hdfs`. 

If `git diff` matches on `git`, then `/usr/bin/git diff` should match also. Not matching on explicit paths:

* `+` Gives rule authors the ability to match only when an explicit path to the command is given
* `-` Prevents rule authors from matching on a command regardless of what path was given (if any)

Since the default behavior for `fuck` is to require user interaction before confirming a command, casting a wider net is unlikely to be harmful. 

Also, the only rule that uses `@for_app` and has a path in the match string that I could find, has the path there because the most common invocation of that tool uses a path and the rule doesn't work otherwise, because of this limitation. In other words, it seems that the only rule that uses a path in the for_app string does so as a work-around to this too-strict behavior. I can only speculate that other rules, including the rm_dir rule, may have avoided the decorator for this reason.

Rule authors should not have to enumerate all the different paths a command could be called from, in my view. Hopefully this has not been litigated previously.

Before accepting, consider my commit message to d30a789. It may be better to strip paths in both places, but I'm not sure. Also if you need more tests, let me know where and I'll be happy to add them.