### PR TITLE
Add `ping` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ following rules are enabled by default:
 * `no_such_file` &ndash; creates missing directories with `mv` and `cp` commands;
 * `omnienv_no_such_command` &ndash; fixes wrong commands for `goenv`, `nodenv`, `pyenv` and `rbenv` (eg.: `pyenv isntall` or `goenv list`);
 * `open` &ndash; either prepends `http://` to address passed to `open` or create a new file or directory and passes it to `open`;
+* `ping` &ndash; fixes cannot resolve host issues when `http(s)://` is prepended (eg. copy url from browser address bar);
 * `pip_install` &ndash; fixes permission issues with `pip install` commands by adding `--user` or prepending `sudo` if necessary;
 * `pip_unknown_command` &ndash; fixes wrong `pip` commands, for example `pip instatl/pip install`;
 * `php_s` &ndash; replaces `-s` by `-S` when trying to run a local php server;

--- a/tests/rules/test_ping.py
+++ b/tests/rules/test_ping.py
@@ -1,0 +1,41 @@
+import pytest
+from thefuck.rules.ping import get_new_command, match
+from thefuck.types import Command
+
+
+cannot_resolve_output = '''
+ping: cannot resolve {}: Unknown host
+'''.format
+
+resolve_output = '''
+PING {} ({}): 56 data bytes
+64 bytes from {}: icmp_seq=0 ttl=64 time=0.050 ms
+'''.format
+
+@pytest.mark.parametrize('command', [
+    Command('ping https://google.com', cannot_resolve_output('https://google.com')),
+    Command('ping http://google.com', cannot_resolve_output('http://google.com')),
+    Command('ping http://google.com/', cannot_resolve_output('http://google.com/')),
+    Command('ping http://google.com/?q=test', cannot_resolve_output('http://google.com/?q=test')),
+    Command('ping ftp://192.168.0.1', cannot_resolve_output('ftp://192.168.0.1')),
+    Command('ping -c 10 ftp://192.168.0.1', cannot_resolve_output('ftp://192.168.0.1')), # allow options
+])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command', [
+    Command('ping http:/google.com/', cannot_resolve_output('http:/google.com/')), # skip invalid url
+    Command('ping google.com', resolve_output('google.com', '142.250.70.174', '142.250.70.174')),
+    Command('ping 127.0.0.1', resolve_output('127.0.0.1', '127.0.0.1', '127.0.0.1')),
+])
+def test_not_match(command):
+    assert not match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('ping https://google.com', cannot_resolve_output('https://google.com')), 'ping google.com'),
+    (Command('ping -c 10 https://google.com', cannot_resolve_output('https://google.com')), 'ping -c 10 google.com'),
+])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/ping.py
+++ b/thefuck/rules/ping.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+from six.moves.urllib.parse import urlparse
+from thefuck.utils import for_app
+
+
+@for_app('ping')
+def match(command):
+    # It only fix if the target host is a valid url
+    try:
+        results = urlparse(command.script_parts[-1])
+        is_valid_url = results.hostname is not None
+    except Exception:
+        is_valid_url = False
+    return 'cannot resolve' in command.output and is_valid_url
+
+
+def get_new_command(command):
+    result = urlparse(command.script_parts[-1])
+    return ' '.join(command.script_parts[:-1]) + ' ' + result.hostname


### PR DESCRIPTION
**Background:** I often made this mistake by copying a URL from the browser's address bar and pasting it to the `ping` command. And it always yields that error:

```
$ ping https://github.com/
ping: cannot resolve https://github.com/: Unknown host
```

I expected `thefuck` could fix this by doing

```
$ fuck
ping github.com
```

So I created this PR to add the `ping` rule.