### PR TITLE
New rule: fix missing `git clone` when given a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ following rules are enabled by default:
 * `git_branch_0flag` &ndash; fixes commands such as `git branch 0v` and `git branch 0r` removing the created branch;
 * `git_checkout` &ndash; fixes branch name or creates new branch;
 * `git_clone_git_clone` &ndash; replaces `git clone git clone ...` with `git clone ...`
+* `git_clone_missing` &ndash; adds `git clone` to URLs that appear to link to a git repository.
 * `git_commit_add` &ndash; offers `git commit -a ...` or `git commit -p ...` after previous commit if it failed because nothing was staged;
 * `git_commit_amend` &ndash; offers `git commit --amend` after previous commit;
 * `git_commit_reset` &ndash; offers `git reset HEAD~` after previous commit;

--- a/tests/rules/test_git_clone_missing.py
+++ b/tests/rules/test_git_clone_missing.py
@@ -22,20 +22,10 @@ invalid_urls = [
     'https:/github.com/nvbn/thefuck.git'  # Bad protocol
 ]
 
-# TODO: Powershell,
-shell_errors = [
-    'not found',  # sh
-    'command not found',  # fish
-    'No such file or directory',  # bash
-    'no such file or directory',  # zsh
-    'is not recognized as',  # cmd, powershell
-]
-
-
 
 @pytest.mark.parametrize(
     'cmd',
-    [Command(c, e) for c, e in product(valid_urls, shell_errors)]
+    [Command(c, 'not found') for c in valid_urls]
 )
 def test_match(cmd):
     assert match(cmd)
@@ -43,7 +33,7 @@ def test_match(cmd):
 
 @pytest.mark.parametrize(
     'cmd',
-    [Command(c, shell_errors[0]) for c in invalid_urls]
+    [Command(c, 'not found') for c in invalid_urls]
 )
 def test_not_match(cmd):
     assert not match(cmd)
@@ -51,7 +41,7 @@ def test_not_match(cmd):
 
 @pytest.mark.parametrize(
     'cmd',
-    [Command(c, shell_errors[0]) for c in valid_urls]
+    [Command(c, 'not found') for c in valid_urls]
 )
 def test_get_new_command(cmd):
     assert get_new_command(cmd) == 'git clone ' + cmd.script

--- a/tests/rules/test_git_clone_missing.py
+++ b/tests/rules/test_git_clone_missing.py
@@ -1,0 +1,37 @@
+from thefuck.rules.git_clone_git_clone import match, get_new_command
+from thefuck.types import Command
+
+output_clean = """
+fatal: Too many arguments.
+
+usage: git clone [<options>] [--] <repo> [<dir>]
+"""
+
+http_url = 'https://github.com/nvbn/thefuck.git'
+ssh_url = 'git@github.com:nvbn/thefuck.git'
+
+# HELP WANTED: How can I make this independent of the shell?
+http_output = """
+bash: https://github.com/nvbn/thefuck.git: No such file or directory
+"""
+ssh_output = """
+bash: hgit@github.com:nvbn/thefuck.git: No such file or directory
+"""
+
+
+def test_match():
+    assert match(Command(http_url, http_output))
+    assert match(Command(ssh_url, ssh_output))
+
+
+def test_not_match():
+    assert not match(Command('', ''))
+    assert not match(Command('git branch', ''))
+    assert not match(Command('git clone foo', ''))
+    assert not match(Command('git clone foo bar baz', output_clean))
+    assert not match(Command('git clone ' + http_url, ''))
+
+
+def test_get_new_command():
+    assert get_new_command(Command(http_url, http_output)) == 'git clone ' + http_url
+    assert get_new_command(Command(ssh_url, ssh_output)) == 'git clone ' + ssh_url

