### PR TITLE
Add rule git_checkout_master

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ following rules are enabled by default:
 * `git_branch_list` &ndash; catches `git branch list` in place of `git branch` and removes created branch;
 * `git_branch_0flag` &ndash; fixes commands such as `git branch 0v` and `git branch 0r` removing the created branch;
 * `git_checkout` &ndash; fixes branch name or creates new branch;
+* `git_checkout_master` &ndash; fixes branch name if branch `main` exists and branch `master` doesn't;
 * `git_clone_git_clone` &ndash; replaces `git clone git clone ...` with `git clone ...`
 * `git_commit_add` &ndash; offers `git commit -a ...` or `git commit -p ...` after previous commit if it failed because nothing was staged;
 * `git_commit_amend` &ndash; offers `git commit --amend` after previous commit;

--- a/tests/rules/test_git_checkout_master.py
+++ b/tests/rules/test_git_checkout_master.py
@@ -1,0 +1,62 @@
+import pytest
+from io import BytesIO
+from thefuck.rules.git_checkout_master import (
+    match, main_branch_exists, get_new_command
+)
+from thefuck.types import Command
+
+
+def did_not_match(target, did_you_forget=False):
+    error = ('error: pathspec \'{}\' did not match any file(s) known to git.'
+             .format(target))
+
+    if did_you_forget:
+        error = ('{}\nDid you forget to \'git add\'?\''.format(error))
+
+    return error
+
+
+@pytest.fixture
+def git_branch_patch(mocker, branches):
+    mock = mocker.patch('subprocess.Popen')
+    mock.return_value.stdout = BytesIO(branches)
+    return mock
+
+
+@pytest.mark.parametrize('command', [
+    Command('git checkout master', did_not_match('master'))])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command', [
+    Command('git checkout master', did_not_match('master', True)),
+    Command('git checkout -b master', ''),
+    Command('git checkout known', '')])
+def test_not_match(command):
+    assert not match(command)
+
+
+@pytest.mark.parametrize('branches', [
+    b'* other\n  remotes/origin/HEAD -> origin/main\n  remotes/origin/main', ])
+def test_main_branch_exists(branches, git_branch_patch):
+    git_branch_patch(branches)
+    assert main_branch_exists()
+
+
+@pytest.mark.parametrize('branches', [
+    b'',
+    b'* not-master',
+    b'* other\n  remotes/origin/HEAD -> origin/master'])
+def test_not_main_branch_exists(branches, git_branch_patch):
+    git_branch_patch(branches)
+    assert not main_branch_exists()
+
+
+@pytest.mark.parametrize('branches, command, new_command', [
+    (b'* other\n  remotes/origin/HEAD -> origin/main\n  remotes/origin/main',
+     Command('git checkout master', did_not_match('master')),
+     'git checkout main'), ])
+def test_get_new_command(branches, command, new_command, git_branch_patch):
+    git_branch_patch(branches)
+    assert get_new_command(command) == new_command

--- a/thefuck/rules/git_checkout_master.py
+++ b/thefuck/rules/git_checkout_master.py
@@ -5,7 +5,7 @@ from thefuck.specific.git import git_support
 
 @git_support
 def match(command):
-    return ('error: pathspec \'master\' did not match any file(s) known to git'
+    return ("error: pathspec 'master' did not match any file(s) known to git"
             in command.output
             and "Did you forget to 'git add'?" not in command.output)
 

--- a/thefuck/rules/git_checkout_master.py
+++ b/thefuck/rules/git_checkout_master.py
@@ -15,7 +15,7 @@ def main_branch_exists():
         ['git', 'branch', '-a', '--list', 'main'],
         stdout=subprocess.PIPE)
     branches = [i.decode('utf-8').strip() for i in proc.stdout.readlines()]
-    return 'remotes/origin/main' in branches
+    return len(branches) > 0
 
 
 @git_support

--- a/thefuck/rules/git_checkout_master.py
+++ b/thefuck/rules/git_checkout_master.py
@@ -12,7 +12,7 @@ def match(command):
 
 def main_branch_exists():
     proc = subprocess.Popen(
-        ['git', 'branch', '-a', '--no-color', '--no-column'],
+        ['git', 'branch', '-a', '--list', 'main'],
         stdout=subprocess.PIPE)
     branches = [i.decode('utf-8').strip() for i in proc.stdout.readlines()]
     return 'remotes/origin/main' in branches

--- a/thefuck/rules/git_checkout_master.py
+++ b/thefuck/rules/git_checkout_master.py
@@ -1,0 +1,26 @@
+import subprocess
+from thefuck.utils import replace_argument
+from thefuck.specific.git import git_support
+
+
+@git_support
+def match(command):
+    return ('error: pathspec \'master\' did not match any file(s) known to git'
+            in command.output
+            and "Did you forget to 'git add'?" not in command.output)
+
+
+def main_branch_exists():
+    proc = subprocess.Popen(
+        ['git', 'branch', '-a', '--no-color', '--no-column'],
+        stdout=subprocess.PIPE)
+    branches = [i.decode('utf-8').strip() for i in proc.stdout.readlines()]
+    return 'remotes/origin/main' in branches
+
+
+@git_support
+def get_new_command(command):
+    if main_branch_exists():
+        return replace_argument(command.script, 'checkout master', 'checkout main')
+
+    return []


### PR DESCRIPTION
Add specific rule for when you type `git checkout master` but it doesn't exist and `main` does exist to suggest `git checkout main`