### PR TITLE
#1215: Remove redirection to stderr with the ^ character

### DIFF
--- a/tests/shells/test_fish.py
+++ b/tests/shells/test_fish.py
@@ -87,8 +87,11 @@ class TestFish(object):
 
     def test_app_alias_alter_history(self, settings, shell):
         settings.alter_history = True
-        assert 'builtin history delete' in shell.app_alias('FUCK')
-        assert 'builtin history merge' in shell.app_alias('FUCK')
+        assert (
+            'builtin history delete --exact --case-sensitive -- $fucked_up_command\n'
+            in shell.app_alias('FUCK')
+        )
+        assert 'builtin history merge\n' in shell.app_alias('FUCK')
         settings.alter_history = False
         assert 'builtin history delete' not in shell.app_alias('FUCK')
         assert 'builtin history merge' not in shell.app_alias('FUCK')

--- a/thefuck/shells/fish.py
+++ b/thefuck/shells/fish.py
@@ -52,7 +52,7 @@ class Fish(Generic):
         if settings.alter_history:
             alter_history = ('    builtin history delete --exact'
                              ' --case-sensitive -- $fucked_up_command\n'
-                             '    builtin history merge ^ /dev/null\n')
+                             '    builtin history merge\n')
         else:
             alter_history = ''
         # It is VERY important to have the variables declared WITHIN the alias


### PR DESCRIPTION
Redirection to standard error with the `^` character is [disabled by default since Fish Shell version 3.3][1].

Fix #1214

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1