### PR TITLE
Avoid using pkg_resources

### DIFF
--- a/thefuck/entrypoints/main.py
+++ b/thefuck/entrypoints/main.py
@@ -7,7 +7,7 @@ import os  # noqa: E402
 import sys  # noqa: E402
 from .. import logs  # noqa: E402
 from ..argument_parser import Parser  # noqa: E402
-from ..utils import get_installation_info  # noqa: E402
+from ..utils import get_installation_version  # noqa: E402
 from ..shells import shell  # noqa: E402
 from .alias import print_alias  # noqa: E402
 from .fix_command import fix_command  # noqa: E402
@@ -20,7 +20,7 @@ def main():
     if known_args.help:
         parser.print_help()
     elif known_args.version:
-        logs.version(get_installation_info().version,
+        logs.version(get_installation_version(),
                      sys.version.split()[0], shell.info())
     # It's important to check if an alias is being requested before checking if
     # `TF_HISTORY` is in `os.environ`, otherwise it might mess with subshells.

--- a/thefuck/utils.py
+++ b/thefuck/utils.py
@@ -294,10 +294,15 @@ def cache(*depends_on):
 cache.disabled = False
 
 
-def get_installation_info():
-    import pkg_resources
+def get_installation_version():
+    try:
+        from importlib.metadata import version
 
-    return pkg_resources.require('thefuck')[0]
+        return version('thefuck')
+    except ImportError:
+        import pkg_resources
+
+        return pkg_resources.require('thefuck')[0].version
 
 
 def get_alias():


### PR DESCRIPTION
pkg_resources is expensive to load, and it's an external module provided
by the setuptools project.

Let's use importlib.metadata from Python 3.8+'s stdlib when available, which
is much faster. This also erases setuptools from thefuck's runtime
dependency.

Simple benchmark data for `thefuck --version`:

Before: 0.602s
After: 0.169s