### PR TITLE
Add instructions to use in corporate environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,17 +543,29 @@ main()
 ```
 Lastly you need to configure your shell, follow the instructions to
 [configure for your choice of shell](https://github.com/nvbn/thefuck/wiki/Shell-aliases).
+If you have kept the name `thefuck`, this is simply the same as a standard install.
+Add the aliasing to your `.bash_profile`, `.bashrc`, `.zshrc` or other startup script
+```bash
+eval $(thefuck --alias)
+```
+
 If you have chosen an alternate name for the script you may need to use a
 tool like `sed` to modify the alias setup output to call the correct script. 
 As an example, here is how to configure fish to use run thefuck as `thedang` 
 with the `dang` alias:
 ```
 ⋊> ~ thedang --alias | sed 's/fuck/dang/g' > ~/.config/fish/functions/dang.fish
-⋊> ~ cat ~/.config/fish/functions/dang.fish | source
 ⋊> ~ ehco foo
 fish: Unknown command: ehco
 ⋊> ~ dang --yeah
 foo
+```
+
+Optionally, you may also want to edit the error message "No fucks given", as you have
+installed as a user the simplest way to do this would be to use to find the location 
+of the package and edit `ui.py`. eg:
+```bash
+sed -i 's/No fucks given/Oopsies!/' `pip3 show thefuck | grep 'Location: ' | sed 's/.* //'`/thefuck/ui.py
 ```
 
 ##### [Back to Contents](#contents)

--- a/README.md
+++ b/README.md
@@ -516,6 +516,48 @@ thefuck_contrib_foo
 
 ##### [Back to Contents](#contents)
 
+## Use in a Corporate Environment
+Installing thefuck is a lot easier when you have admin access to your machine,
+but many developers may be using computers owned by their employer.
+It is still possible to use thefuck without administrator access, but there 
+are some additional steps needed to install that only depend on you having a 
+python install.
+
+You might also like to take the opportunity to install it under an alternate
+name that is more acceptable to talk about out loud in the workplace such as
+Theph Oock, thefeck, or thedang.
+
+If pip is available, you can install thefuck as a user with the following
+command:
+```bash
+➜ pip3 install --user thefuck
+```
+If for some reaason you don't have pip, the python code can be copied from 
+this repository. Next, you'll need to create a script to fill the role of
+the executable `thefuck` and put it somewhere in your user `$PATH`. A simple
+example of this is:
+```python
+#!/usr/bin/env python3
+from thefuck.main import main
+main()
+```
+Lastly you need to configure your shell, follow the instructions to
+[configure for your choice of shell](https://github.com/nvbn/thefuck/wiki/Shell-aliases).
+If you have chosen an alternate name for the script you may need to use a
+tool like `sed` to modify the alias setup output to call the correct script. 
+As an example, here is how to configure fish to use run thefuck as `thedang` 
+with the `dang` alias:
+```
+⋊> ~ thedang --alias | sed 's/fuck/dang/g' > ~/.config/fish/functions/dang.fish
+⋊> ~ cat ~/.config/fish/functions/dang.fish | source
+⋊> ~ ehco foo
+fish: Unknown command: ehco
+⋊> ~ dang --yeah
+foo
+```
+
+##### [Back to Contents](#contents)
+
 ## Experimental instant mode
 
 The default behavior of *The Fuck* requires time to re-run previous commands.


### PR DESCRIPTION
thefuck is extremely useful for developers and other professions that might require using, for example, a locked down Macbook that does not have local administrator access. I think it is important to include some instructions on how to get the tool set up in such an environment because it may not be obvious but fairly straightforward if you know what you're doing.

By the way, since I use it as an example, I got fish installed without admin access too:
```
ln -s ~/Applications/fish.app/Contents/Resources/base/usr/local/bin/fish ~/bin/fish
```

Fixes #1252