### PR TITLE
Add support for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,10 @@ jobs:
         run: coverage run --source=thefuck,tests -m pytest -v --capture=sys tests
       - name: Run tests (including functional)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == env.PYTHON_LATEST
-        run: coverage run --source=thefuck,tests -m pytest -v --capture=sys tests --enable-functional
+        run: |
+          docker build -t thefuck/python3 -f tests/Dockerfile --build-arg PYTHON_VERSION=3 .
+          docker build -t thefuck/python2 -f tests/Dockerfile --build-arg PYTHON_VERSION=2 .
+          coverage run --source=thefuck,tests -m pytest -v --capture=sys tests --enable-functional
       - name: Post coverage results
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == env.PYTHON_LATEST
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ on:
     types: [opened, reopened]
 
 env:
-  PYTHON_LATEST: 3.9
+  PYTHON_LATEST: "3.10"
 
 jobs:
   test:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ on:
     types: [opened, reopened]
 
 env:
-  PYTHON_LATEST: "3.10"
+  PYTHON_LATEST: "3.11"
 
 jobs:
   test:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,6 @@
 name: Tests
 
-on:
-  push:
-    branches: master]
-  pull_request:
-    branches: [master]
-    types: [opened, reopened]
+on: [push, pull_request]
 
 env:
   PYTHON_LATEST: "3.11"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -47,3 +47,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: coveralls --service=github
