### PR TITLE
Closing bug in brew update formula rule (changed error message)

### DIFF
--- a/tests/rules/test_brew_update_formula.py
+++ b/tests/rules/test_brew_update_formula.py
@@ -4,7 +4,7 @@ from thefuck.rules.brew_update_formula import get_new_command, match
 
 
 output = ("Error: This command updates brew itself, and does not take formula"
-          r" names.\nUse `brew upgrade thefuck`.")
+          " names.\nUse `brew upgrade thefuck`.")
 
 
 def test_match():

--- a/tests/rules/test_brew_update_formula.py
+++ b/tests/rules/test_brew_update_formula.py
@@ -4,7 +4,7 @@ from thefuck.rules.brew_update_formula import get_new_command, match
 
 
 output = ("Error: This command updates brew itself, and does not take formula"
-          " names.\nUse 'brew upgrade thefuck'.")
+          r" names.\nUse `brew upgrade thefuck`.")
 
 
 def test_match():

--- a/thefuck/rules/brew_update_formula.py
+++ b/thefuck/rules/brew_update_formula.py
@@ -1,11 +1,14 @@
+import re
 from thefuck.utils import for_app
+
+message_regex = re.compile(r"Use ['\`]brew upgrade")
 
 
 @for_app('brew', at_least=2)
 def match(command):
     return ('update' in command.script
             and "Error: This command updates brew itself" in command.output
-            and "Use 'brew upgrade" in command.output)
+            and message_regex.search(command.output))
 
 
 def get_new_command(command):

--- a/thefuck/rules/brew_update_formula.py
+++ b/thefuck/rules/brew_update_formula.py
@@ -5,7 +5,7 @@ from thefuck.utils import for_app
 def match(command):
     return ('update' in command.script
             and "Error: This command updates brew itself" in command.output
-            and r"Use `brew upgrade" in command.output)
+            and "Use `brew upgrade" in command.output)
 
 
 def get_new_command(command):

--- a/thefuck/rules/brew_update_formula.py
+++ b/thefuck/rules/brew_update_formula.py
@@ -1,14 +1,11 @@
-import re
 from thefuck.utils import for_app
-
-message_regex = re.compile(r"Use ['\`]brew upgrade")
 
 
 @for_app('brew', at_least=2)
 def match(command):
     return ('update' in command.script
             and "Error: This command updates brew itself" in command.output
-            and message_regex.search(command.output))
+            and r"Use `brew upgrade" in command.output)
 
 
 def get_new_command(command):


### PR DESCRIPTION
Brew changed the output of the error message so that the rule no longer works. They have changed the apostrophe to a backtick

```
from 

Use 'brew upgrade foo' instead.

changed to 

Use `brew upgrade foo` instead.
```

Change in brew: https://github.com/Homebrew/brew/commit/2f7c3afeb8b6cb76b35860ac195e3b35d18132f6#diff-c234c527e0e187e0743c519ab0e415afdc1e41e33e014cd78152930b11885057

The regex in the code change will handle both scenarios.

This PR fixes or closes #1290 support brew update `<package name>`


