### PR TITLE
fix: Update output for brew_install and cleanup feat: multi suggestions for formulas

### DIFF
--- a/tests/rules/test_brew_install.py
+++ b/tests/rules/test_brew_install.py
@@ -1,5 +1,5 @@
 import pytest
-from thefuck.rules.brew_install import match, get_new_command, get_suggestions
+from thefuck.rules.brew_install import match, get_new_command, _get_suggestions
 from thefuck.types import Command
 
 
@@ -29,9 +29,9 @@ def brew_already_installed():
 
 
 def test_suggestions():
-    assert get_suggestions("one") == ['one']
-    assert get_suggestions("one or two") == ['one', 'two']
-    assert get_suggestions("one, two or three") == ['one', 'two', 'three']
+    assert _get_suggestions("one") == ['one']
+    assert _get_suggestions("one or two") == ['one', 'two']
+    assert _get_suggestions("one, two or three") == ['one', 'two', 'three']
 
 
 def test_match(brew_no_available_formula_one, brew_no_available_formula_two,

--- a/tests/rules/test_brew_install.py
+++ b/tests/rules/test_brew_install.py
@@ -1,10 +1,20 @@
 import pytest
-from thefuck.rules.brew_install import match, get_new_command
+from thefuck.rules.brew_install import match, get_new_command, get_suggestions
 from thefuck.types import Command
 
 
 @pytest.fixture
-def brew_no_available_formula():
+def brew_no_available_formula_one():
+    return '''Warning: No available formula with the name "giss". Did you mean gist?'''
+
+
+@pytest.fixture
+def brew_no_available_formula_two():
+    return '''Warning: No available formula with the name "elasticserar". Did you mean elasticsearch or elasticsearch@6?'''
+
+
+@pytest.fixture
+def brew_no_available_formula_three():
     return '''Warning: No available formula with the name "gitt". Did you mean git, gitg or gist?'''
 
 
@@ -18,20 +28,38 @@ def brew_already_installed():
     return '''Warning: git-2.3.5 already installed'''
 
 
-def test_match(brew_no_available_formula, brew_already_installed,
+def test_suggestions():
+    assert get_suggestions("one") == ['one']
+    assert get_suggestions("one or two") == ['one', 'two']
+    assert get_suggestions("one, two or three") == ['one', 'two', 'three']
+
+
+def test_match(brew_no_available_formula_one, brew_no_available_formula_two,
+               brew_no_available_formula_three, brew_already_installed,
                brew_install_no_argument):
+    assert match(Command('brew install giss',
+                         brew_no_available_formula_one))
+    assert match(Command('brew install elasticserar',
+                         brew_no_available_formula_two))
     assert match(Command('brew install gitt',
-                         brew_no_available_formula))
+                         brew_no_available_formula_three))
     assert not match(Command('brew install git',
                              brew_already_installed))
     assert not match(Command('brew install', brew_install_no_argument))
 
 
-def test_get_new_command(brew_no_available_formula):
+def test_get_new_command(brew_no_available_formula_one, brew_no_available_formula_two,
+                         brew_no_available_formula_three):
+    assert get_new_command(Command('brew install giss',
+                                   brew_no_available_formula_one))\
+        == ['brew install gist']
+    assert get_new_command(Command('brew install elasticsear',
+                                   brew_no_available_formula_two))\
+        == ['brew install elasticsearch', 'brew install elasticsearch@6']
     assert get_new_command(Command('brew install gitt',
-                                   brew_no_available_formula))\
-        == 'brew install git'
+                                   brew_no_available_formula_three))\
+        == ['brew install git', 'brew install gitg', 'brew install gist']
 
     assert get_new_command(Command('brew install aa',
-                                   brew_no_available_formula))\
+                                   brew_no_available_formula_one))\
         != 'brew install aha'

--- a/tests/rules/test_brew_install.py
+++ b/tests/rules/test_brew_install.py
@@ -1,17 +1,16 @@
 import pytest
 from thefuck.rules.brew_install import match, get_new_command
-from thefuck.rules.brew_install import _get_formulas
 from thefuck.types import Command
 
 
 @pytest.fixture
 def brew_no_available_formula():
-    return '''Error: No available formula for elsticsearch '''
+    return '''Warning: No available formula with the name "gitt". Did you mean git, gitg or gist?'''
 
 
 @pytest.fixture
 def brew_install_no_argument():
-    return '''This command requires a formula argument'''
+    return '''Install a formula or cask. Additional options specific to a formula may be'''
 
 
 @pytest.fixture
@@ -19,27 +18,21 @@ def brew_already_installed():
     return '''Warning: git-2.3.5 already installed'''
 
 
-def _is_not_okay_to_test():
-    return 'elasticsearch' not in _get_formulas()
 
 
-@pytest.mark.skipif(_is_not_okay_to_test(),
-                    reason='No need to run if there\'s no formula')
 def test_match(brew_no_available_formula, brew_already_installed,
                brew_install_no_argument):
