### PR TITLE
#618: Fix git_push_without_commits rule

### DIFF
--- a/tests/rules/test_git_push_without_commits.py
+++ b/tests/rules/test_git_push_without_commits.py
@@ -1,27 +1,20 @@
-import pytest
-
 from thefuck.types import Command
-from thefuck.rules.git_push_without_commits import (
-    fix,
-    get_new_command,
-    match,
-)
-
-command = 'git push -u origin master'
-expected_error = '''
-error: src refspec master does not match any.
-error: failed to push some refs to 'git@github.com:User/repo.git'
-'''
+from thefuck.rules.git_push_without_commits import get_new_command, match
 
 
-@pytest.mark.parametrize('command', [Command(command, expected_error)])
-def test_match(command):
-    assert match(command)
+def test_match():
+    script = "git push -u origin master"
+    output = "error: src refspec master does not match any\nerror: failed to..."
+    assert match(Command(script, output))
 
 
-@pytest.mark.parametrize('command, result', [(
-    Command(command, expected_error),
-    fix.format(command=command),
-)])
-def test_get_new_command(command, result):
-    assert get_new_command(command) == result
+def test_not_match():
+    script = "git push -u origin master"
+    assert not match(Command(script, "Everything up-to-date"))
+
+
+def test_get_new_command():
+    script = "git push -u origin master"
+    output = "error: src refspec master does not match any\nerror: failed to..."
+    new_command = 'git commit -m "Initial commit" && git push -u origin master'
+    assert get_new_command(Command(script, output)) == new_command

--- a/thefuck/rules/git_push_without_commits.py
+++ b/thefuck/rules/git_push_without_commits.py
@@ -1,14 +1,12 @@
 import re
+from thefuck.shells import shell
 from thefuck.specific.git import git_support
-
-fix = u'git commit -m "Initial commit." && {command}'
-refspec_does_not_match = re.compile(r'src refspec \w+ does not match any\.')
 
 
 @git_support
 def match(command):
-    return bool(refspec_does_not_match.search(command.output))
+    return bool(re.search(r"src refspec \w+ does not match any", command.output))
 
 
 def get_new_command(command):
-    return fix.format(command=command.script)
+    return shell.and_('git commit -m "Initial commit"', command.script)


### PR DESCRIPTION
The rule was in a non-working state. And the tests needed some bit of simplification. Certain degree of repetition is oftentimes a good thing.