### PR TITLE
Encapsulate force_command in _get_raw_command

### DIFF
--- a/tests/entrypoints/test_fix_command.py
+++ b/tests/entrypoints/test_fix_command.py
@@ -5,8 +5,8 @@ from thefuck.entrypoints.fix_command import _get_raw_command
 
 class TestGetRawCommand(object):
     def test_from_force_command_argument(self):
-        known_args = Mock(force_command=['git', 'brunch'])
-        assert _get_raw_command(known_args) == ['git', 'brunch']
+        known_args = Mock(force_command='git brunch')
+        assert _get_raw_command(known_args) == ['git brunch']
 
     def test_from_command_argument(self, os_environ):
         os_environ['TF_HISTORY'] = None

--- a/thefuck/entrypoints/fix_command.py
+++ b/thefuck/entrypoints/fix_command.py
@@ -12,7 +12,7 @@ from ..utils import get_alias, get_all_executables
 
 def _get_raw_command(known_args):
     if known_args.force_command:
-        return known_args.force_command
+        return [known_args.force_command]
     elif not os.environ.get('TF_HISTORY'):
         return known_args.command
     else:


### PR DESCRIPTION
Using the `force_command` argument will run into issues as the `_get_raw_command` method simply returns the value of `force_command` (which is a string) while it should actually return a list.

To reproduce the issue:

```bash
$ fuck --force-command 'cd foo'
cd d f o o [enter/↑/↓/ctrl+c]
$ cd foo
-bash: cd: foo: No such file or directory
$ fuck
mkdir -p foo && cd foo [enter/↑/↓/ctrl+c]
```

This bug is fixed by splitting the `force_command`:

```bash
$ fuck --force-command 'cd foo'
mkdir -p foo && cd foo [enter/↑/↓/ctrl+c]
```

Fixes #1240