--- a/tests/rules/test_git_clone_missing.py
+++ b/tests/rules/test_git_clone_missing.py
@@ -13,11 +13,12 @@ valid_urls = [
 invalid_urls = [
     '',  # No command
     'notacommand',  # Command not found
+    'ssh git@github.com:nvbn/thefrick.git',  # ssh command, not a git clone
     'git clone foo',  # Valid clone
     'git clone https://github.com/nvbn/thefuck.git',  # Full command
     'github.com/nvbn/thefuck.git',  # Missing protocol
     'github.com:nvbn/thefuck.git',  # SSH missing username
-    'git clone git clone ssh://git@github.com:nvbn/thefrick.git',  # Double clone
+    'git clone git clone ssh://git@github.com:nvbn/thefrick.git',  # 2x clone
     'https:/github.com/nvbn/thefuck.git'  # Bad protocol
 ]
 
@@ -38,9 +39,8 @@ def test_not_match(cmd):
     assert not match(cmd)
 
 
-@pytest.mark.parametrize(
-    'cmd',
-    [Command(c, 'not found') for c in valid_urls]
-)
-def test_get_new_command(cmd):
-    assert get_new_command(cmd) == 'git clone ' + cmd.script
+@pytest.mark.parametrize('script', valid_urls)
+def test_get_new_command(script):
+    command = Command(script, 'not found')
+    new_command = 'git clone ' + script
+    assert get_new_command(command) == new_command

--- a/tests/rules/test_git_clone_missing.py
+++ b/tests/rules/test_git_clone_missing.py
@@ -1,53 +1,60 @@
 import pytest
+from itertools import product
 from thefuck.rules.git_clone_missing import match, get_new_command
 from thefuck.types import Command
 
-https_url = 'https://github.com/nvbn/thefuck.git'
-http_url = 'http://github.com/nvbn/thefuck.git'
-ssh_url = 'git@github.com:nvbn/thefuck.git'
+valid_urls = [
+    'https://github.com/nvbn/thefuck.git',
+    'https://github.com/nvbn/thefuck',
+    'http://github.com/nvbn/thefuck.git',
+    'git@github.com:nvbn/thefuck.git',
+    'git@github.com:nvbn/thefuck',
+    'ssh://git@github.com:nvbn/thefuck.git',
+]
+invalid_urls = [
+    '',  # No command
+    'notacommand',  # Command not found
+    'git clone foo',  # Valid clone
+    'git clone https://github.com/nvbn/thefuck.git',  # Full command
+    'github.com/nvbn/thefuck.git',  # Missing protocol
+    'github.com:nvbn/thefuck.git',  # SSH missing username
+    'git clone git clone ssh://git@github.com:nvbn/thefrick.git',  # Double clone
+    'https:/github.com/nvbn/thefuck.git'  # Bad protocol
+]
 
-# HELP WANTED: How can I make this independent of the shell?
-https_output = """
-output=/bin/sh: 1: https://github.com/nvbn/thefuck.git: not found
-"""
-http_output = """
-output=/bin/sh: 1: http://github.com/nvbn/thefuck.git: not found
-"""
-ssh_output = """
-/bin/sh: 1: git@github.com:nvbn/thefuck.git: not found
-"""
+# TODO: Powershell,
+shell_errors = [
+    'not found',  # sh
+    'command not found',  # fish
+    'No such file or directory',  # bash
+    'no such file or directory',  # zsh
+    'is not recognized as',  # cmd, powershell
+]
+
+
 
 @pytest.mark.parametrize(
-    'cmd', [
-        Command(https_url, https_output),
-        Command(http_url, http_output),
-        Command(ssh_url, ssh_output),
-    ]
+    'cmd',
+    [Command(c, e) for c, e in product(valid_urls, shell_errors)]
 )
 def test_match(cmd):
+    print(cmd)
     assert match(cmd)
 
+
 @pytest.mark.parametrize(
-    'cmd', [
-        Command('', ''),
-        Command('git branch', ''),
-        Command('git clone foo', ''),
-        Command('git clone foo bar baz', ''),
-        Command('git clone ' + http_url, http_output),
-        Command('git@example.com:thing.gut', ssh_output),
-        Command('https:/github.com/nvbn/thefuck.git', http_output),
-    ]
+    'cmd',
+    [Command(c, e) for c, e in product(invalid_urls, shell_errors)]
 )
 def test_not_match(cmd):
+    print(cmd)
     assert not match(cmd)
 
 
 @pytest.mark.parametrize(
-    'cmd', [
-        Command(https_url, https_output),
-        Command(http_url, http_output),
-        Command(ssh_url, ssh_output),
-    ]
+    'cmd',
+    [Command(c, e) for c, e in product(valid_urls, shell_errors)]
 )
 def test_get_new_command(cmd):
+    print(cmd)
     assert get_new_command(cmd) == 'git clone ' + cmd.script

--- a/tests/rules/test_git_clone_missing.py
+++ b/tests/rules/test_git_clone_missing.py
@@ -23,20 +23,16 @@ invalid_urls = [
 ]
 
 
-@pytest.mark.parametrize(
-    'cmd',
-    [Command(c, 'not found') for c in valid_urls]
-)
+@pytest.mark.parametrize('cmd', valid_urls)
 def test_match(cmd):
-    assert match(cmd)
+    c = Command(cmd, 'not found')
+    assert match(c)
 
 
-@pytest.mark.parametrize(
-    'cmd',
-    [Command(c, 'not found') for c in invalid_urls]
-)
+@pytest.mark.parametrize('cmd', invalid_urls)
 def test_not_match(cmd):
-    assert not match(cmd)
+    c = Command(cmd, 'not found')
+    assert not match(c)
 
 
 @pytest.mark.parametrize('script', valid_urls)

--- a/tests/rules/test_git_clone_missing.py
+++ b/tests/rules/test_git_clone_missing.py
@@ -1,37 +1,53 @@
-from thefuck.rules.git_clone_git_clone import match, get_new_command
+import pytest
+from thefuck.rules.git_clone_missing import match, get_new_command
 from thefuck.types import Command
 
-output_clean = """
-fatal: Too many arguments.
-
-usage: git clone [<options>] [--] <repo> [<dir>]
-"""
-
-http_url = 'https://github.com/nvbn/thefuck.git'
+https_url = 'https://github.com/nvbn/thefuck.git'
+http_url = 'http://github.com/nvbn/thefuck.git'
 ssh_url = 'git@github.com:nvbn/thefuck.git'
 
 # HELP WANTED: How can I make this independent of the shell?
+https_output = """
+bash: https://github.com/nvbn/thefuck.git: No such file or directory
+"""
 http_output = """
 bash: https://github.com/nvbn/thefuck.git: No such file or directory
 """
 ssh_output = """
-bash: hgit@github.com:nvbn/thefuck.git: No such file or directory
+bash: git@github.com:nvbn/thefuck.git: No such file or directory
 """
 
+@pytest.mark.parametrize(
+    'cmd', [
+        Command(https_url, https_output),
+        Command(http_url, http_output),
+        Command(ssh_url, ssh_output),
+    ]
+)
+def test_match(cmd):
+    assert match(cmd)
 
-def test_match():
-    assert match(Command(http_url, http_output))
-    assert match(Command(ssh_url, ssh_output))
+@pytest.mark.parametrize(
+    'cmd', [
+        Command('', ''),
+        Command('git branch', ''),
+        Command('git clone foo', ''),
+        Command('git clone foo bar baz', ''),
+        Command('git clone ' + http_url, http_output),
+        Command('git@example.com:thing.gut', ssh_output),
+        Command('https:/github.com/nvbn/thefuck.git', http_output),
+    ]
+)
+def test_not_match(cmd):
+    assert not match(cmd)
 
 
-def test_not_match():
-    assert not match(Command('', ''))
-    assert not match(Command('git branch', ''))
-    assert not match(Command('git clone foo', ''))
-    assert not match(Command('git clone foo bar baz', output_clean))
-    assert not match(Command('git clone ' + http_url, ''))
-
-
-def test_get_new_command():
-    assert get_new_command(Command(http_url, http_output)) == 'git clone ' + http_url
-    assert get_new_command(Command(ssh_url, ssh_output)) == 'git clone ' + ssh_url
+@pytest.mark.parametrize(
+    'cmd', [
+        Command(https_url, https_output),
+        Command(http_url, http_output),
+        Command(ssh_url, ssh_output),
+    ]
+)
+def test_get_new_command(cmd):
+    assert get_new_command(cmd) == 'git clone ' + cmd.script

--- a/tests/rules/test_git_clone_missing.py
+++ b/tests/rules/test_git_clone_missing.py
@@ -1,5 +1,4 @@
 import pytest
-from itertools import product
 from thefuck.rules.git_clone_missing import match, get_new_command
 from thefuck.types import Command
 

--- a/tests/rules/test_git_clone_missing.py
+++ b/tests/rules/test_git_clone_missing.py
@@ -21,22 +21,30 @@ invalid_urls = [
     'git clone git clone ssh://git@github.com:nvbn/thefrick.git',  # 2x clone
     'https:/github.com/nvbn/thefuck.git'  # Bad protocol
 ]
+outputs = [
+    'No such file or directory',
+    'not found',
+    'is not recognised as',
+]
 
 
 @pytest.mark.parametrize('cmd', valid_urls)
-def test_match(cmd):
-    c = Command(cmd, 'not found')
+@pytest.mark.parametrize('output', outputs)
+def test_match(cmd, output):
+    c = Command(cmd, output)
     assert match(c)
 
 
 @pytest.mark.parametrize('cmd', invalid_urls)
-def test_not_match(cmd):
-    c = Command(cmd, 'not found')
+@pytest.mark.parametrize('output', outputs)
+def test_not_match(cmd, output):
+    c = Command(cmd, output)
     assert not match(c)
 
 
 @pytest.mark.parametrize('script', valid_urls)
-def test_get_new_command(script):
-    command = Command(script, 'not found')
+@pytest.mark.parametrize('output', outputs)
+def test_get_new_command(script, output):
+    command = Command(script, output)
     new_command = 'git clone ' + script
     assert get_new_command(command) == new_command

--- a/tests/rules/test_git_clone_missing.py
+++ b/tests/rules/test_git_clone_missing.py
@@ -44,7 +44,7 @@ def test_match(cmd):
 
 @pytest.mark.parametrize(
     'cmd',
-    [Command(c, e) for c, e in product(invalid_urls, shell_errors)]
+    [Command(c, shell_errors[0]) for c in invalid_urls]
 )
 def test_not_match(cmd):
     print(cmd)
@@ -53,7 +53,7 @@ def test_not_match(cmd):
 
 @pytest.mark.parametrize(
     'cmd',
-    [Command(c, e) for c, e in product(valid_urls, shell_errors)]
+    [Command(c, shell_errors[0]) for c in valid_urls]
 )
 def test_get_new_command(cmd):
     print(cmd)

--- a/tests/rules/test_git_clone_missing.py
+++ b/tests/rules/test_git_clone_missing.py
@@ -38,7 +38,6 @@ shell_errors = [
     [Command(c, e) for c, e in product(valid_urls, shell_errors)]
 )
 def test_match(cmd):
-    print(cmd)
     assert match(cmd)
 
 
@@ -47,7 +46,6 @@ def test_match(cmd):
     [Command(c, shell_errors[0]) for c in invalid_urls]
 )
 def test_not_match(cmd):
