### PR TITLE
Add rule 'rails_migrations_pending'

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ following rules are enabled by default:
 * `python_module_error` &ndash; fixes ModuleNotFoundError by trying to `pip install` that module;
 * `quotation_marks` &ndash; fixes uneven usage of `'` and `"` when containing args';
 * `path_from_history` &ndash; replaces not found path with similar absolute path from history;
+* `rails_migrations_pending` &ndash; runs pending migrations;
 * `react_native_command_unrecognized` &ndash; fixes unrecognized `react-native` commands;
 * `remove_shell_prompt_literal` &ndash; remove leading shell prompt symbol `$`, common when copying commands from documentations;
 * `remove_trailing_cedilla` &ndash; remove trailing cedillas `ç`, a common typo for european keyboard layouts;

--- a/tests/rules/test_rails_migrations_pending.py
+++ b/tests/rules/test_rails_migrations_pending.py
@@ -1,0 +1,46 @@
+import pytest
+from thefuck.rules.rails_migrations_pending import match, get_new_command
+from thefuck.types import Command
+
+output_env_development = '''
+Migrations are pending. To resolve this issue, run:
+
+        rails db:migrate RAILS_ENV=development
+'''
+output_env_test = '''
+Migrations are pending. To resolve this issue, run:
+
+        bin/rails db:migrate RAILS_ENV=test
+'''
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        Command("", output_env_development),
+        Command("", output_env_test),
+    ],
+)
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        Command("Environment data not found in the schema. To resolve this issue, run: \n\n", ""),
+    ],
+)
+def test_not_match(command):
+    assert not match(command)
+
+
+@pytest.mark.parametrize(
+    "command, new_command",
+    [
+        (Command("", output_env_development), "rails db:migrate RAILS_ENV=development"),
+        (Command("", output_env_test), "bin/rails db:migrate RAILS_ENV=test"),
+    ],
+)
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_rails_migrations_pending.py
+++ b/tests/rules/test_rails_migrations_pending.py
@@ -38,8 +38,8 @@ def test_not_match(command):
 @pytest.mark.parametrize(
     "command, new_command",
     [
-        (Command("", output_env_development), "rails db:migrate RAILS_ENV=development"),
-        (Command("", output_env_test), "bin/rails db:migrate RAILS_ENV=test"),
+        (Command("bin/rspec", output_env_development), "rails db:migrate RAILS_ENV=development && bin/rspec"),
+        (Command("bin/rspec", output_env_test), "bin/rails db:migrate RAILS_ENV=test && bin/rspec"),
     ],
 )
 def test_get_new_command(command, new_command):

--- a/thefuck/rules/rails_migrations_pending.py
+++ b/thefuck/rules/rails_migrations_pending.py
@@ -5,7 +5,7 @@ SUGGESTION_REGEX = r"To resolve this issue, run:\s+(.*?)\n"
 
 
 def match(command):
-    return ("Migrations are pending. To resolve this issue, run:" in command.output)
+    return "Migrations are pending. To resolve this issue, run:" in command.output
 
 
 def get_new_command(command):

--- a/thefuck/rules/rails_migrations_pending.py
+++ b/thefuck/rules/rails_migrations_pending.py
@@ -1,4 +1,5 @@
 import re
+from thefuck.shells import shell
 
 
 SUGGESTION_REGEX = r"To resolve this issue, run:\s+(.*?)\n"
@@ -9,4 +10,5 @@ def match(command):
 
 
 def get_new_command(command):
-    return re.search(SUGGESTION_REGEX, command.output).group(1)
+    migration_script = re.search(SUGGESTION_REGEX, command.output).group(1)
+    return shell.and_(migration_script, command.script)

--- a/thefuck/rules/rails_migrations_pending.py
+++ b/thefuck/rules/rails_migrations_pending.py
@@ -1,0 +1,12 @@
+import re
+
+
+SUGGESTION_REGEX = r"To resolve this issue, run:\s+(.*?)\n"
+
+
+def match(command):
+    return ("Migrations are pending. To resolve this issue, run:" in command.output)
+
+
+def get_new_command(command):
+    return re.search(SUGGESTION_REGEX, command.output).group(1)


### PR DESCRIPTION
Add rule to fix a common Rails issue when running tests. 

Rails source code that generates the message: https://github.com/rails/rails/blob/main/activerecord/lib/active_record/migration.rb#L152

Example output on my console:
```
abrahamchan [master] > bin/rspec     
Running via Spring preloader in process 35661
Migrations are pending. To resolve this issue, run:

        rails db:migrate RAILS_ENV=test
No examples found.

abrahamchan [master] > fuck
rails db:migrate RAILS_ENV=test [enter/↑/↓/ctrl+c]
== 20210627174953 Example: migrating ==========================================
== 20210627174953 Example: migrated (0.0000s) =================================

abrahamchan [master] > bin/rspec
[successful rspec output]
```