### PR TITLE
update npm missing script matchers

### DIFF
--- a/thefuck/rules/npm_missing_script.py
+++ b/thefuck/rules/npm_missing_script.py
@@ -8,10 +8,10 @@ enabled_by_default = npm_available
 @for_app('npm')
 def match(command):
     return (any(part.startswith('ru') for part in command.script_parts)
-            and 'npm ERR! missing script: ' in command.output)
+            and 'npm ERR! Missing script: ' in command.output)
 
 
 def get_new_command(command):
     misspelled_script = re.findall(
-        r'.*missing script: (.*)\n', command.output)[0]
+        r'.*Missing script: "(.*)"\n', command.output)[0]
     return replace_command(command, misspelled_script, get_scripts())


### PR DESCRIPTION
Npm error logs has changed:

![Screenshot 2023-03-28 at 9 33 35 AM](https://user-images.githubusercontent.com/686933/228308036-d37cfa6c-a6bd-4aec-840a-f14ca1507180.jpg)

Without this change, `fuck` will give either an irrelevant script or `no fucks given` message. 

With this change, an appropriate suggestion will be given:
![Screenshot 2023-03-28 at 9 34 57 AM](https://user-images.githubusercontent.com/686933/228308208-5fdb7c01-73d6-4906-bcd3-9d875b1c2709.jpg)


