### PR TITLE
Fix yield_fixture deprecation

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -231,7 +231,7 @@ class TestCache(object):
 
 
 class TestGetValidHistoryWithoutCurrent(object):
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def fail_on_warning(self):
         warnings.simplefilter('error')
         yield


### PR DESCRIPTION
I get this warning when running `py.test`. Simply changed `.yield_fixture` to `.fixture` as instructed.

```
tests/test_utils.py:234
  /Users/abrahamchan/Source/thefuck/tests/test_utils.py:234: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    @pytest.yield_fixture(autouse=True)
```

