### PR TITLE
Replace deprecated imp module with importlib for Python compatibility

### DIFF
--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -14,7 +14,8 @@ try:
         module_spec.loader.exec_module(module)
         return module
 except ImportError:
-    from imp import load_source
+    # This block is no longer needed if importlib.util is always available.
+    pass
 
 
 class Settings(dict):

--- a/~/.config/thefuck/settings.py
+++ b/~/.config/thefuck/settings.py
@@ -1,0 +1,26 @@
+# The Fuck settings file
+#
+# The rules are defined as in the example bellow:
+#
+# rules = ['cd_parent', 'git_push', 'python_command', 'sudo']
+#
+# The default values are as follows. Uncomment and change to fit your needs.
+# See https://github.com/nvbn/thefuck#settings for more information.
+#
+
+# rules = [<const: All rules enabled>]
+# exclude_rules = []
+# wait_command = 3
+# require_confirmation = True
+# no_colors = False
+# debug = False
+# priority = {}
+# history_limit = None
+# alter_history = True
+# wait_slow_command = 15
+# slow_commands = ['lein', 'react-native', 'gradle', './gradlew', 'vagrant']
+# repeat = False
+# instant_mode = False
+# num_close_matches = 3
+# env = {'LC_ALL': 'C', 'LANG': 'C', 'GIT_TRACE': '1'}
+# excluded_search_path_prefixes = []


### PR DESCRIPTION
Replaced all usages of the deprecated imp module with importlib to ensure compatibility with Python 3.12 and beyond.