### PR TITLE
Prioritise main/master mix ups

### DIFF
--- a/thefuck/rules/git_main_master.py
+++ b/thefuck/rules/git_main_master.py
@@ -13,4 +13,4 @@ def get_new_command(command):
     return command.script.replace("main", "master")
 
 
-priority = 1200
+priority = 800


### PR DESCRIPTION
Fixing the mix up of branches `main` and `master` should have a higher priority than other rules, because it is more logical most of the time. One example:
```
$ git checkout main
error: pathspec 'main' did not match any file(s) known to git
```

The suggestion `git checkout master` should have the highest priority, rather than `git checkout -b main` which is the case now.