### PR TITLE
Cd rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ following rules are enabled by default:
 * `cd_cs` &ndash; changes `cs` to `cd`;
 * `cd_mkdir` &ndash; creates directories before cd'ing into them;
 * `cd_parent` &ndash; changes `cd..` to `cd ..`;
+* `chdir` &ndash; creates directories before changing into them using chdir;
 * `chmod_x` &ndash; add execution bit;
 * `choco_install` &ndash; append common suffixes for chocolatey packages;
 * `composer_not_command` &ndash; fixes composer command name;

--- a/tests/rules/test_chdir.py
+++ b/tests/rules/test_chdir.py
@@ -1,0 +1,25 @@
+import pytest
+from thefuck.rules.cd_mkdir import match, get_new_command
+from thefuck.types import Command
+
+
+@pytest.mark.parametrize('command', [
+    Command('chdir foo', 'cannot find the path'),
+    Command('chdir foo/bar', 'can\'t cd to'),
+    Command('chdir foo/bar', 'cannot find paht'),
+    Command('chdir /foo/bar/', 'can\'t cd to')])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command', [
+    Command('chdir foo', ''), Command('', '')])
+def test_not_match(command):
+    assert not match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('chdir foo', ''), 'mkdir -p foo && chdir foo'),
+    (Command('chdir foo/bar', ''), 'mkdir -p foo/bar && chdir foo/bar')])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/entrypoints/fix_command.py
+++ b/thefuck/entrypoints/fix_command.py
@@ -6,17 +6,17 @@ from .. import logs, types, const
 from ..conf import settings
 from ..corrector import get_corrected_commands
 from ..exceptions import EmptyCommand
-from ..ui import select_command, confirm_command
+from ..ui import select_command
 from ..utils import get_alias, get_all_executables
 
 
 def _get_raw_command(known_args):
     if known_args.force_command:
         return known_args.force_command
-    elif not os.environ.get("TF_HISTORY"):
+    elif not os.environ.get('TF_HISTORY'):
         return known_args.command
     else:
-        history = os.environ["TF_HISTORY"].split("\n")[::-1]
+        history = os.environ['TF_HISTORY'].split('\n')[::-1]
         alias = get_alias()
         executables = get_all_executables()
         for command in history:
@@ -29,24 +29,20 @@ def _get_raw_command(known_args):
 def fix_command(known_args):
     """Fixes previous command. Used when `thefuck` called without arguments."""
     settings.init(known_args)
-    with logs.debug_time("Total"):
-        logs.debug(u"Run with settings: {}".format(pformat(settings)))
+    with logs.debug_time('Total'):
+        logs.debug(u'Run with settings: {}'.format(pformat(settings)))
         raw_command = _get_raw_command(known_args)
 
         try:
             command = types.Command.from_raw_script(raw_command)
         except EmptyCommand:
-            logs.debug("Empty command, nothing to do")
+            logs.debug('Empty command, nothing to do')
             return
 
         corrected_commands = get_corrected_commands(command)
         selected_command = select_command(corrected_commands)
 
-        confirmation = True
-        if selected_command.script == "reboot":
-            confirmation = confirm_command("Reboot System?")
-
-        if selected_command and confirmation:
+        if selected_command:
             selected_command.run(command)
         else:
             sys.exit(1)

--- a/thefuck/entrypoints/fix_command.py
+++ b/thefuck/entrypoints/fix_command.py
@@ -6,17 +6,17 @@ from .. import logs, types, const
 from ..conf import settings
 from ..corrector import get_corrected_commands
 from ..exceptions import EmptyCommand
-from ..ui import select_command
+from ..ui import select_command, confirm_command
 from ..utils import get_alias, get_all_executables
 
 
 def _get_raw_command(known_args):
     if known_args.force_command:
         return known_args.force_command
-    elif not os.environ.get('TF_HISTORY'):
+    elif not os.environ.get("TF_HISTORY"):
         return known_args.command
     else:
