### PR TITLE
Use unittest's buildin mock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 flake8
 pytest
-mock
 pytest-mock
 wheel
 setuptools>=17.1

--- a/tests/entrypoints/test_alias.py
+++ b/tests/entrypoints/test_alias.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 import pytest
 from thefuck.entrypoints.alias import _get_alias, print_alias
 

--- a/tests/entrypoints/test_fix_command.py
+++ b/tests/entrypoints/test_fix_command.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 from thefuck.entrypoints.fix_command import _get_raw_command
 
 

--- a/tests/entrypoints/test_not_configured.py
+++ b/tests/entrypoints/test_not_configured.py
@@ -1,7 +1,7 @@
 import pytest
 import json
 from six import StringIO
-from mock import MagicMock
+from unittest.mock import MagicMock
 from thefuck.shells.generic import ShellConfiguration
 from thefuck.entrypoints.not_configured import main
 

--- a/tests/output_readers/test_rerun.py
+++ b/tests/output_readers/test_rerun.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from psutil import AccessDenied, TimeoutExpired
 
 from thefuck.output_readers import rerun

--- a/tests/rules/test_has_exists_script.py
+++ b/tests/rules/test_has_exists_script.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 from thefuck.rules.has_exists_script import match, get_new_command
 from thefuck.types import Command
 

--- a/tests/rules/test_pacman.py
+++ b/tests/rules/test_pacman.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import patch
+from unittest.mock import patch
 from thefuck.rules import pacman
 from thefuck.rules.pacman import match, get_new_command
 from thefuck.types import Command

--- a/tests/rules/test_pacman_not_found.py
+++ b/tests/rules/test_pacman_not_found.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import patch
+from unittest.mock import patch
 from thefuck.rules import pacman_not_found
 from thefuck.rules.pacman_not_found import match, get_new_command
 from thefuck.types import Command

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,7 +1,7 @@
 import pytest
 import six
 import os
-from mock import Mock
+from unittest.mock import Mock
 from thefuck import const
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2,7 +2,7 @@
 
 import os
 from subprocess import PIPE, STDOUT
-from mock import Mock
+from unittest.mock import Mock
 import pytest
 from tests.utils import CorrectedCommand, Rule
 from thefuck import const

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 
 import pytest
 import warnings
-from mock import Mock, call, patch
+from unittest.mock import Mock, call, patch
 from thefuck.utils import default_settings, \
     memoize, get_closest, get_all_executables, replace_argument, \
     get_all_matched_commands, is_app, for_app, cache, \


### PR DESCRIPTION
Since Python 3.3 unittest has a mock module buildin, so a seperate mock module is no longer required.