### PR TITLE
#1227: Make `git_support` support output-independent rules

### DIFF
--- a/tests/specific/test_git.py
+++ b/tests/specific/test_git.py
@@ -27,9 +27,10 @@ def test_git_support(called, command, output):
     ('ls', False),
     ('cat git', False),
     ('cat hub', False)])
-def test_git_support_match(command, is_git):
+@pytest.mark.parametrize('output', ['', None])
+def test_git_support_match(command, is_git, output):
     @git_support
     def fn(command):
         return True
 
-    assert fn(Command(command, '')) == is_git
+    assert fn(Command(command, output)) == is_git

--- a/thefuck/specific/git.py
+++ b/thefuck/specific/git.py
@@ -14,7 +14,7 @@ def git_support(fn, command):
         return False
 
     # perform git aliases expansion
-    if 'trace: alias expansion:' in command.output:
+    if command.output and 'trace: alias expansion:' in command.output:
         search = re.search("trace: alias expansion: ([^ ]*) => ([^\n]*)",
                            command.output)
         alias = search.group(1)


### PR DESCRIPTION
Fix #1227