### PR TITLE
Fix git_hook_bypass priority (#1207)

### DIFF
--- a/thefuck/rules/git_hook_bypass.py
+++ b/thefuck/rules/git_hook_bypass.py
@@ -23,5 +23,5 @@ def get_new_command(command):
     )
 
 
-priority = 900
+priority = 1100
 requires_output = False


### PR DESCRIPTION
This fixes behaviour change raised in #1207 where `git [commit|am|push] --no-verify` has priority over other suggestions.