### PR TITLE
Fix Python 3.13 compatibility: replace distutils with shutil

### DIFF
--- a/thefuck/system/unix.py
+++ b/thefuck/system/unix.py
@@ -3,7 +3,7 @@ import sys
 import tty
 import termios
 import colorama
-from distutils.spawn import find_executable
+from shutil import which as find_executable
 from .. import const
 
 init_output = colorama.init


### PR DESCRIPTION
## Summary

This PR fixes the remaining Python 3.12+ compatibility issue by replacing the deprecated `distutils.spawn` import with the recommended `shutil.which` alternative.

## Problem

The `distutils` module was removed in Python 3.12+, causing a `ModuleNotFoundError: No module named 'distutils'` when running thefuck on Python 3.12/3.13. This affects users as reported in issues #1489, #1491, and #1501.

## Solution

- Replace `from distutils.spawn import find_executable` with `from shutil import which as find_executable` in `thefuck/system/unix.py`
- `shutil.which` provides identical functionality to `distutils.spawn.find_executable`
- This is the recommended migration path according to Python documentation

## Testing

- Tested on Python 3.13.3 on Ubuntu
- The fix allows thefuck to start without the distutils import error
- Functionality remains identical (both functions return the path to an executable or None)

## Related Issues

Fixes #1489, #1491, #1501

## Notes

This PR complements the existing `importlib` fixes for the `imp` module that are already in the codebase, providing complete Python 3.12+ compatibility.
