### PR TITLE
replace distutils for python 3.12

### DIFF
--- a/thefuck/system/unix.py
+++ b/thefuck/system/unix.py
@@ -3,7 +3,7 @@ import sys
 import tty
 import termios
 import colorama
-from distutils.spawn import find_executable
+from shutil import which
 from .. import const
 
 init_output = colorama.init
@@ -38,7 +38,7 @@ def get_key():
 
 
 def open_command(arg):
-    if find_executable('xdg-open'):
+    if which('xdg-open'):
         return 'xdg-open ' + arg
     return 'open ' + arg
 


### PR DESCRIPTION
Python 3.12 has removed `distutils`: https://docs.python.org/3.12/whatsnew/3.12.html#removed
