### PR TITLE
fix: gracefully handle non-TTY environments

### DIFF
--- a/thefuck/system/unix.py
+++ b/thefuck/system/unix.py
@@ -11,7 +11,12 @@ init_output = colorama.init
 
 def getch():
     fd = sys.stdin.fileno()
-    old = termios.tcgetattr(fd)
+    try:
+        old = termios.tcgetattr(fd)
+    except termios.error:
+        # Not a TTY (e.g. piped input, subprocess capture, CI).
+        # Return newline to auto-select the first suggestion.
+        return '\n'
     try:
         tty.setraw(fd)
         return sys.stdin.read(1)

--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -1,11 +1,20 @@
 # -*- encoding: utf-8 -*-
 
+import os
 import sys
 from .conf import settings
 from .exceptions import NoRuleMatched
 from .system import get_key
 from .utils import get_alias
 from . import logs, const
+
+
+def _is_interactive():
+    """Check if stdin is a TTY (interactive terminal)."""
+    try:
+        return os.isatty(sys.stdin.fileno())
+    except (AttributeError, ValueError):
+        return False
 
 
 def read_actions():
@@ -74,7 +83,7 @@ def select_command(corrected_commands):
                     else 'Nothing found')
         return
 
-    if not settings.require_confirmation:
+    if not settings.require_confirmation or not _is_interactive():
         logs.show_corrected_command(selector.value)
         return selector.value
 


### PR DESCRIPTION
## Summary

- Auto-select first suggestion when stdin is not a TTY (CI, subprocess capture, editor integrations like Claude Code)
- Harden `getch()` to catch `termios.error` instead of crashing in non-terminal contexts
- Matches existing `--yeah` behavior — no new flags or config needed

## Problem

When `thefuck` runs in a non-TTY context (e.g. piped through `$()` in a subprocess, CI pipelines, AI coding assistants), `termios.tcgetattr()` in `getch()` crashes with:

```
termios.error: (25, 'Inappropriate ioctl for device')
```

This happens because the interactive key-reading path is reached even when there's no terminal to read from.

## Changes

- **`thefuck/ui.py`**: Added `_is_interactive()` TTY check in `select_command()`. When no TTY is detected, auto-selects the first suggestion (same behavior as `--yeah`)
- **`thefuck/system/unix.py`**: Hardened `getch()` to catch `termios.error` and return `'\n'` (auto-select) as a defense-in-depth fallback

## Test plan

- [x] Verified `_is_interactive()` returns `False` in subprocess context
- [x] Verified `getch()` returns `'\n'` instead of crashing without TTY
- [x] Verified full `thefuck` flow works in non-TTY (auto-selects first suggestion)
- [ ] Existing interactive behavior unchanged when TTY is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)