### PR TITLE
README: Use `--user` with pip, not `sudo pip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ On Ubuntu / Mint, install *The Fuck* with the following commands:
 ```bash
 sudo apt update
 sudo apt install python3-dev python3-pip python3-setuptools
-sudo pip3 install thefuck
+pip3 install thefuck --user
 ```
 
 On FreeBSD, install *The Fuck* with the following commands:


### PR DESCRIPTION
`sudo` with `pip` is [considered unsafe](https://stackoverflow.com/a/22517157/2469559).

Instead, run such commands with the `--user` argument to get the same result _safely._