### PR TITLE
Correct "pip delete|remove" -> "pip uninstall"

### DIFF
--- a/tests/rules/test_pip_unknown_command.py
+++ b/tests/rules/test_pip_unknown_command.py
@@ -4,8 +4,8 @@ from thefuck.types import Command
 
 
 @pytest.fixture
-def pip_unknown_cmd_without_recommend():
-    return '''ERROR: unknown command "i"'''
+def synonym():
+    return 'remove'
 
 
 @pytest.fixture
@@ -19,14 +19,18 @@ def suggested():
 
 
 @pytest.fixture
+def pip_unknown_cmd_without_recommend(synonym):
+    return 'ERROR: unknown command "{}"'.format(synonym)
+
+
+@pytest.fixture
 def pip_unknown_cmd(broken, suggested):
     return 'ERROR: unknown command "{}" - maybe you meant "{}"'.format(broken, suggested)
 
 
 def test_match(pip_unknown_cmd, pip_unknown_cmd_without_recommend):
     assert match(Command('pip instatl', pip_unknown_cmd))
-    assert not match(Command('pip i',
-                             pip_unknown_cmd_without_recommend))
+    assert match(Command('pip remove', pip_unknown_cmd_without_recommend))
 
 
 @pytest.mark.parametrize('script, broken, suggested, new_cmd', [
@@ -35,3 +39,11 @@ def test_match(pip_unknown_cmd, pip_unknown_cmd_without_recommend):
 def test_get_new_command(script, new_cmd, pip_unknown_cmd):
     assert get_new_command(Command(script,
                                    pip_unknown_cmd)) == new_cmd
+
+
+@pytest.mark.parametrize('script, synonym, new_cmd', [
+    ('pip delete thefuck', 'delete', 'pip uninstall thefuck'),
+    ('pip remove thefuck', 'remove', 'pip uninstall thefuck')
+])
+def test_get_new_command_without_recommended(script, new_cmd, pip_unknown_cmd_without_recommend):
+    assert get_new_command(Command(script, pip_unknown_cmd_without_recommend)) == new_cmd

--- a/thefuck/rules/pip_unknown_command.py
+++ b/thefuck/rules/pip_unknown_command.py
@@ -8,12 +8,18 @@ from thefuck.specific.sudo import sudo_support
 def match(command):
     return ('pip' in command.script and
             'unknown command' in command.output and
-            'maybe you meant' in command.output)
+            ('maybe you meant' in command.output or
+             'delete' in command.output or
+             'remove' in command.output))
 
 
 def get_new_command(command):
     broken_cmd = re.findall(r'ERROR: unknown command "([^"]+)"',
                             command.output)[0]
-    new_cmd = re.findall(r'maybe you meant "([^"]+)"', command.output)[0]
+    suggest = re.findall(r'maybe you meant "([^"]+)"', command.output)
+    suggest = suggest[0] if suggest else None
 
-    return replace_argument(command.script, broken_cmd, new_cmd)
+    if broken_cmd == 'delete' or broken_cmd == 'remove':
+        suggest = 'uninstall'
+
+    return replace_argument(command.script, broken_cmd, suggest)


### PR DESCRIPTION
Correct "pip delete ..." to "pip uninstall ..."
Correct "pip remove ..." to "pip uninstall ..."

Frequent mistakes.

- Before change
![image](https://github.com/nvbn/thefuck/assets/68285620/f89bf81e-3f87-45b2-a39a-2d77f04c3e58)


- After change
![image](https://github.com/nvbn/thefuck/assets/68285620/7e6fea3b-feaf-4c9e-b943-3ee169fa0767)
