### PR TITLE
Add `cd_quotes` rule

### DIFF
--- a/thefuck/rules/cd_quotes.py
+++ b/thefuck/rules/cd_quotes.py
@@ -1,0 +1,10 @@
+def match(command):
+    return command.script_parts[0] == "cd" and command.script.count(" ") > 1 and (not("\"" in command.script))
+
+
+def get_new_command(command):
+    return 'cd \"{}\"'.format(' '.join(command.script_parts[1:]))
+
+enabled_by_default = True
+priority = 900  
+requires_output = False


### PR DESCRIPTION
```
> cd Some folder
cd: string not in pwd: Some
> fuck
cd "Some folder" [enter/↑/↓/ctrl+c]
```

This rule fixes forgotten quotes around directory containing spaces names when using `cd`.

The rule has priority 900 to override the `cd_mkdir` rule. 