-        history = os.environ['TF_HISTORY'].split('\n')[::-1]
+        history = os.environ["TF_HISTORY"].split("\n")[::-1]
         alias = get_alias()
         executables = get_all_executables()
         for command in history:
@@ -29,20 +29,24 @@ def _get_raw_command(known_args):
 def fix_command(known_args):
     """Fixes previous command. Used when `thefuck` called without arguments."""
     settings.init(known_args)
-    with logs.debug_time('Total'):
-        logs.debug(u'Run with settings: {}'.format(pformat(settings)))
+    with logs.debug_time("Total"):
+        logs.debug(u"Run with settings: {}".format(pformat(settings)))
         raw_command = _get_raw_command(known_args)
 
         try:
             command = types.Command.from_raw_script(raw_command)
         except EmptyCommand:
-            logs.debug('Empty command, nothing to do')
+            logs.debug("Empty command, nothing to do")
             return
 
         corrected_commands = get_corrected_commands(command)
         selected_command = select_command(corrected_commands)
 
-        if selected_command:
+        confirmation = True
+        if selected_command.script == "reboot":
+            confirmation = confirm_command("Reboot System?")
+
+        if selected_command and confirmation:
             selected_command.run(command)
         else:
             sys.exit(1)

--- a/thefuck/logs.py
+++ b/thefuck/logs.py
@@ -8,7 +8,6 @@ import colorama
 from .conf import settings
 from . import const
 
-
 def color(color_):
     """Utility for ability to disabling colored output."""
     if settings.no_colors:
@@ -58,7 +57,7 @@ def show_corrected_command(corrected_command):
 
 def confirm_text(corrected_command):
     sys.stderr.write(
-        (u'{prefix}{clear}{bold}{script}{reset}{side_effect} '
+        (u'{prefix}{clear}{bold}{script}{reset}{side_effect}'
          u'[{green}enter{reset}/{blue}↑{reset}/{blue}↓{reset}'
          u'/{red}ctrl+c{reset}]').format(
             prefix=const.USER_COMMAND_MARK,

--- a/thefuck/logs.py
+++ b/thefuck/logs.py
@@ -139,14 +139,3 @@ def version(thefuck_version, python_version, shell_info):
         u'The Fuck {} using Python {} and {}\n'.format(thefuck_version,
                                                        python_version,
                                                        shell_info))
-
-
-def confirmation(confirm):
-    if confirm is True:
-        sys.stderr.write(u"\n{bold}System Rebooting!{reset}".format(
-            bold=color(colorama.Style.BRIGHT),
-            reset=color(colorama.Style.RESET_ALL)))
-    else:
-        sys.stderr.write(u"\n{bold}Reboot Cancelled{reset}".format(
-            bold=color(colorama.Style.BRIGHT),
-            reset=color(colorama.Style.RESET_ALL)))

--- a/thefuck/logs.py
+++ b/thefuck/logs.py
@@ -139,3 +139,14 @@ def version(thefuck_version, python_version, shell_info):
         u'The Fuck {} using Python {} and {}\n'.format(thefuck_version,
                                                        python_version,
                                                        shell_info))
+
+
+def confirmation(confirm):
+    if confirm is True:
+        sys.stderr.write(u"\n{bold}System Rebooting!{reset}".format(
+            bold=color(colorama.Style.BRIGHT),
+            reset=color(colorama.Style.RESET_ALL)))
+    else:
+        sys.stderr.write(u"\n{bold}Reboot Cancelled{reset}".format(
+            bold=color(colorama.Style.BRIGHT),
+            reset=color(colorama.Style.RESET_ALL)))

--- a/thefuck/rules/cd_mkdir.py
+++ b/thefuck/rules/cd_mkdir.py
@@ -11,7 +11,9 @@ def match(command):
         command.script.startswith('cd ') and any((
             'no such file or directory' in command.output.lower(),
             'cd: can\'t cd to' in command.output.lower(),
-            'does not exist' in command.output.lower()
+            'does not exist' in command.output.lower(),
+            'cannot find the path' in command.output.lower(),
+            'cannot find path' in command.output.lower()
         )))
 
 