-    print(cmd)
     assert not match(cmd)
 
 
@@ -56,5 +54,4 @@ def test_not_match(cmd):
     [Command(c, shell_errors[0]) for c in valid_urls]
 )
 def test_get_new_command(cmd):
-    print(cmd)
     assert get_new_command(cmd) == 'git clone ' + cmd.script

--- a/tests/rules/test_git_clone_missing.py
+++ b/tests/rules/test_git_clone_missing.py
@@ -8,13 +8,13 @@ ssh_url = 'git@github.com:nvbn/thefuck.git'
 
 # HELP WANTED: How can I make this independent of the shell?
 https_output = """
-bash: https://github.com/nvbn/thefuck.git: No such file or directory
+output=/bin/sh: 1: https://github.com/nvbn/thefuck.git: not found
 """
 http_output = """
-bash: https://github.com/nvbn/thefuck.git: No such file or directory
+output=/bin/sh: 1: http://github.com/nvbn/thefuck.git: not found
 """
 ssh_output = """
-bash: git@github.com:nvbn/thefuck.git: No such file or directory
+/bin/sh: 1: git@github.com:nvbn/thefuck.git: not found
 """
 
 @pytest.mark.parametrize(

--- a/tests/rules/test_git_clone_missing.py
+++ b/tests/rules/test_git_clone_missing.py
@@ -36,7 +36,7 @@ def test_match(cmd, output):
 
 
 @pytest.mark.parametrize('cmd', invalid_urls)
-@pytest.mark.parametrize('output', outputs)
+@pytest.mark.parametrize('output', outputs + ["some other output"])
 def test_not_match(cmd, output):
     c = Command(cmd, output)
     assert not match(c)

--- a/thefuck/rules/git_clone_missing.py
+++ b/thefuck/rules/git_clone_missing.py
@@ -15,14 +15,14 @@ from thefuck.utils import which
 
 
 def match(command):
+    # We want it to be a URL by itself
+    if len(command.script_parts) != 1:
+        return False
     # Ensure we got the error we expected
     if which(command.script_parts[0]) or not (
         'not found' in command.output
         or 'is not recognised as' in command.output
     ):
-        return False
-    # We want it to be a URL by itself
-    if len(command.script_parts) > 1:
         return False
     url = parse.urlparse(command.script, scheme='ssh')
     # HTTP URLs need a network address

--- a/thefuck/rules/git_clone_missing.py
+++ b/thefuck/rules/git_clone_missing.py
@@ -1,0 +1,22 @@
+from thefuck.specific.git import git_support
+
+# Note: could probably use better checking for URLs
+
+@git_support
+def match(command):
+    return command.script.endswith('.git') and (
+        (  # HTTP cloning
+            command.script.startswith('https://')
+            or command.script.startswith('http://')
+        )
+        or (  # SSH cloning: user@website.com:path/to/repo.git
+            command.script.find('@') < command.script.find(':')
+            and command.script.find('@') != -1
+            and command.script.find(':') != -1
+        )
+    )
+
+
+@git_support
+def get_new_command(command):
+    return 'git clone ' + command.script

--- a/thefuck/rules/git_clone_missing.py
+++ b/thefuck/rules/git_clone_missing.py
@@ -20,7 +20,8 @@ def match(command):
         return False
     # Ensure we got the error we expected
     if which(command.script_parts[0]) or not (
-        'not found' in command.output
+        'No such file or directory' in command.output
+        or 'not found' in command.output
         or 'is not recognised as' in command.output
     ):
         return False

--- a/thefuck/rules/git_clone_missing.py
+++ b/thefuck/rules/git_clone_missing.py
@@ -4,29 +4,20 @@ Rule: git_clone_missing
 Correct missing `git clone` command when pasting a git URL
 
 ```sh
-& https://github.com/nvbn/thefuck.git
+>>> https://github.com/nvbn/thefuck.git
 git clone https://github.com/nvbn/thefuck.git
+```
 
 Author: Miguel Guthridge
 '''
-from urllib import parse
-
-output_contains = [
-    'not found',
-    'no such file or directory',
-    'is not recognized as',
-]
+from six.moves.urllib import parse
 
 
 def match(command):
-    # Ignore capitalisation in output
-    output = command.output.lower()
     script = command.script
-    # Check for a command not found error
-    if not any([search in output for search in output_contains]):
-        return False
-    # URLs can't have spaces
-    if ' ' in command.script:
+    parts = command.script_parts
+    # We want it to be a URL by itself
+    if len(parts) > 1:
         return False
     url = parse.urlparse(script, scheme='ssh')
     # HTTP URLs need a network address

--- a/thefuck/rules/git_clone_missing.py
+++ b/thefuck/rules/git_clone_missing.py
@@ -1,15 +1,19 @@
 from thefuck.specific.git import git_support
 
+output_contains = 'No such file or directory'
 # Note: could probably use better checking for URLs
 
-@git_support
+
+# @git_support
 def match(command):
+    if not output_contains in command.output:
+        return False
     return command.script.endswith('.git') and (
         (  # HTTP cloning
             command.script.startswith('https://')
             or command.script.startswith('http://')
         )
-        or (  # SSH cloning: user@website.com:path/to/repo.git
+        or (  # SSH cloning: user[@]website.com[:]path/to/repo[.git]
             command.script.find('@') < command.script.find(':')
             and command.script.find('@') != -1
             and command.script.find(':') != -1
@@ -17,6 +21,6 @@ def match(command):
     )
 
 
-@git_support
+# @git_support
 def get_new_command(command):
     return 'git clone ' + command.script

--- a/thefuck/rules/git_clone_missing.py
+++ b/thefuck/rules/git_clone_missing.py
@@ -11,20 +11,28 @@ git clone https://github.com/nvbn/thefuck.git
 Author: Miguel Guthridge
 '''
 from six.moves.urllib import parse
+from thefuck.utils import which
 
 
 def match(command):
-    script = command.script
-    parts = command.script_parts
-    # We want it to be a URL by itself
-    if len(parts) > 1:
+    # Ensure we got the error we expected
+    if which(command.script_parts[0]) or not (
+        'not found' in command.output
+        or 'is not recognised as' in command.output
+    ):
         return False
-    url = parse.urlparse(script, scheme='ssh')
+    # We want it to be a URL by itself
+    if len(command.script_parts) > 1:
+        return False
+    url = parse.urlparse(command.script, scheme='ssh')
     # HTTP URLs need a network address
     if not url.netloc and url.scheme != 'ssh':
         return False
     # SSH needs a username and a splitter between the path
-    if url.scheme == 'ssh' and not ('@' in script and ':' in script):
+    if url.scheme == 'ssh' and not (
+        '@' in command.script
+        and ':' in command.script
+    ):
         return False
     return url.scheme in ['http', 'https', 'ssh']
 

--- a/thefuck/rules/git_clone_missing.py
+++ b/thefuck/rules/git_clone_missing.py
@@ -1,6 +1,6 @@
 from thefuck.specific.git import git_support
 
-output_contains = 'No such file or directory'
+output_contains = ': not found'
 # Note: could probably use better checking for URLs
 
 


### PR DESCRIPTION
Often when I'm trying to `git clone` a project, I'll paste the URL into my terminal expecting it to also contain the `git clone` part. This rule should allow `thefuck` to detect the missing `git clone` and suggest it when someone pastes an SSH or HTTP/HTTP url that ends in `.git`.

A rule for correcting for double `git clone git clone [repo]` already exists. This rule addresses the opposite problem.

![image](https://user-images.githubusercontent.com/31365175/169957706-14e2c30d-5f84-4fb1-b59a-9b04e05db6eb.png)

I've also added some simple tests for it, which appear to pass.

This is my first PR with any meaningful change, so I'd appreciate some feedback on it. It still needs a bit of cleaning up, but I think it should be good to merge in once I remove a couple of random things