+  test-deprecated:
+    strategy:
+      matrix:
+        python-version: ["2.7", "3.6"]
+    runs-on: ubuntu-latest
+    container: python:${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install The Fuck with all dependencies
+        run: |
+          pip install -Ur requirements.txt coveralls
+          python setup.py develop
+      - name: Lint
+        run: flake8
+      - name: Run tests
+        run: coverage run --source=thefuck,tests -m pytest -v --capture=sys tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,13 +51,13 @@ flake8
 Run unit tests:
 
 ```bash
-py.test
+pytest
 ```
 
 Run unit and functional tests (requires docker):
 
 ```bash
-py.test --enable-functional
+pytest --enable-functional
 ```
 
 For sending package to pypi:

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Reading package lists... Done
 
 ## Requirements
 
-- python (3.4+)
+- python (3.5+)
 - pip
 - python-dev
 

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ following rules are enabled by default:
 * `systemctl` &ndash; correctly orders parameters of confusing `systemctl`;
 * `terraform_init.py` &ndash; run `terraform init` before plan or apply;
 * `terraform_no_command.py` &ndash; fixes unrecognized `terraform` commands;
-* `test.py` &ndash; runs `py.test` instead of `test.py`;
+* `test.py` &ndash; runs `pytest` instead of `test.py`;
 * `touch` &ndash; creates missing directories before "touching";
 * `tsuru_login` &ndash; runs `tsuru login` if not authenticated or session expired;
 * `tsuru_not_command` &ndash; fixes wrong `tsuru` commands like `tsuru shell`;

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(name='thefuck',
                                       'tests', 'tests.*', 'release']),
       include_package_data=True,
       zip_safe=False,
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
       install_requires=install_requires,
       extras_require=extras_require,
       entry_points={'console_scripts': [

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,7 @@
+ARG PYTHON_VERSION
+FROM python:${PYTHON_VERSION}
+RUN apt-get update -y
+RUN apt-get install -yy --no-install-recommends --no-install-suggests fish tcsh zsh
+RUN pip install --upgrade pip
+COPY . /src
+RUN pip install /src

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,6 +1,20 @@
 import pytest
 
+from pytest_docker_pexpect.docker import run as pexpect_docker_run, \
+    stats as pexpect_docker_stats
+
 
 @pytest.fixture(autouse=True)
 def build_container_mock(mocker):
     return mocker.patch('pytest_docker_pexpect.docker.build_container')
+
+
+def run_side_effect(*args, **kwargs):
+    container_id = pexpect_docker_run(*args, **kwargs)
+    pexpect_docker_stats(container_id)
+    return container_id
+
+
+@pytest.fixture(autouse=True)
+def run_mock(mocker):
+    return mocker.patch('pytest_docker_pexpect.docker.run', side_effect=run_side_effect)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def build_container_mock(mocker):
+    return mocker.patch('pytest_docker_pexpect.docker.build_container')

--- a/tests/functional/plots.py
+++ b/tests/functional/plots.py
@@ -20,10 +20,12 @@ def with_confirmation(proc, TIMEOUT):
     assert proc.expect([TIMEOUT, u'test'])
 
 
-def history_changed(proc, TIMEOUT, to):
+def history_changed(proc, TIMEOUT, *to):
     """Ensures that history changed."""
     proc.send('\033[A')
-    assert proc.expect([TIMEOUT, to])
+    pattern = [TIMEOUT]
+    pattern.extend(to)
+    assert proc.expect(pattern)
 
 
 def history_not_changed(proc, TIMEOUT):
@@ -44,14 +46,14 @@ def select_command_with_arrows(proc, TIMEOUT):
     proc.send('\033[B')
     assert proc.expect([TIMEOUT, u'git push'])
     proc.send('\033[B')
-    assert proc.expect([TIMEOUT, u'git help'])
+    assert proc.expect([TIMEOUT, u'git help', u'git hook'])
     proc.send('\033[A')
     assert proc.expect([TIMEOUT, u'git push'])
     proc.send('\033[B')
-    assert proc.expect([TIMEOUT, u'git help'])
+    assert proc.expect([TIMEOUT, u'git help', u'git hook'])
     proc.send('\n')
 
-    assert proc.expect([TIMEOUT, u'usage'])
+    assert proc.expect([TIMEOUT, u'usage', u'fatal: not a git repository'])
 
 
 def refuse_with_confirmation(proc, TIMEOUT):

--- a/tests/functional/test_bash.py
+++ b/tests/functional/test_bash.py
@@ -4,12 +4,12 @@ from tests.functional.plots import with_confirmation, without_confirmation, \
     select_command_with_arrows, how_to_configure
 
 
-python_3 = (u'thefuck/python3-bash',
-            u'FROM python:3',
+python_3 = (u'thefuck/python3',
+            u'',
             u'sh')
 
-python_2 = (u'thefuck/python2-bash',
-            u'FROM python:2',
+python_2 = (u'thefuck/python2',
+            u'',
             u'sh')
 
 
@@ -28,8 +28,6 @@ echo "instant mode ready: $THEFUCK_INSTANT_MODE"
 def proc(request, spawnu, TIMEOUT):
     container, instant_mode = request.param
     proc = spawnu(*container)
-    proc.sendline(u"pip install /src")
-    assert proc.expect([TIMEOUT, u'Successfully installed'])
     proc.sendline(init_bashrc.format(
         u'--enable-experimental-instant-mode' if instant_mode else ''))
     proc.sendline(u"bash")

--- a/tests/functional/test_bash.py
+++ b/tests/functional/test_bash.py
@@ -45,7 +45,7 @@ def test_with_confirmation(proc, TIMEOUT):
 @pytest.mark.functional
 def test_select_command_with_arrows(proc, TIMEOUT):
     select_command_with_arrows(proc, TIMEOUT)
-    history_changed(proc, TIMEOUT, u'git help')
+    history_changed(proc, TIMEOUT, u'git help', u'git hook')
 
 
 @pytest.mark.functional

--- a/tests/functional/test_fish.py
+++ b/tests/functional/test_fish.py
@@ -2,29 +2,13 @@ import pytest
 from tests.functional.plots import with_confirmation, without_confirmation, \
     refuse_with_confirmation, select_command_with_arrows
 
-containers = (('thefuck/python3-fish',
-               u'''FROM python:3
-                   # Use jessie-backports since it has the fish package. See here for details:
-                   # https://github.com/tianon/docker-brew-debian/blob/88ae21052affd8a14553bb969f9d41c464032122/jessie/backports/Dockerfile
-                   RUN awk '$1 ~ "^deb" { $3 = $3 "-backports"; print; exit }' /etc/apt/sources.list > /etc/apt/sources.list.d/backports.list
-                   RUN apt-get update
-                   RUN apt-get install -yy fish''',
-               u'fish'),
-              ('thefuck/python2-fish',
-               u'''FROM python:2
-                   # Use jessie-backports since it has the fish package. See here for details:
-                   # https://github.com/tianon/docker-brew-debian/blob/88ae21052affd8a14553bb969f9d41c464032122/jessie/backports/Dockerfile
-                   RUN awk '$1 ~ "^deb" { $3 = $3 "-backports"; print; exit }' /etc/apt/sources.list > /etc/apt/sources.list.d/backports.list
-                   RUN apt-get update
-                   RUN apt-get install -yy fish''',
-               u'fish'))
+containers = ((u'thefuck/python3', u'', u'fish'),
+              (u'thefuck/python2', u'', u'fish'))
 
 
 @pytest.fixture(params=containers)
 def proc(request, spawnu, TIMEOUT):
     proc = spawnu(*request.param)
-    proc.sendline(u"pip install /src")
-    assert proc.expect([TIMEOUT, u'Successfully installed'])
     proc.sendline(u'thefuck --alias > ~/.config/fish/config.fish')
     proc.sendline(u'fish')
     return proc

--- a/tests/functional/test_tcsh.py
+++ b/tests/functional/test_tcsh.py
@@ -2,23 +2,13 @@ import pytest
 from tests.functional.plots import with_confirmation, without_confirmation, \
     refuse_with_confirmation, select_command_with_arrows
 
-containers = (('thefuck/python3-tcsh',
-               u'''FROM python:3
-                   RUN apt-get update
-                   RUN apt-get install -yy tcsh''',
-               u'tcsh'),
-              ('thefuck/python2-tcsh',
-               u'''FROM python:2
-                   RUN apt-get update
-                   RUN apt-get install -yy tcsh''',
-               u'tcsh'))
+containers = ((u'thefuck/python3', u'', u'tcsh'),
+              (u'thefuck/python2', u'', u'tcsh'))
 
 
 @pytest.fixture(params=containers)
 def proc(request, spawnu, TIMEOUT):
     proc = spawnu(*request.param)
-    proc.sendline(u'pip install /src')
-    assert proc.expect([TIMEOUT, u'Successfully installed'])
     proc.sendline(u'tcsh')
     proc.sendline(u'setenv PYTHONIOENCODING utf8')
     proc.sendline(u'eval `thefuck --alias`')

--- a/tests/functional/test_zsh.py
+++ b/tests/functional/test_zsh.py
@@ -43,7 +43,7 @@ def test_with_confirmation(proc, TIMEOUT):
 @pytest.mark.functional
 def test_select_command_with_arrows(proc, TIMEOUT):
     select_command_with_arrows(proc, TIMEOUT)
-    history_changed(proc, TIMEOUT, u'git help')
+    history_changed(proc, TIMEOUT, u'git help', u'git hook')
 
 
 @pytest.mark.functional

--- a/tests/functional/test_zsh.py
+++ b/tests/functional/test_zsh.py
@@ -4,17 +4,8 @@ from tests.functional.plots import with_confirmation, without_confirmation, \
     select_command_with_arrows, how_to_configure
 
 
-python_3 = ('thefuck/python3-zsh',
-            u'''FROM python:3
-                RUN apt-get update
-                RUN apt-get install -yy zsh''',
-            u'sh')
-
-python_2 = ('thefuck/python2-zsh',
-            u'''FROM python:2
-                RUN apt-get update
-                RUN apt-get install -yy zsh''',
-            u'sh')
+python_3 = (u'thefuck/python3', u'', u'sh')
+python_2 = (u'thefuck/python2', u'', u'sh')
 
 
 init_zshrc = u'''echo '
@@ -35,8 +26,6 @@ echo "instant mode ready: $THEFUCK_INSTANT_MODE"
 def proc(request, spawnu, TIMEOUT):
     container, instant_mode = request.param
     proc = spawnu(*container)
-    proc.sendline(u'pip install /src')
-    assert proc.expect([TIMEOUT, u'Successfully installed'])
     proc.sendline(init_zshrc.format(
         u'--enable-experimental-instant-mode' if instant_mode else ''))
     proc.sendline(u"zsh")

--- a/tests/output_readers/test_rerun.py
+++ b/tests/output_readers/test_rerun.py
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8 -*-
 
+import pytest
+import sys
 from mock import Mock, patch
 from psutil import AccessDenied, TimeoutExpired
 
@@ -30,6 +32,7 @@ class TestRerun(object):
         actual = rerun.get_output('', '')
         assert actual == expected
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="skip when running on Windows")
     @patch('thefuck.output_readers.rerun._wait_output')
     def test_get_output_unicode_misspell(self, wait_output_mock):
         rerun.get_output(u'pácman', u'pácman')

--- a/tests/rules/test_fix_file.py
+++ b/tests/rules/test_fix_file.py
@@ -157,7 +157,7 @@ ReferenceError: conole is not defined
 ./tests/rules/test_whois.py:22:80: E501 line too long (83 > 79 characters)
 """),
 
-    FixFileTest('py.test', '/home/thefuck/tests/rules/test_fix_file.py', 218, None, """
+    FixFileTest('pytest', '/home/thefuck/tests/rules/test_fix_file.py', 218, None, """
 monkeypatch = <_pytest.monkeypatch.monkeypatch object at 0x7fdb76a25b38>
 test = ('fish a.sh', '/tmp/fix-error/a.sh', 2, None, '', "\\nfish: Unknown command 'foo'\\n/tmp/fix-error/a.sh (line 2): foo\\n                              ^\\n")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -245,7 +245,7 @@ class TestGetValidHistoryWithoutCurrent(object):
     def history(self, mocker):
         mock = mocker.patch('thefuck.shells.shell.get_history')
         #  Passing as an argument causes `UnicodeDecodeError`
-        #  with newer py.test and python 2.7
+        #  with newer pytest and python 2.7
         mock.return_value = ['le cat', 'fuck', 'ls cat',
                              'diff x', 'nocommand x', u'café ô']
         return mock

--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -1,10 +1,20 @@
-from imp import load_source
 import os
 import sys
 from warnings import warn
 from six import text_type
 from . import const
 from .system import Path
+
+try:
+    import importlib.util
+
+    def load_source(name, pathname, _file=None):
+        module_spec = importlib.util.spec_from_file_location(name, pathname)
+        module = importlib.util.module_from_spec(module_spec)
+        module_spec.loader.exec_module(module)
+        return module
+except ImportError:
+    from imp import load_source
 
 
 class Settings(dict):

--- a/thefuck/rules/test.py.py
+++ b/thefuck/rules/test.py.py
@@ -3,7 +3,7 @@ def match(command):
 
 
 def get_new_command(command):
-    return 'py.test'
+    return 'pytest'
 
 
 # make it come before the python_command rule

--- a/thefuck/types.py
+++ b/thefuck/types.py
@@ -1,9 +1,8 @@
-from imp import load_source
 import os
 import sys
 from . import logs
 from .shells import shell
-from .conf import settings
+from .conf import settings, load_source
 from .const import DEFAULT_PRIORITY, ALL_ENABLED
 from .exceptions import EmptyCommand
 from .utils import get_alias, format_raw_script

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38
+envlist = py27,py35,py36,py37,py38,py39,py310
 
 [testenv]
 deps = -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,py310
+envlist = py{27,35,36,37,38,39,310,311}
 
 [testenv]
 deps = -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27,py35,py36,py37,py38,py39,py310
 
 [testenv]
 deps = -rrequirements.txt
-commands = py.test -v --capture=sys
+commands = pytest -v --capture=sys
 
 [flake8]
 ignore = E501,W503,W504


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

![image](https://user-images.githubusercontent.com/1324225/198232883-ff62aefa-6590-4ddb-a34b-6ffb75d565f9.png)

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955

Drop the dot in `pytest`: 

* https://twitter.com/pytestdotorg/status/753767547866972160

Update min Python 3 version required in `README` to 3.5 to match `setup.py`.

Add `python_requires` to help pip.