### PR TITLE
Changes to induce compatablity with python 12+ 

### DIFF
--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -1,20 +1,19 @@
+import importlib.util
+import sys
+import os
+
+def load_source(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
 import os
 import sys
 from warnings import warn
 from six import text_type
 from . import const
 from .system import Path
-
-try:
-    import importlib.util
-
-    def load_source(name, pathname, _file=None):
-        module_spec = importlib.util.spec_from_file_location(name, pathname)
-        module = importlib.util.module_from_spec(module_spec)
-        module_spec.loader.exec_module(module)
-        return module
-except ImportError:
-    from imp import load_source
 
 
 class Settings(dict):

--- a/thefuck/types.py
+++ b/thefuck/types.py
@@ -1,8 +1,18 @@
+import importlib.util
+import sys
+import os
+
+def load_source(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
 import os
 import sys
 from . import logs
 from .shells import shell
-from .conf import settings, load_source
+from .conf import settings
 from .const import DEFAULT_PRIORITY, ALL_ENABLED
 from .exceptions import EmptyCommand
 from .utils import get_alias, format_raw_script


### PR DESCRIPTION
Some minute changes to thefuck/conf.py and thefuck/types.py to make it compatible with python 12+(python 13) which does not support use of imp lib, i have used some code as a drop-in replacement, which will make it easier to check and extract into a file if so becomes a requirement