### PR TITLE
Fix crash on newer pythons

### DIFF
--- a/thefuck/system/unix.py
+++ b/thefuck/system/unix.py
@@ -3,7 +3,7 @@ import sys
 import tty
 import termios
 import colorama
-from distutils.spawn import find_executable
+from shutil import which
 from .. import const
 
 init_output = colorama.init
@@ -38,9 +38,9 @@ def get_key():
 
 
 def open_command(arg):
-    if find_executable('xdg-open'):
-        return 'xdg-open ' + arg
-    return 'open ' + arg
+    """ Get a shell command calling the system's generic opener."""
+    cmd = which('xdg-open') or 'open'
+    return cmd + ' ' + arg
 
 
 try:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38,39,310,311}
+envlist = py{27,35,36,37,38,39,310,311,312}
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
distutils was removed in python 3.12, causing the import of
find_executable to fail.  According to the python devs, find_executable
was never intended as an external interface to begin with (see python
issue #39260[^1]). This replaces find_executable with shutil.which,
which is available on all pythons supported by thefuck.

Four tox tests fail, but they are not related to this change (and they
failed in the previous version too).

I notice a few other PRs for the same issue; is thefuck still maintained?

[^1]: https://bugs.python.org/issue39260#msg359644