-    assert match(Command('brew install elsticsearch',
+    assert match(Command('brew install gitt',
                          brew_no_available_formula))
     assert not match(Command('brew install git',
                              brew_already_installed))
     assert not match(Command('brew install', brew_install_no_argument))
 
 
-@pytest.mark.skipif(_is_not_okay_to_test(),
-                    reason='No need to run if there\'s no formula')
 def test_get_new_command(brew_no_available_formula):
-    assert get_new_command(Command('brew install elsticsearch',
+    assert get_new_command(Command('brew install gitt',
                                    brew_no_available_formula))\
-        == 'brew install elasticsearch'
+        == 'brew install git'
 
     assert get_new_command(Command('brew install aa',
                                    brew_no_available_formula))\

--- a/tests/rules/test_brew_install.py
+++ b/tests/rules/test_brew_install.py
@@ -18,8 +18,6 @@ def brew_already_installed():
     return '''Warning: git-2.3.5 already installed'''
 
 
-
-
 def test_match(brew_no_available_formula, brew_already_installed,
                brew_install_no_argument):
     assert match(Command('brew install gitt',

--- a/thefuck/rules/brew_install.py
+++ b/thefuck/rules/brew_install.py
@@ -1,8 +1,13 @@
 import re
-from thefuck.utils import for_app, replace_argument
+from thefuck.utils import for_app
 from thefuck.specific.brew import brew_available
 
 enabled_by_default = brew_available
+
+
+def get_suggestions(str):
+    suggestions = str.replace(" or ", ", ").split(", ")
+    return suggestions
 
 
 @for_app('brew', at_least=2)
@@ -14,7 +19,6 @@ def match(command):
 
 
 def get_new_command(command):
-    matcher = re.search('Warning: No available formula with the name "([^"]+)". Did you mean ([^, ?]+)', command.output)
-    not_exist_formula = matcher.group(1)
-    exist_formula = matcher.group(2)
-    return replace_argument(command.script, not_exist_formula, exist_formula)
+    matcher = re.search('Warning: No available formula with the name "(?:[^"]+)". Did you mean (.+)\\?', command.output)
+    suggestions = get_suggestions(matcher.group(1))
+    return ["brew install " + formula for formula in suggestions]

--- a/thefuck/rules/brew_install.py
+++ b/thefuck/rules/brew_install.py
@@ -5,7 +5,7 @@ from thefuck.specific.brew import brew_available
 enabled_by_default = brew_available
 
 
-def get_suggestions(str):
+def _get_suggestions(str):
     suggestions = str.replace(" or ", ", ").split(", ")
     return suggestions
 
@@ -20,5 +20,5 @@ def match(command):
 
 def get_new_command(command):
     matcher = re.search('Warning: No available formula with the name "(?:[^"]+)". Did you mean (.+)\\?', command.output)
-    suggestions = get_suggestions(matcher.group(1))
+    suggestions = _get_suggestions(matcher.group(1))
     return ["brew install " + formula for formula in suggestions]

--- a/thefuck/rules/brew_install.py
+++ b/thefuck/rules/brew_install.py
@@ -14,8 +14,7 @@ def match(command):
 
 
 def get_new_command(command):
-    matcher = re.search('Warning: No available formula with the name "([^"]+)". Did you mean ([^, ?]+)',
-                         command.output)
+    matcher = re.search('Warning: No available formula with the name "([^"]+)". Did you mean ([^, ?]+)', command.output)
     not_exist_formula = matcher.group(1)
     exist_formula = matcher.group(2)
     return replace_argument(command.script, not_exist_formula, exist_formula)

--- a/thefuck/rules/brew_install.py
+++ b/thefuck/rules/brew_install.py
@@ -1,42 +1,21 @@
-import os
 import re
-from thefuck.utils import get_closest, replace_argument
-from thefuck.specific.brew import get_brew_path_prefix, brew_available
+from thefuck.utils import for_app, replace_argument
+from thefuck.specific.brew import brew_available
 
 enabled_by_default = brew_available
 
 
-def _get_formulas():
-    # Formulas are based on each local system's status
-    try:
-        brew_path_prefix = get_brew_path_prefix()
-        brew_formula_path = brew_path_prefix + '/Library/Formula'
-
-        for file_name in os.listdir(brew_formula_path):
-            if file_name.endswith('.rb'):
-                yield file_name[:-3]
-    except Exception:
-        pass
-
-
-def _get_similar_formula(formula_name):
-    return get_closest(formula_name, _get_formulas(), cutoff=0.85)
-
-
+@for_app('brew', at_least=2)
 def match(command):
-    is_proper_command = ('brew install' in command.script and
-                         'No available formula' in command.output)
-
-    if is_proper_command:
-        formula = re.findall(r'Error: No available formula for ([a-z]+)',
-                             command.output)[0]
-        return bool(_get_similar_formula(formula))
-    return False
+    is_proper_command = ('install' in command.script and
+                         'No available formula' in command.output and
+                         'Did you mean' in command.output)
+    return is_proper_command
 
 
 def get_new_command(command):
-    not_exist_formula = re.findall(r'Error: No available formula for ([a-z]+)',
-                                   command.output)[0]
-    exist_formula = _get_similar_formula(not_exist_formula)
-
+    matcher = re.search('Warning: No available formula with the name "([^"]+)". Did you mean ([^, ?]+)',
+                         command.output)
+    not_exist_formula = matcher.group(1)
+    exist_formula = matcher.group(2)
     return replace_argument(command.script, not_exist_formula, exist_formula)


### PR DESCRIPTION
The output of `brew install`, if no suitable formula was found, has changed. Before it was an error, now it is a warning with suggestions which formula could be meant. 

The function to find the most similar formula doesn't work anymore (`_get_formulas()`), because the path in brew and the logic has changed. But this is not necessary anymore, because brew provides the matching match.

Example output:
```
$ brew install gitt
Warning: No available formula with the name "gitt". Did you mean git, gitg or gist?
==> Searching for similarly named formulae...
These similarly named formulae were found:
git-test            git-town            gitter-cli          git
git-tf              git-tracker         moz-git-tools       gitg
git-tig             git-trim            sagittarius-scheme  gist
To install one of them, run (for example):
  brew install git-test
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.
==> Searching taps on GitHub...
Error: No formulae found in taps.
```

The formulas can contain special characters. That is why the regex has been extended.

Rule brew_install and test test_brew_install are adjusted and cleaned up.

closes #1299