### PR TITLE
Add appimage build

### DIFF
--- a/appimage/entrypoint.sh
+++ b/appimage/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+{{ python-executable }} "${APPDIR}/opt/python{{ python-version }}/bin/thefuck" "$@"
+

--- a/appimage/thefuck-appimage-build.sh
+++ b/appimage/thefuck-appimage-build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+set -e
+
+BUILD_DIR="$(git rev-parse --show-toplevel)/build"
+
+mkdir -p "$BUILD_DIR"
+docker build .. -f ./thefuck-appimage.Dockerfile -t tmp/thefuck-appimage --no-cache --force-rm
+docker run --rm -v "$BUILD_DIR":/result tmp/thefuck-appimage
+echo "Done. Appimage saved in $BUILD_DIR directory: $(ls -sh1 "$BUILD_DIR")"
+

--- a/appimage/thefuck-appimage.Dockerfile
+++ b/appimage/thefuck-appimage.Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.8-slim-buster
+VOLUME /result
+
+RUN apt update && \
+    apt install -y git file gpg && \
+    pip install git+https://github.com/niess/python-appimage pip-tools pipreqs && \
+    mkdir -p /result
+
+ADD . /thefuck
+WORKDIR /thefuck/thefuck
+RUN pipreqs --savepath=requirements.in &&\
+        pip-compile && \
+        rm ./requirements.in && \
+        sed -i -e '1 i\\/thefuck' requirements.txt && \
+        mv ./requirements.txt /thefuck/appimage
+
+WORKDIR /thefuck
+RUN python -m python_appimage build app -p 3.8 /thefuck/appimage
+
+CMD cp /thefuck/thefuck-x86_64.AppImage /result

--- a/appimage/thefuck.appdata.xml
+++ b/appimage/thefuck.appdata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+    <id>thefuck</id>
+    <metadata_license>MIT</metadata_license>
+    <project_license>MIT</project_license>
+    <name>thefuck</name>
+    <summary>thefuck app running python {{ python-fullversion }}</summary>
+    <description>
+        <p>Magnificent app which corrects your previous console command.</p>
+    </description>
+    <launchable type="desktop-id">thefuck.desktop</launchable>
+    <url type="homepage">https://github.com/nvbn/thefuck</url>
+    <provides>
+        <binary>python{{ python-version }}</binary>
+    </provides>
+</component>
+

--- a/appimage/thefuck.desktop
+++ b/appimage/thefuck.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=thefuck
+Exec=thefuck
+Comment=Magnificent app which corrects your previous console command.
+Icon=python
+Categories=System;Utility;
+Terminal=true


### PR DESCRIPTION
This PR adds support for building appimages that can be added to release assets as mentioned in #1349.

The build process uses a shell script `thefuck/appimage/thefuck-appimage-build.sh` and a dockerfile to build and run a container that packages the app into an appimage that will reside in `thefuck/build`.

Closes #1349