### PR TITLE
support:support for Python 3.12+

### DIFF
--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -8,8 +8,6 @@ from warnings import warn
 from six import text_type
 from . import const
 from .system import Path
-
-
 class Settings(dict):
     def __getattr__(self, item):
         return self.get(item)

--- a/thefuck/conf.py
+++ b/thefuck/conf.py
@@ -1,20 +1,13 @@
+try:
+    from importlib.util import spec_from_file_location, module_from_spec
+except ImportError:
+    from imp import load_source
 import os
 import sys
 from warnings import warn
 from six import text_type
 from . import const
 from .system import Path
-
-try:
-    import importlib.util
-
-    def load_source(name, pathname, _file=None):
-        module_spec = importlib.util.spec_from_file_location(name, pathname)
-        module = importlib.util.module_from_spec(module_spec)
-        module_spec.loader.exec_module(module)
-        return module
-except ImportError:
-    from imp import load_source
 
 
 class Settings(dict):
@@ -76,11 +69,16 @@ class Settings(dict):
 
     def _settings_from_file(self):
         """Loads settings from file."""
-        settings = load_source(
-            'settings', text_type(self.user_dir.joinpath('settings.py')))
+        settings_path = self.user_dir.joinpath('settings.py')
+        try:
+            spec = spec_from_file_location('settings', text_type(settings_path))
+            settings = module_from_spec(spec)
+            spec.loader.exec_module(settings)
+        except Exception:
+            settings = None
         return {key: getattr(settings, key)
                 for key in const.DEFAULT_SETTINGS.keys()
-                if hasattr(settings, key)}
+                if settings is not None and hasattr(settings, key)}
 
     def _rules_from_env(self, val):
         """Transforms rules list from env-string to python."""

--- a/thefuck/types.py
+++ b/thefuck/types.py
@@ -1,8 +1,12 @@
+try:
+    from importlib.util import spec_from_file_location, module_from_spec
+except ImportError:
+    from imp import load_source
 import os
 import sys
 from . import logs
 from .shells import shell
-from .conf import settings, load_source
+from .conf import settings
 from .const import DEFAULT_PRIORITY, ALL_ENABLED
 from .exceptions import EmptyCommand
 from .utils import get_alias, format_raw_script
@@ -140,7 +144,9 @@ class Rule(object):
             return
         with logs.debug_time(u'Importing rule: {};'.format(name)):
             try:
-                rule_module = load_source(name, str(path))
+                spec = spec_from_file_location(name, str(path))
+                rule_module = module_from_spec(spec)
+                spec.loader.exec_module(rule_module)
             except Exception:
                 logs.exception(u"Rule {} failed to load".format(name), sys.exc_info())
                 return


### PR DESCRIPTION
At the top of `conf.py`, add:

```python
try:
    from importlib.util import spec_from_file_location, module_from_spec
except ImportError:
    from imp import load_source
```

Replace line 71:

```python
settings = load_source('settings', text_type(self.user_dir.joinpath('settings.py')))
```

with:

```python
settings_path = self.user_dir.joinpath('settings.py')
try:
    spec = spec_from_file_location('settings', text_type(settings_path))
    settings = module_from_spec(spec)
    spec.loader.exec_module(settings)
except Exception:
    settings = None
```

Replace line 81:

```python
if hasattr(settings, key)
```

with:

```python
if settings is None and hasattr(settings, key)
```

At the top of `types.py`, add:

```python
try:
    from importlib.util import spec_from_file_location, module_from_spec
except ImportError:
    from imp import load_source
```

Replace line 147:

```python
rule_module = load_source(name, str(path))
```

with:

```python
spec = spec_from_file_location(name, str(path))
rule_module = module_from_spec(spec)
spec.loader.exec_module(rule_module)
```

You can also download these two files to overwrite them: My environment is 3.12, it should run correctly.

`types.py`

`conf.py`At the top of `conf.py`, add:

```python
try:
    from importlib.util import spec_from_file_location, module_from_spec
except ImportError:
    from imp import load_source
```

Replace line 71:

```python
settings = load_source('settings', text_type(self.user_dir.joinpath('settings.py')))
```

with:

```python
settings_path = self.user_dir.joinpath('settings.py')
try:
    spec = spec_from_file_location('settings', text_type(settings_path))
    settings = module_from_spec(spec)
    spec.loader.exec_module(settings)
except Exception:
    settings = None
```

Replace line 81:

```python
if hasattr(settings, key)
```

with:

```python
if settings is None and hasattr(settings, key)
```

At the top of `types.py`, add:

```python
try:
    from importlib.util import spec_from_file_location, module_from_spec
except ImportError:
    from imp import load_source
```

Replace line 147:

```python
rule_module = load_source(name, str(path))
```

with:

```python
spec = spec_from_file_location(name, str(path))
rule_module = module_from_spec(spec)
spec.loader.exec_module(rule_module)
```
