### PR TITLE
#994: Replace decoding errors with the replacement marker

### DIFF
--- a/tests/output_readers/test_rerun.py
+++ b/tests/output_readers/test_rerun.py
@@ -22,6 +22,14 @@ class TestRerun(object):
         assert rerun.get_output('', '') is None
         wait_output_mock.assert_called_once()
 
+    @patch('thefuck.output_readers.rerun.Popen')
+    def test_get_output_invalid_continuation_byte(self, popen_mock):
+        output = b'ls: illegal option -- \xc3\nusage: ls [-@ABC...] [file ...]\n'
+        expected = u'ls: illegal option -- \ufffd\nusage: ls [-@ABC...] [file ...]\n'
+        popen_mock.return_value.stdout.read.return_value = output
+        actual = rerun.get_output('', '')
+        assert actual == expected
+
     def test_wait_output_is_slow(self, settings):
         assert rerun._wait_output(Mock(), True)
         self.proc_mock.wait.assert_called_once_with(settings.wait_slow_command)

--- a/thefuck/output_readers/rerun.py
+++ b/thefuck/output_readers/rerun.py
@@ -60,7 +60,7 @@ def get_output(script, expanded):
         result = Popen(expanded, shell=True, stdin=PIPE,
                        stdout=PIPE, stderr=STDOUT, env=env)
         if _wait_output(result, is_slow):
-            output = result.stdout.read().decode('utf-8')
+            output = result.stdout.read().decode('utf-8', errors='replace')
             logs.debug(u'Received output: {}'.format(output))
             return output
         else:


### PR DESCRIPTION
Fix #994

Reference: https://docs.python.org/3/library/codecs.html#error-handlers