### PR TITLE
Allow multiple alias arguments

### DIFF
--- a/thefuck/argument_parser.py
+++ b/thefuck/argument_parser.py
@@ -1,7 +1,27 @@
 import sys
-from argparse import ArgumentParser, SUPPRESS
+from argparse import ArgumentParser, SUPPRESS, Action
 from .const import ARGUMENT_PLACEHOLDER
 from .utils import get_alias
+import os
+
+class Alias(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+
+        if option_string:
+            if not values:
+                setattr(namespace, 'alias', [os.environ.get('TF_alias', 'fuck')])
+
+        if hasattr(namespace, 'alias'):
+            current_values = getattr(namespace, 'alias')
+            try:
+                current_values.extend(values)
+            except AttributeError:
+                current_values = values
+            finally:
+                setattr(namespace, 'alias', current_values)
+        else:
+            setattr(namespace, 'alias', values)
+
 
 
 class Parser(object):
@@ -22,8 +42,8 @@ class Parser(object):
             help="show program's version number and exit")
         self._parser.add_argument(
             '-a', '--alias',
-            nargs='?',
-            const=get_alias(),
+            nargs='*',
+            action=Alias,
             help='[custom-alias-name] prints alias for current shell')
         self._parser.add_argument(
             '-l', '--shell-logger',

--- a/thefuck/entrypoints/alias.py
+++ b/thefuck/entrypoints/alias.py
@@ -2,14 +2,18 @@ import six
 from ..logs import warn
 from ..shells import shell
 from ..utils import which
+from collections import Iterable
 
 
-def _get_alias(known_args):
+def _warn_py2(known_args):
     if six.PY2:
         warn("The Fuck will drop Python 2 support soon, more details "
              "https://github.com/nvbn/thefuck/issues/685")
 
-    alias = shell.app_alias(known_args.alias)
+
+
+def _get_alias(known_args):
+    _warn_py2(known_args)
 
     if known_args.enable_experimental_instant_mode:
         if six.PY2:
@@ -19,8 +23,26 @@ def _get_alias(known_args):
         else:
             return shell.instant_mode_alias(known_args.alias)
 
-    return alias
+    return shell.app_alias(known_args.alias)
+
+
+def _print_alias_multi(known_args):
+    _warn_py2(known_args)
+    if known_args.enable_experimental_instant_mode:
+        if six.PY2:
+            warn("Instant mode requires Python 3")
+        elif not which('script'):
+            warn("Instant mode requires `script` app")
+        else:
+            for a in known_args.alias:
+                print(shell.instant_mode_alias(a))
+    else:
+        for a in known_args.alias:
+            print(shell.app_alias(a))
 
 
 def print_alias(known_args):
-    print(_get_alias(known_args))
+    if isinstance(shell.app_alias(known_args), Iterable):
+        _print_alias_multi(known_args)
+    else:
+        print(_get_alias(known_args))

--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -298,7 +298,6 @@ def get_installation_info():
 def get_alias():
     return os.environ.get('TF_ALIAS', 'fuck')
 
-
 @memoize
 def get_valid_history_without_current(command):
     def _not_corrected(history, tf_alias):


### PR DESCRIPTION
This change makes up somewhat for thefuck's >100ms time to print the
aliases.

Some profiling shows that 50% of that time is spent loading a bunch of
unsued packages, and the other 50% is unavoidable overhead for starting
a python script.

These are valid:
thefuck --alias f k fuck fk # new!
thefuck --alias fk # one arg form
thefuck --alias # uses fuck by default still (backward compatibility)
thefuck --alias fk --enable-experimental-instant-mode # also supported!

Before, setting 10 aliases meant a 1second shell startup. Now:

$ time thefuck --alias a b c d e f g h i j
thefuck --alias a b c d e f g h i j  0.20s user 0.04s system 96% cpu 0.256 total

Not bad!