### PR TITLE
Add terraform_init_upgrade

### DIFF
--- a/thefuck/rules/terraform_init_upgrade.py
+++ b/thefuck/rules/terraform_init_upgrade.py
@@ -1,0 +1,10 @@
+from thefuck.shells import shell
+from thefuck.utils import for_app
+
+
+@for_app('terraform')
+def match(command):
+    return 'Inconsistent dependency lock file' in command.output
+           
+def get_new_command(command):
+    return shell.and_('terraform init -upgrade', command.script)


### PR DESCRIPTION
When working on different branches, terraform provider versions may differ.
Often you forget to run terraform init -upgrade before your regular terraform commands.
This rule lets you fix that.

Example:

```console
$ tf plan
╷
│ Error: Inconsistent dependency lock file
│ 
│ The following dependency selections recorded in the lock file are inconsistent with the current configuration:
│   - provider registry.terraform.io/hashicorp/google: locked version selection 4.42.1 doesn't match the updated version constraints "4.42.0"
│ 
│ To update the locked dependency selections to match a changed configuration, run:
│   terraform init -upgrade
╵
$ fuck
terraform init -upgrade && terraform plan [enter/↑/↓/ctrl+c]

Initializing the backend...

Initializing provider plugins...
- Finding hashicorp/google versions matching "4.42.0"...
- Installing hashicorp/google v4.42.0...
- Installed hashicorp/google v4.42.0 (signed by HashiCorp)

Terraform has made some changes to the provider dependency selections recorded
in the .terraform.lock.hcl file. Review those changes and commit them to your
version control system if they represent changes you intended to make.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
google_project_iam_member.[REDACTED]: Refreshing state... [REDACTED]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```