### PR TITLE
Fix `No module named 'distutils'` for Python3.12+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ elif (3, 0) < version < (3, 5):
 
 VERSION = '3.32'
 
-install_requires = ['psutil', 'colorama', 'six']
+install_requires = ['psutil', 'colorama', 'six', 'setuptools; python_version>="3.12"']
 extras_require = {':python_version<"3.4"': ['pathlib2'],
                   ':python_version<"3.3"': ['backports.shutil_get_terminal_size'],
                   ':python_version<="2.7"': ['decorator<5', 'pyte<0.8.1'],

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,12 @@ elif (3, 0) < version < (3, 5):
 
 VERSION = '3.32'
 
-install_requires = ['psutil', 'colorama', 'six', 'setuptools; python_version>="3.12"']
+install_requires = ['psutil', 'colorama', 'six']
 extras_require = {':python_version<"3.4"': ['pathlib2'],
                   ':python_version<"3.3"': ['backports.shutil_get_terminal_size'],
                   ':python_version<="2.7"': ['decorator<5', 'pyte<0.8.1'],
                   ':python_version>"2.7"': ['decorator', 'pyte'],
+                  ':python_version>"3.11"': ['setuptools'],
                   ":sys_platform=='win32'": ['win_unicode_console']}
 
 if sys.platform == "win32":


### PR DESCRIPTION
# Description

When I install thefuck by Python3.12, it raises `ModuleNotFoundError: No module named 'distutils'` when running fuck

## How to reproduce

```
uvx --python=3.12 --from=thefuck fuck
```

## Solution

This PR introduce a new requirement `setuptools`(it include the distutils module) for Python3.12+