### PR TITLE
Added basic support for Atuin

### DIFF
--- a/thefuck/const.py
+++ b/thefuck/const.py
@@ -44,7 +44,8 @@ DEFAULT_SETTINGS = {'rules': DEFAULT_RULES,
                     'instant_mode': False,
                     'num_close_matches': 3,
                     'env': {'LC_ALL': 'C', 'LANG': 'C', 'GIT_TRACE': '1'},
-                    'excluded_search_path_prefixes': []}
+                    'excluded_search_path_prefixes': [],
+                    'atuin_path': ''}
 
 ENV_TO_ATTR = {'THEFUCK_RULES': 'rules',
                'THEFUCK_EXCLUDE_RULES': 'exclude_rules',

--- a/thefuck/shells/generic.py
+++ b/thefuck/shells/generic.py
@@ -55,20 +55,37 @@ class Generic(object):
 
     def _get_history_lines(self):
         """Returns list of history entries."""
-        history_file_name = self._get_history_file_name()
-        if os.path.isfile(history_file_name):
-            with io.open(history_file_name, 'r',
-                         encoding='utf-8', errors='ignore') as history_file:
+        lines = []
+        if settings.atuin_path != '':
+            import sqlite3
 
-                lines = history_file.readlines()
-                if settings.history_limit:
-                    lines = lines[-settings.history_limit:]
+            # Connect to the database
+            conn = sqlite3.connect(settings.atuin_path)
+            cur = conn.cursor()
 
-                for line in lines:
-                    prepared = self._script_from_history(line) \
-                        .strip()
-                    if prepared:
-                        yield prepared
+            # Get the commands
+            cur.execute("SELECT command FROM history")
+            rows = cur.fetchall()
+            lines = [row[0] for row in rows]
+            if settings.history_limit:
+                lines = lines[-settings.history_limit:]
+            conn.close()
+        else:
+            history_file_name = self._get_history_file_name()
+            if os.path.isfile(history_file_name):
+                with io.open(history_file_name, 'r',
+                             encoding='utf-8',
+                             errors='ignore') as history_file:
+
+                    lines = history_file.readlines()
+                    if settings.history_limit:
+                        lines = lines[-settings.history_limit:]
+
+        for line in lines:
+            prepared = self._script_from_history(line) \
+                .strip()
+            if prepared:
+                yield prepared
 
     def and_(self, *commands):
         return u' && '.join(commands)


### PR DESCRIPTION
Atuin is shell history on steriods and is commonly used as an enhancement of the existing shell history. Unlike Bash or Zsh, Atuin uses an SQLite database to store the command history.

The nice thing about this however is that this makes Atuin shell agnostic, so all we've done is add a basic check in the generic shell class to check to see if the user provided a path to the Atuin database. If so, then we check the database instead of the default location.

Right now this system has an issue where it'll reconnect to the database multiple times, which may cause performance issues. The point however is that this works, and that we can search the Atuin database.