### PR TITLE
feat: new rule for `nix-shell`

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ The following rules are enabled by default on specific platforms only:
 * `brew_update_formula` &ndash; turns `brew update <formula>` into `brew upgrade <formula>`;
 * `dnf_no_such_command` &ndash; fixes mistyped DNF commands;
 * `nixos_cmd_not_found` &ndash; installs apps on NixOS;
+* `nix_shell` &ndash; re-runs your command in a `nix-shell`;
 * `pacman` &ndash; installs app with `pacman` if it is not installed (uses `yay`, `pikaur` or `yaourt` if available);
 * `pacman_invalid_option` &ndash; replaces lowercase `pacman` options with uppercase.
 * `pacman_not_found` &ndash; fixes package name with `pacman`, `yay`, `pikaur` or `yaourt`.

--- a/tests/rules/test_nix_shell.py
+++ b/tests/rules/test_nix_shell.py
@@ -1,6 +1,5 @@
 import pytest
 from thefuck.rules.nix_shell import get_nixpkgs_name, get_new_command
-from thefuck.rules import nix_shell
 from thefuck.types import Command
 from unittest.mock import patch
 
@@ -15,9 +14,8 @@ mocked_nixpkgs = {
     "command, output", [("lsof", "lsof"), ("xev", "xorg.xev"), ("foo", "")]
 )
 def test_get_nixpkgs_name(command, output):
-    """ Check that `get_nixpkgs_name` returns the correct name """
+    """Check that `get_nixpkgs_name` returns the correct name"""
 
-    nix_shell.nixpkgs_name = ""
     with patch("subprocess.run") as mocked_run:
         instance = mocked_run.return_value
         instance.stderr = mocked_nixpkgs[command]
@@ -25,15 +23,18 @@ def test_get_nixpkgs_name(command, output):
 
 
 # check that flags and params are preserved for the new command
-@pytest.mark.parametrize('command_script, new_command', [
-    ('lsof -i :3000', 'nix-shell -p lsof --run "lsof -i :3000"'),
-    ('xev', 'nix-shell -p xorg.xev --run "xev"')])
+@pytest.mark.parametrize(
+    "command_script, new_command",
+    [
+        ("lsof -i :3000", 'nix-shell -p lsof --run "lsof -i :3000"'),
+        ("xev", 'nix-shell -p xorg.xev --run "xev"'),
+    ],
+)
 def test_get_new_command(command_script, new_command):
-    """ Check that flags and params are preserved in the new command """
+    """Check that flags and params are preserved in the new command"""
 
-    nix_shell.nixpkgs_name = ""
-    command = Command(command_script, '')
-    with patch('subprocess.run') as mocked_run:
+    command = Command(command_script, "")
+    with patch("subprocess.run") as mocked_run:
         instance = mocked_run.return_value
         instance.stderr = mocked_nixpkgs[command.script_parts[0]]
         assert get_new_command(command) == new_command

