### PR TITLE
fix: add tests folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .Python
 env/
 build/
+tests/
 develop-eggs/
 dist/
 downloads/


### PR DESCRIPTION
i've seen that there's a tests folder which has been added to the project and i guess it was by mistake