### PR TITLE
#N/A: Force decorator<5 for Python <= 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ VERSION = '3.30'
 install_requires = ['psutil', 'colorama', 'six', 'decorator', 'pyte']
 extras_require = {':python_version<"3.4"': ['pathlib2'],
                   ':python_version<"3.3"': ['backports.shutil_get_terminal_size'],
+                  ':python_version<="2.7"': ['decorator<5'],
                   ":sys_platform=='win32'": ['win_unicode_console']}
 
 setup(name='thefuck',


### PR DESCRIPTION
For some reason, the index used by GH Actions is not considering the requesting Python version to decide which package version to deliver. This is unnecessary for the official index and will be removed once we drop support to Python 2.