### PR TITLE
Reduce cyclomatic complexity

### DIFF
--- a/thefuck/rules/git_clone_missing.py
+++ b/thefuck/rules/git_clone_missing.py
@@ -14,16 +14,22 @@ from six.moves.urllib import parse
 from thefuck.utils import which
 
 
-def match(command):
-    # We want it to be a URL by itself
-    if len(command.script_parts) != 1:
-        return False
-    # Ensure we got the error we expected
+def is_expected_error(command):
     if which(command.script_parts[0]) or not (
         'No such file or directory' in command.output
         or 'not found' in command.output
         or 'is not recognised as' in command.output
     ):
+        return False
+    return True
+
+
+def match(command):
+    # We want it to be a URL by itself
+    if len(command.script_parts) != 1:
+        return False
+    # Ensure we got the error we expected
+    if not is_expected_error(command):
         return False
     url = parse.urlparse(command.script, scheme='ssh')
     # HTTP URLs need a network address


### PR DESCRIPTION
As part of my training assignment I found a complex function using the [radon utility](https://radon.readthedocs.io/en/latest/)
(It is about cyclomatic complexity)
```
bash-3.2$ radon cc thefuck -s -n C
thefuck/rules/git_clone_missing.py
    F 17:0 match - C (11)
```

After moving ```is_expected_error``` out, it gets better:
```
bash-3.2$  radon cc thefuck/rules/git_clone_missing.py -s
thefuck/rules/git_clone_missing.py
    F 27:0 match - B (8)
    F 17:0 is_expected_error - A (5)
    F 47:0 get_new_command - A (1)
```