### PR TITLE
Fix the fuck for Python 3.12

### DIFF
--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -4,6 +4,20 @@ from warnings import warn
 from six import text_type
 from . import const
 from .system import Path
+    
+import importlib.util
+import importlib.machinery
+
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 try:
     import importlib.util

--- a/thefuck/types.py
+++ b/thefuck/types.py
@@ -8,6 +8,20 @@ from .exceptions import EmptyCommand
 from .utils import get_alias, format_raw_script
 from .output_readers import get_output
 
+import importlib.util
+import importlib.machinery
+
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
+
 
 class Command(object):
     """Command that should be fixed."""


### PR DESCRIPTION
The imp module has been long deprecated and has been removed entirely in Python 3.12.

This solution is what was suggested in the release notes: https://docs.python.org/3.12/whatsnew/3.12.html#imp