### PR TITLE
Reduce Startup Execution Time

### DIFF
--- a/thefuck/system/unix.py
+++ b/thefuck/system/unix.py
@@ -3,7 +3,6 @@ import sys
 import tty
 import termios
 import colorama
-from distutils.spawn import find_executable
 from .. import const
 
 init_output = colorama.init
@@ -38,6 +37,7 @@ def get_key():
 
 
 def open_command(arg):
+    from distutils.spawn import find_executable
     if find_executable('xdg-open'):
         return 'xdg-open ' + arg
     return 'open ' + arg


### PR DESCRIPTION
Reduces the impact of #1428

Nearly half of the startup time of running `thefuck -a` is caused by the removed line of code in `thefuck/system/unix.py`.  This line of code imports `find_executable` from `distutils`, however this import takes on the order of 40% of the total startup time. This means my personal startup time has been reduced from about 400ms to 250ms or so as seen in the below image.

![image](https://github.com/user-attachments/assets/e42f600b-4541-41c4-9f13-4f67ba0bf486)

I've attempted to find further ways of reducing this time, but bar from fully isolating the entire chain of functions, it looks like this isn't particularly feasible.

One thing I haven't tried is to use lazy importing of some kind. This could yield serious performance improvements, as most of the delays are caused by `import` statements which, for the most part, aren't used by the `--alias` code path, however are not possible to easily move or remove due to their numerous quantity and interlinked dependencies in just about every source file. Transitioning to lazy loading would likely take a fair bit of effort to make sure everything still works and there is still no guarantee of better performance, however it is a possible avenue to continue down.