### PR TITLE
Make tests compatible with pytest v8.x

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -265,6 +265,7 @@ class TestGetValidHistoryWithoutCurrent(object):
         path_mock = mocker.Mock(iterdir=mocker.Mock(return_value=callables))
         return mocker.patch('thefuck.utils.Path', return_value=path_mock)
 
+    @pytest.mark.usefixtures('no_memoize')
     @pytest.mark.parametrize('script, result', [
         ('le cat', ['ls cat', 'diff x', u'café ô']),
         ('diff x', ['ls cat', u'café ô']),


### PR DESCRIPTION
Hey :wave:  Arch Linux maintainer here.

The test test_get_valid_history_without_current fails when using pytest v8.x in the following manner:

```
======================================================== short test summary info =========================================================
FAILED tests/test_utils.py::TestGetValidHistoryWithoutCurrent::test_get_valid_history_without_current[le cat-result0] - AssertionError: assert ['ls cat', 'diff x'] == ['ls cat', 'diff x', 'café ô']
FAILED tests/test_utils.py::TestGetValidHistoryWithoutCurrent::test_get_valid_history_without_current[diff x-result1] - AssertionError: assert ['ls cat'] == ['ls cat', 'café ô']
FAILED tests/test_utils.py::TestGetValidHistoryWithoutCurrent::test_get_valid_history_without_current[fuck-result2] - AssertionError: assert ['ls cat', 'diff x'] == ['ls cat', 'diff x', 'café ô']
FAILED tests/test_utils.py::TestGetValidHistoryWithoutCurrent::test_get_valid_history_without_current[cafe \xf4-result3] - AssertionError: assert ['ls cat', 'diff x'] == ['ls cat', 'diff x', 'café ô']
======================================== 4 failed, 1793 passed, 62 skipped, 273 warnings in 4.04s ========================================
```

The issue stems from the function `thefuck/utils.py:get_all_executables()` and seems to be related to the memoization decorator used.

Disable memoization for the failing tests with the fixture `no_meomize` to resolve the issue.