### PR TITLE
Introducing the cd-cs feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ following rules are enabled by default:
 * `cargo_no_command` &ndash; fixes wrongs commands like `cargo buid`;
 * `cat_dir` &ndash; replaces `cat` with `ls` when you try to `cat` a directory;
 * `cd_correction` &ndash; spellchecks and correct failed cd commands;
+* `cd_cs` &ndash; changes `cs` to `cd`;
 * `cd_mkdir` &ndash; creates directories before cd'ing into them;
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;
 * `chmod_x` &ndash; add execution bit;

--- a/tests/rules/test_cd_cs.py
+++ b/tests/rules/test_cd_cs.py
@@ -1,0 +1,11 @@
+from thefuck.rules.cd_cs import match, get_new_command
+from thefuck.types import Command
+
+
+def test_match():
+    assert match(Command('cs', 'cs: command not found'))
+    assert match(Command('cs /etc/', 'cs: command not found'))
+
+
+def test_get_new_command():
+    assert get_new_command(Command('cs /etc/', 'cs: command not found')) == 'cd /etc/'

--- a/thefuck/rules/cd_cs.py
+++ b/thefuck/rules/cd_cs.py
@@ -1,7 +1,10 @@
 # Redirects cs to cd when there is a typo
-# Due to the proximity of the keys - d and s, I found this to be a common problem for me
-# > cs /etc/
+# Due to the proximity of the keys — d and s — this seems like a common typo
+# ~ > cs /etc/
 # cs: command not found
+# ~ > fuck
+# cd /etc/ [enter/↑/↓/ctrl+c]
+# /etc >
 
 
 def match(command):

--- a/thefuck/rules/cd_cs.py
+++ b/thefuck/rules/cd_cs.py
@@ -1,5 +1,5 @@
 # Redirects cs to cd when there is a typo
-# Due to the proximity of the keys — d and s — this seems like a common typo
+# Due to the proximity of the keys - d and s - this seems like a common typo
 # ~ > cs /etc/
 # cs: command not found
 # ~ > fuck

--- a/thefuck/rules/cd_cs.py
+++ b/thefuck/rules/cd_cs.py
@@ -1,0 +1,16 @@
+# Redirects cs to cd when there is a typo
+# Due to the proximity of the keys - d and s, I found this to be a common problem for me
+# > cs /etc/
+# cs: command not found
+
+
+def match(command):
+    if command.script_parts[0] == 'cs':
+        return True
+
+
+def get_new_command(command):
+    return 'cd' + ''.join(command.script[2:])
+
+
+priority = 900

--- a/thefuck/rules/cd_cs.py
+++ b/thefuck/rules/cd_cs.py
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 # Redirects cs to cd when there is a typo
 # Due to the proximity of the keys - d and s - this seems like a common typo
 # ~ > cs /etc/


### PR DESCRIPTION
I found in my usage that due to the proximity of the 's' and 'd' key, I would commonly type cs when I mean to say cd.
I am hoping to address that with this update to the rules.