--- a/thefuck/rules/chdir.py
+++ b/thefuck/rules/chdir.py
@@ -8,13 +8,14 @@ from thefuck.shells import shell
 @for_app('chdir')
 def match(command):
     return (
-        command.script.startswith('chdir ') and any((
+        command.script.startswith('chdir') and any((
             'cannot find the path' in command.output.lower(),
-        )))
+            'cannot find path' in command.output.lower(),
+            'can\'t cd to' in command.output.lower()
+            )))
 
 
 @sudo_support
 def get_new_command(command):
     repl = shell.and_('mkdir -p \\1', 'chdir \\1')
-    return re.sub(r'^chdir (.*)', repl, command.script)
-
+    return re.sub(r'^chdir(.*)', repl, command.script)

--- a/thefuck/rules/chdir.py
+++ b/thefuck/rules/chdir.py
@@ -1,0 +1,20 @@
+import re
+from thefuck.utils import for_app
+from thefuck.specific.sudo import sudo_support
+from thefuck.shells import shell
+
+
+@sudo_support
+@for_app('chdir')
+def match(command):
+    return (
+        command.script.startswith('chdir ') and any((
+            'cannot find the path' in command.output.lower(),
+        )))
+
+
+@sudo_support
+def get_new_command(command):
+    repl = shell.and_('mkdir -p \\1', 'chdir \\1')
+    return re.sub(r'^chdir (.*)', repl, command.script)
+

--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -6,6 +6,7 @@ from .exceptions import NoRuleMatched
 from .system import get_key
 from .utils import get_alias
 from . import logs, const
+from .types import CorrectedCommand
 
 
 def read_actions():
@@ -14,13 +15,13 @@ def read_actions():
         key = get_key()
 
         # Handle arrows, j/k (qwerty), and n/e (colemak)
-        if key in (const.KEY_UP, const.KEY_CTRL_N, 'k', 'e'):
+        if key in (const.KEY_UP, const.KEY_CTRL_N, "k", "e"):
             yield const.ACTION_PREVIOUS
-        elif key in (const.KEY_DOWN, const.KEY_CTRL_P, 'j', 'n'):
+        elif key in (const.KEY_DOWN, const.KEY_CTRL_P, "j", "n"):
             yield const.ACTION_NEXT
-        elif key in (const.KEY_CTRL_C, 'q'):
+        elif key in (const.KEY_CTRL_C, "q"):
             yield const.ACTION_ABORT
-        elif key in ('\n', '\r'):
+        elif key in ("\n", "\r"):
             yield const.ACTION_SELECT
 
 
@@ -58,20 +59,16 @@ class CommandSelector(object):
 
 def select_command(corrected_commands):
     """Returns:
-
      - the first command when confirmation disabled;
      - None when ctrl+c pressed;
      - selected command.
-
     :type corrected_commands: Iterable[thefuck.types.CorrectedCommand]
     :rtype: thefuck.types.CorrectedCommand | None
-
     """
     try:
         selector = CommandSelector(corrected_commands)
     except NoRuleMatched:
-        logs.failed('No fucks given' if get_alias() == 'fuck'
-                    else 'Nothing found')
+        logs.failed("No fucks given" if get_alias() == "fuck" else "Nothing found")
         return
 
     if not settings.require_confirmation:
@@ -82,10 +79,10 @@ def select_command(corrected_commands):
 
     for action in read_actions():
         if action == const.ACTION_SELECT:
-            sys.stderr.write('\n')
+            sys.stderr.write("\n")
             return selector.value
         elif action == const.ACTION_ABORT:
-            logs.failed('\nAborted')
+            logs.failed("\nAborted")
             return
         elif action == const.ACTION_PREVIOUS:
             selector.previous()
@@ -93,3 +90,23 @@ def select_command(corrected_commands):
         elif action == const.ACTION_NEXT:
             selector.next()
             logs.confirm_text(selector.value)
