### PR TITLE
minor improvement to test_brew_unknown_command

### DIFF
--- a/tests/rules/test_brew_unknown_command.py
+++ b/tests/rules/test_brew_unknown_command.py
@@ -14,8 +14,9 @@ def brew_unknown_cmd2():
     return '''Error: Unknown command: instaa'''
 
 
-def test_match(brew_unknown_cmd):
+def test_match(brew_unknown_cmd, brew_unknown_cmd2):
     assert match(Command('brew inst', brew_unknown_cmd))
+    assert match(Command('brew instaa', brew_unknown_cmd2))
     for command in _brew_commands():
         assert not match(Command('brew ' + command, ''))
 


### PR DESCRIPTION
Minor improvement to test `test_match` in test_brew_unknown_command.py.
Specifically, this PR is testing the input already there provided by the fixture `brew_unknown_cmd2`.