### PR TITLE
Fix docker_login rule

### DIFF
--- a/thefuck/rules/docker_login.py
+++ b/thefuck/rules/docker_login.py
@@ -1,4 +1,5 @@
 from thefuck.utils import for_app
+from thefuck.shells import shell
 
 
 @for_app('docker')
@@ -9,4 +10,4 @@ def match(command):
 
 
 def get_new_command(command):
-    return 'docker login && {}'.format(command.script)
+    return shell.and_('docker login', command.script)


### PR DESCRIPTION
`docker login` rule used `&&` directly in the output, which could fail in older PowerShell and fish shell versions.

Replaced it with thefuck's `shell._and` helper