### PR TITLE
fix: fish history file location

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pypandoc
 pytest-benchmark
 pytest-docker-pexpect
 twine
+xdg

--- a/thefuck/shells/fish.py
+++ b/thefuck/shells/fish.py
@@ -8,6 +8,7 @@ from ..conf import settings
 from ..const import ARGUMENT_PLACEHOLDER
 from ..utils import DEVNULL, cache
 from .generic import Generic
+from xdg import xdg_data_home
 
 
 @cache('~/.config/fish/config.fish', '~/.config/fish/functions')
@@ -83,7 +84,7 @@ class Fish(Generic):
             return command_script
 
     def _get_history_file_name(self):
-        return os.path.expanduser('~/.config/fish/fish_history')
+        return xdg_data_home().joinpath("fish").joinpath("fish_history")
 
     def _get_history_line(self, command_script):
         return u'- cmd: {}\n   when: {}\n'.format(command_script, int(time()))


### PR DESCRIPTION
Fixes #1027

However, the entries still contain both, the original `fuck` command and the corrected one. Not sure if this is intended behavior or not.