### PR TITLE
Upper to lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ following rules are enabled by default:
 * `tmux` &ndash; fixes `tmux` commands;
 * `unknown_command` &ndash; fixes hadoop hdfs-style "unknown command", for example adds missing '-' to the command on `hdfs dfs ls`;
 * `unsudo` &ndash; removes `sudo` from previous command if a process refuses to run on superuser privilege.
+* `upper_to_lowercase` &ndash; replaces the uppercase letters with lowercase, if all the srcipt is typed in uppercase letters;
 * `vagrant_up` &ndash; starts up the vagrant instance;
 * `whois` &ndash; fixes `whois` command;
 * `workon_doesnt_exists` &ndash; fixes `virtualenvwrapper` env name os suggests to create new.

--- a/tests/rules/test_upper_to_lowercase.py
+++ b/tests/rules/test_upper_to_lowercase.py
@@ -1,0 +1,47 @@
+import pytest
+
+from thefuck.rules.upper_to_lowercase import match, get_new_command
+from thefuck.types import Command
+
+
+
+@pytest.mark.parametrize(
+    "script, output",
+    [
+        ("LS", ""),
+        ("CD THEFUCK", ""),
+        ("CAT README.MD", ""),
+        ("MV TESTS TESTING", ""),
+        ("GIT ADD .", ""),
+    ],
+)
+def test_match(script, output):
+    assert match(Command(script, output))
+
+
+@pytest.mark.parametrize(
+    "script, output",
+    [
+        ("ls", ""),
+        ("cd thefuck", ""),
+        ("cat README.md", ""),
+        ("mv tests testing", ""),
+        ("git add .", ""),
+    ],
+)
+def test_not_match(script, output):
+    assert not match(Command(script, output))
+
+
+@pytest.mark.parametrize(
+    "script, output, new_command",
+    [
+        ("LS", "", "ls"),
+        ("CD THEFUCK", "", "cd thefuck"),
+        ("CAT README.MD", "", "cat readme.md"),
+        ("MV TESTS TESTING", "", "mv tests testing"),
+        ("GIT ADD .", "", "git add ."),
+    ],
+)
+def test_get_new_command(script, output, new_command):
+    assert get_new_command(Command(script, output)) == new_command

--- a/thefuck/rules/upper_to_lowercase.py
+++ b/thefuck/rules/upper_to_lowercase.py
@@ -1,0 +1,8 @@
+def match(command):
+    return command.script.isupper()
+
+
+def get_new_command(command):
+    return command.script.lower()
+
+priority = 0


### PR DESCRIPTION
This rule convert the uppercase letters of the command to lowercase, only if all the letters of the command are uppercase (which is the most common mistake). 
For example, if I type
`$ LS`
an error will occur. So I will type
`$ fuck
ls ([enter/↑/↓/ctrl+c]`