### PR TITLE
Exclude unwanted directories from flake8 and imrpove gitignore

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+exclude = .git,__pycache__,.venv,.env,old,build,dist
+; max-complexity = 10

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,11 @@ docs/_build/
 target/
 
 .env
+.venv
+
+# IDE things
 .idea
+.vscode
 
 # vim temporary files
 .*.swp


### PR DESCRIPTION
It appears that without a global configuration, Flake8 will scan folders such as the virtual environment, which leads to much slower performance and a lot of unrelated errors. I added a simple `.flake8` file to exclude these directories

I also added a couple more unwanted directories to the `.gitignore` file to prevent additional headaches
* `.venv`: virtual environments
* `.vscode`: IDE configurations

This is my first contribution to this (or any) repo other than my own, so be nice please thanks :)