--- a/tests/rules/test_nix_shell.py
+++ b/tests/rules/test_nix_shell.py
@@ -1,0 +1,39 @@
+import pytest
+from thefuck.rules.nix_shell import get_nixpkgs_name, get_new_command
+from thefuck.rules import nix_shell
+from thefuck.types import Command
+from unittest.mock import patch
+
+mocked_nixpkgs = {
+    "lsof": "The program 'lsof' is not in your PATH. It is provided by several packages.\nYou can make it available in an ephemeral shell by typing one of the following:\n  nix-shell -p busybox\n  nix-shell -p lsof",
+    "xev": "The program 'xev' is not in your PATH. You can make it available in an ephemeral shell by typing:\n  nix-shell -p xorg.xev",
+    "foo": "foo: command not found",
+}
+
+
+@pytest.mark.parametrize(
+    "command, output", [("lsof", "lsof"), ("xev", "xorg.xev"), ("foo", "")]
+)
+def test_get_nixpkgs_name(command, output):
+    """ Check that `get_nixpkgs_name` returns the correct name """
+
+    nix_shell.nixpkgs_name = ""
+    with patch("subprocess.run") as mocked_run:
+        instance = mocked_run.return_value
+        instance.stderr = mocked_nixpkgs[command]
+        assert get_nixpkgs_name(command) == output
+
+
+# check that flags and params are preserved for the new command
+@pytest.mark.parametrize('command_script, new_command', [
+    ('lsof -i :3000', 'nix-shell -p lsof --run "lsof -i :3000"'),
+    ('xev', 'nix-shell -p xorg.xev --run "xev"')])
+def test_get_new_command(command_script, new_command):
+    """ Check that flags and params are preserved in the new command """
+
+    nix_shell.nixpkgs_name = ""
+    command = Command(command_script, '')
+    with patch('subprocess.run') as mocked_run:
+        instance = mocked_run.return_value
+        instance.stderr = mocked_nixpkgs[command.script_parts[0]]
+        assert get_new_command(command) == new_command

--- a/thefuck/rules/nix_shell.py
+++ b/thefuck/rules/nix_shell.py
@@ -8,19 +8,11 @@ enabled_by_default = nix_available
 priority = 999
 
 
-nixpkgs_name = ""
-
-
 def get_nixpkgs_name(bin):
     """
     Returns the name of the Nix package that provides the given binary. It uses the
     `command-not-found` binary to do so, which is how nix-shell generates it's own suggestions.
     """
-
-    # Avoid getting the nixpkgs_name twice
-    global nixpkgs_name
-    if nixpkgs_name:
-        return nixpkgs_name
 
     result = subprocess.run(
         ["command-not-found", bin], stderr=subprocess.PIPE, universal_newlines=True

--- a/thefuck/rules/nix_shell.py
+++ b/thefuck/rules/nix_shell.py
@@ -1,0 +1,48 @@
+from thefuck.specific.nix import nix_available
+import subprocess
+
+enabled_by_default = nix_available
+
+# Set the priority just ahead of `fix_file` rule, which can generate low quality matches due
+# to the sheer amount of paths in the nix store.
+priority = 999
+
+
+nixpkgs_name = ""
+
+
+def get_nixpkgs_name(bin):
+    """
+    Returns the name of the Nix package that provides the given binary. It uses the
+    `command-not-found` binary to do so, which is how nix-shell generates it's own suggestions.
+    """
+
+    # Avoid getting the nixpkgs_name twice
+    global nixpkgs_name
+    if nixpkgs_name:
+        return nixpkgs_name
+
+    result = subprocess.run(
+        ["command-not-found", bin], stderr=subprocess.PIPE, universal_newlines=True
+    )
+
+    # return early if package is not available through nix
+    if "nix-shell" not in result.stderr:
+        return ""
+
+    nixpkgs_name = result.stderr.split()[-1] if result.stderr.split() else ""
+    return nixpkgs_name
+
+
+def match(command):
+    bin = command.script_parts[0]
+    return (
+        "nix-shell" not in command.script
+        and "command not found" in command.output
+        and get_nixpkgs_name(bin)
+    )
+
+
+def get_new_command(command):
+    bin = command.script_parts[0]
+    return 'nix-shell -p {0} --run "{1}"'.format(get_nixpkgs_name(bin), command.script)


### PR DESCRIPTION
Implementation is similar to the one explained in https://github.com/nvbn/thefuck/issues/912#issue-441679613.

In a nutshell, it tries to wrap the user's failed command in a nix-shell call.

```
$ ponysay moo
The program 'ponysay' is not in your PATH. You can make it available in an
ephemeral shell by typing:
  nix-shell -p ponysay

$ fuck
nix-shell -p ponysay --run "ponysay moo" [enter/↑/↓/ctrl+c]
```

Further info on nix-shell: https://thiagowfx.github.io/2022/02/nix-shell-in-a-nutshell/#hello-world-classic