### PR TITLE
Fix outdated link to homebrew for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,5 @@ Project License can be found [here](LICENSE.md).
 [examples-link]:   https://raw.githubusercontent.com/nvbn/thefuck/master/example.gif
 [instant-mode-gif-link]:   https://raw.githubusercontent.com/nvbn/thefuck/master/example_instant_mode.gif
 [homebrew]:        https://brew.sh/
-[linuxbrew]:       https://linuxbrew.sh/
 
 ##### [Back to Contents](#contents)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Reading package lists... Done
 
 ## Installation
 
-On macOS, you can install *The Fuck* via [Homebrew][homebrew] (or via [Linuxbrew][linuxbrew] on Linux):
+On macOS or Linux, you can install *The Fuck* via [Homebrew][homebrew]:
 
 ```bash
 brew install thefuck


### PR DESCRIPTION
Homebrew for Linux now shares the same domain name as Homebrew for macOS.

The URL to homebrew for Linux became inaccessible.