+
+
+def confirm_command(confirmation_text):
+    """Returns:
+     - the first command when confirmation disabled;
+     - None when ctrl+c pressed;
+     - selected command.
+    :type corrected_commands: Iterable[thefuck.types.CorrectedCommand]
+    :rtype: thefuck.types.CorrectedCommand | None
+    """
+
+    logs.confirm_text(CorrectedCommand(confirmation_text, None, 0))
+
+    for action in read_actions():
+        if action == const.ACTION_SELECT:
+            logs.confirmation(True)
+            return True
+        elif action == const.ACTION_ABORT:
+            logs.confirmation(False)
+            return False

--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -6,7 +6,6 @@ from .exceptions import NoRuleMatched
 from .system import get_key
 from .utils import get_alias
 from . import logs, const
-from .types import CorrectedCommand
 
 
 def read_actions():
@@ -15,13 +14,13 @@ def read_actions():
         key = get_key()
 
         # Handle arrows, j/k (qwerty), and n/e (colemak)
-        if key in (const.KEY_UP, const.KEY_CTRL_N, "k", "e"):
+        if key in (const.KEY_UP, const.KEY_CTRL_N, 'k', 'e'):
             yield const.ACTION_PREVIOUS
-        elif key in (const.KEY_DOWN, const.KEY_CTRL_P, "j", "n"):
+        elif key in (const.KEY_DOWN, const.KEY_CTRL_P, 'j', 'n'):
             yield const.ACTION_NEXT
-        elif key in (const.KEY_CTRL_C, "q"):
+        elif key in (const.KEY_CTRL_C, 'q'):
             yield const.ACTION_ABORT
-        elif key in ("\n", "\r"):
+        elif key in ('\n', '\r'):
             yield const.ACTION_SELECT
 
 
@@ -59,16 +58,20 @@ class CommandSelector(object):
 
 def select_command(corrected_commands):
     """Returns:
+
      - the first command when confirmation disabled;
      - None when ctrl+c pressed;
      - selected command.
+
     :type corrected_commands: Iterable[thefuck.types.CorrectedCommand]
     :rtype: thefuck.types.CorrectedCommand | None
+
     """
     try:
         selector = CommandSelector(corrected_commands)
     except NoRuleMatched:
-        logs.failed("No fucks given" if get_alias() == "fuck" else "Nothing found")
+        logs.failed('No fucks given' if get_alias() == 'fuck'
+                    else 'Nothing found')
         return
 
     if not settings.require_confirmation:
@@ -79,10 +82,10 @@ def select_command(corrected_commands):
 
     for action in read_actions():
         if action == const.ACTION_SELECT:
-            sys.stderr.write("\n")
+            sys.stderr.write('\n')
             return selector.value
         elif action == const.ACTION_ABORT:
-            logs.failed("\nAborted")
+            logs.failed('\nAborted')
             return
         elif action == const.ACTION_PREVIOUS:
             selector.previous()
@@ -90,23 +93,3 @@ def select_command(corrected_commands):
         elif action == const.ACTION_NEXT:
             selector.next()
             logs.confirm_text(selector.value)
-
-
-def confirm_command(confirmation_text):
-    """Returns:
-     - the first command when confirmation disabled;
-     - None when ctrl+c pressed;
-     - selected command.
-    :type corrected_commands: Iterable[thefuck.types.CorrectedCommand]
-    :rtype: thefuck.types.CorrectedCommand | None
-    """
-
-    logs.confirm_text(CorrectedCommand(confirmation_text, None, 0))
-
-    for action in read_actions():
-        if action == const.ACTION_SELECT:
-            logs.confirmation(True)
-            return True
-        elif action == const.ACTION_ABORT:
-            logs.confirmation(False)
-            return False


### PR DESCRIPTION
I fixed cd_mkdir.py to work with powershell in linux and windows. I also modified it and added it as chdir.py so that the same corrections can be made for the chdir command, which is the cd command, in case anyone uses it.