### PR TITLE
added support for Remote Cloud Development with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,140 @@
+## Learn more about this file at 'https://www.gitpod.io/docs/references/gitpod-yml'
+##
+## This '.gitpod.yml' file when placed at the root of a project instructs
+## Gitpod how to prepare & build the project, start development environments
+## and configure continuous prebuilds. Prebuilds when enabled builds a project
+## like a CI server so you can start coding right away - no more waiting for
+## dependencies to download and builds to finish when reviewing pull-requests
+## or hacking on something new.
+##
+## With Gitpod you can develop software from any device (even iPads) via 
+## desktop or browser based versions of VS Code or any JetBrains IDE and
+## customise it to your individual needs - from themes to extensions, you
+## have full control.
+##
+## The easiest way to try out Gitpod is install the browser extenion:
+## 'https://www.gitpod.io/docs/browser-extension' or by prefixing
+## 'https://gitpod.io#' to the source control URL of any project.
+##
+## For example: 'https://gitpod.io#https://github.com/gitpod-io/gitpod'
+
+
+## The 'image' section defines which Docker image Gitpod should use. 
+## By default, Gitpod uses a standard Docker Image called 'workspace-full'
+## which can be found at 'https://github.com/gitpod-io/workspace-images'
+##
+## Workspaces started based on this default image come pre-installed with
+## Docker, Go, Java, Node.js, C/C++, Python, Ruby, Rust, PHP as well as
+## tools such as Homebrew, Tailscale, Nginx and several more.
+##
+## If this image does not include the tools needed for your project then
+## a public Docker image or your own Docker file can be configured.
+## 
+## Learn more about images at 'https://www.gitpod.io/docs/config-docker'
+
+#image: node:buster                        # use 'https://hub.docker.com/_/node'
+#
+#image:                                    # leave image undefined if using a Dockerfile
+#  file: .gitpod.Dockerfile                # relative path to the Dockerfile from the
+#                                          # roof of the project
+
+## The 'tasks' section defines how Gitpod prepares and builds this project
+## or how Gitpod can start development servers. With Gitpod, there are three
+## types of tasks:
+##
+## - before: Use this for tasks that need to run before init and before command. 
+## - init: Use this to configure prebuilds of heavy-lifting tasks such as
+##         downloading dependencies or compiling source code.
+## - command: Use this to start your database or application when the workspace starts.
+##
+## Learn more about these tasks at 'https://www.gitpod.io/docs/config-start-tasks'
+
+#tasks:
+#  - before: |
+#      # commands to execute...
+#
+#  - init: |
+#      # sudo apt-get install python3     # can be used to install operating system  which
+#                                         # dependencies but these are after the prebuild
+#                                         # completes thus Gitpod recommends moving
+#                                         # operating system dependency installation steps
+#                                         # to a custom Dockerfile to make prebuilds faster
+#                                         # and to keep your codebase DRY.  
+#                                         # 'https://www.gitpod.io/docs/config-docker'
+#
+#      # pip install -r requirements.txt  # install codebase dependencies
+#      # cmake                            # precompile codebase
+#
+#  - name: Web Server
+#    openMode: split-left
+#    env:
+#      WEBSERVER_PORT: 8080
+#    command: |
+#     python3 -m http.server $WEBSERVER_PORT
+#
+#  - name: Web Browser
+#    openMode: split-right
+#    env:
+#      WEBSERVER_PORT: 8080
+#    command: |
+#     gp await-port $WEBSERVER_PORT
+#     lynx `gp url`
+
+tasks:
+  - init: pip3 install -r requirements.txt && python3 setup.py develop
+  - command: pip3 install -r requirements.txt && python3 setup.py develop
+
+## The 'ports' section defines various ports your may listen on are 
+## configured in Gitpod on an authenticated URL. By default, all ports
+## are in private visibility state.
+##
+## Learn more about ports at 'https://www.gitpod.io/docs/config-ports'
+
+#ports:
+#  - port: 8080 # alternatively configure entire ranges via '8080-8090'
+#    visibility: private # either 'public' or 'private' (default)
+#    onOpen: open-browser # either 'open-browser', 'open-preview' or 'ignore'
+
+
+## The 'vscode' section defines a list of Visual Studio Code extensions from
+## the OpenVSX.org registry to be installed upon workspace startup. OpenVSX
+## is an open alternative to the proprietary Visual Studio Code Marketplace
+## and extensions can be added by sending a pull-request with the extension
+## identifier to https://github.com/open-vsx/publish-extensions
+##
+## The identifier of an extension is always ${publisher}.${name}.
+##
+## For example: 'vscodevim.vim'
+##
+## Learn more at 'https://www.gitpod.io/docs/ides-and-editors/vscode'
+
+#vscode:
+#  extensions: 
+#    - vscodevim.vim
+#    - esbenp.prettier-vscode@9.5.0
+#    - https://example.com/abc/releases/extension-0.26.0.vsix
+
+
+## The 'github' section defines configuration of continuous prebuilds
+## for GitHub repositories when the GitHub application
+## 'https://github.com/apps/gitpod-io' is installed in GitHub and granted
+## permissions to access the repository.
+##
+## Learn more at 'https://www.gitpod.io/docs/prebuilds'
+
+github: 
+  prebuilds:
+    # enable for the default branch
+    master: true
+    # enable for all branches in this repo
+    branches: true
+    # enable for pull requests coming from this repo
+    pullRequests: true
+    # enable for pull requests coming from forks
+    pullRequestsFromForks: true
+    # add a check to pull requests
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description
+    addBadge: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Fuck [![Version][version-badge]][version-link] [![Build Status][workflow-badge]][workflow-link] [![Coverage][coverage-badge]][coverage-link] [![MIT License][license-badge]](LICENSE.md)
+# The Fuck [![Version][version-badge]][version-link] [![Build Status][workflow-badge]][workflow-link] [![Coverage][coverage-badge]][coverage-link] [![MIT License][license-badge]](LICENSE.md) [![MIT License][license-badge]](LICENSE.md) [![Contribute with Gitpod](https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/nvbn/thefuck)
 
 *The Fuck* is a magnificent app, inspired by a [@liamosaur](https://twitter.com/liamosaur/)
 [tweet](https://twitter.com/liamosaur/status/506975850596536320),


### PR DESCRIPTION
:wave: Hey Folks,

Siddhant here from [Gitpod](https://www.gitpod.io). This PR enables development of [`nvbn/thefuck`](https://github.com/nvbn/thefuck) on any device on Gitpod and enables community members to contribute more easily by adding a single YAML file to your repository which essentially removes the need to even have your developer setup guide :rocket: just mash the button below:

<a href="https://gitpod.io/#https://github.com/nvbn/thefuck">
  <img src="https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod" alt="Contribute with Gitpod" />
</a>

---