### PR TITLE
Drop support for EOL Python 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,14 @@ name: Tests
 on: [push, pull_request]
 
 env:
-  PYTHON_LATEST: 3.9
+  PYTHON_LATEST: "3.10"
 
 jobs:
   test:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,13 +51,13 @@ flake8
 Run unit tests:
 
 ```bash
-py.test
+pytest
 ```
 
 Run unit and functional tests (requires docker):
 
 ```bash
-py.test --enable-functional
+pytest --enable-functional
 ```
 
 For sending package to pypi:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ If it is (sorry again), check if the problem has not already been reported and
 if not, just open an issue on [GitHub](https://github.com/nvbn/thefuck) with
 the following basic information:
   - the output of `thefuck --version` (something like `The Fuck 3.1 using
-    Python 3.5.0`);
+    Python 3.10.0`);
   - your shell and its version (`bash`, `zsh`, *Windows PowerShell*, etc.);
   - your system (Debian 7, ArchLinux, Windows, etc.);
   - how to reproduce the bug;

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Reading package lists... Done
 
 ## Requirements
 
-- python (3.4+)
+- python (3.5+)
 - pip
 - python-dev
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Reading package lists... Done
 
 ## Requirements
 
-- python (3.5+)
+- python (3.6+)
 - pip
 - python-dev
 

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ following rules are enabled by default:
 * `switch_lang` &ndash; switches command from your local layout to en;
 * `systemctl` &ndash; correctly orders parameters of confusing `systemctl`;
 * `terraform_init.py` &ndash; run `terraform init` before plan or apply;
-* `test.py` &ndash; runs `py.test` instead of `test.py`;
+* `test.py` &ndash; runs `pytest` instead of `test.py`;
 * `touch` &ndash; creates missing directories before "touching";
 * `tsuru_login` &ndash; runs `tsuru login` if not authenticated or session expired;
 * `tsuru_not_command` &ndash; fixes wrong `tsuru` commands like `tsuru shell`;

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ if version < (2, 7):
     print('thefuck requires Python version 2.7 or later' +
           ' ({}.{} detected).'.format(*version))
     sys.exit(-1)
-elif (3, 0) < version < (3, 5):
-    print('thefuck requires Python version 3.5 or later' +
+elif (3, 0) < version < (3, 6):
+    print('thefuck requires Python version 3.6 or later' +
           ' ({}.{} detected).'.format(*version))
     sys.exit(-1)
 
@@ -51,7 +51,7 @@ setup(name='thefuck',
                                       'tests', 'tests.*', 'release']),
       include_package_data=True,
       zip_safe=False,
-      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
       install_requires=install_requires,
       extras_require=extras_require,
       entry_points={'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(name='thefuck',
                                       'tests', 'tests.*', 'release']),
       include_package_data=True,
       zip_safe=False,
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
       install_requires=install_requires,
       extras_require=extras_require,
       entry_points={'console_scripts': [

--- a/tests/rules/test_fix_file.py
+++ b/tests/rules/test_fix_file.py
@@ -157,7 +157,7 @@ ReferenceError: conole is not defined
 ./tests/rules/test_whois.py:22:80: E501 line too long (83 > 79 characters)
 """),
 
-    FixFileTest('py.test', '/home/thefuck/tests/rules/test_fix_file.py', 218, None, """
+    FixFileTest('pytest', '/home/thefuck/tests/rules/test_fix_file.py', 218, None, """
 monkeypatch = <_pytest.monkeypatch.monkeypatch object at 0x7fdb76a25b38>
 test = ('fish a.sh', '/tmp/fix-error/a.sh', 2, None, '', "\\nfish: Unknown command 'foo'\\n/tmp/fix-error/a.sh (line 2): foo\\n                              ^\\n")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -245,7 +245,7 @@ class TestGetValidHistoryWithoutCurrent(object):
     def history(self, mocker):
         mock = mocker.patch('thefuck.shells.shell.get_history')
         #  Passing as an argument causes `UnicodeDecodeError`
-        #  with newer py.test and python 2.7
+        #  with newer pytest and python 2.7
         mock.return_value = ['le cat', 'fuck', 'ls cat',
                              'diff x', 'nocommand x', u'café ô']
         return mock

--- a/thefuck/rules/test.py.py
+++ b/thefuck/rules/test.py.py
@@ -3,7 +3,7 @@ def match(command):
 
 
 def get_new_command(command):
-    return 'py.test'
+    return 'pytest'
 
 
 # make it come before the python_command rule

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38
+envlist = py27,py35,py36,py37,py38,py39,py310
 
 [testenv]
 deps = -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27,py35,py36,py37,py38,py39,py310
 
 [testenv]
 deps = -rrequirements.txt
-commands = py.test -v --capture=sys
+commands = pytest -v --capture=sys
 
 [flake8]
 ignore = E501,W503,W504

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,py310
+envlist = py27,py36,py37,py38,py39,py310
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
(Includes https://github.com/nvbn/thefuck/pull/1248 to avoid conflicts, the [last commit](e7215062ae65d6ac34e0391404db59bc2b64a8de) here is unique. Happy to rebase or split it out.)

Drop support for EOL Python 3.5:

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |
| 3.5   | 3.5.10 | 2015-09-30 | 2020-09-13 |
| 2.7   | 2.7.18 | 2010-07-03 | 2020-01-01 |

It's also little used.

Here's the pip installs for thefuck from PyPI for October 2021:

| category | percent | downloads |
|:---------|--------:|----------:|
| 3.8      |  31.04% |     1,950 |
| 3.9      |  26.97% |     1,694 |
| null     |  25.74% |     1,617 |
| 3.6      |   5.46% |       343 |
| 3.10     |   3.82% |       240 |
| 3.7      |   3.77% |       237 |
| 2.7      |   2.34% |       147 |
| 3.5      |   0.65% |        41 |
| 3.4      |   0.19% |        12 |
| 3.11     |   0.02% |         1 |
| Total    |         |     6,282 |

Source: `pip install -U pypistats && pypistats python_minor thefuck --last-month`

