### PR TITLE
Support long flag --delete

### DIFF
--- a/thefuck/rules/git_branch_delete.py
+++ b/thefuck/rules/git_branch_delete.py
@@ -4,10 +4,10 @@ from thefuck.specific.git import git_support
 
 @git_support
 def match(command):
-    return ('branch -d' in command.script
+    return (('branch -d' in command.script or 'branch --delete' in command.script)
             and 'If you are sure you want to delete it' in command.output)
 
 
 @git_support
 def get_new_command(command):
-    return replace_argument(command.script, '-d', '-D')
+    return replace_argument(replace_argument(command.script, '-d', '-D'), '--delete', '-D')


### PR DESCRIPTION
The VSCode Git integration uses the long `--delete` flag instead of `-d`. This PR adds support for that.