### PR TITLE
Make sure to use builtin alias

### DIFF
--- a/thefuck/shells/zsh.py
+++ b/thefuck/shells/zsh.py
@@ -19,7 +19,7 @@ class Zsh(Generic):
                 TF_PYTHONIOENCODING=$PYTHONIOENCODING;
                 export TF_SHELL=zsh;
                 export TF_ALIAS={name};
-                TF_SHELL_ALIASES=$(alias);
+                TF_SHELL_ALIASES=$(builtin alias);
                 export TF_SHELL_ALIASES;
                 TF_HISTORY="$(fc -ln -10)";
                 export TF_HISTORY;


### PR DESCRIPTION
If user aliases the alias command or has a file called alias in the path it will use that instead. We should make sure to use the builtin alias.