### PR TITLE
Update chmod_x to work with non-relative paths

### DIFF
--- a/thefuck/rules/chmod_x.py
+++ b/thefuck/rules/chmod_x.py
@@ -3,10 +3,9 @@ from thefuck.shells import shell
 
 
 def match(command):
-    return (command.script.startswith('./')
-            and 'permission denied' in command.output.lower()
-            and os.path.exists(command.script_parts[0])
-            and not os.access(command.script_parts[0], os.X_OK))
+    return ('permission denied' in command.output.lower()
+            and os.path.exists(os.path.expanduser(command.script_parts[0]))
+            and not os.access(os.path.expanduser(command.script_parts[0]), os.X_OK))
 
 
 def get_new_command(command):


### PR DESCRIPTION
Originally the chmod_x rule only worked for scripts run with relative paths (eg `./funStuff.sh`) but that's not always what we need. Imagine I have a file at `/home/alice/scripts/funStuff.sh`
``` bash
$ pwd
/home/alice
# I could run the script with any of these:
$ ./scripts/funStuff.sh
$ ~/scripts/funStuff.sh
$ /home/alice/scripts/funStuff.sh
```