### PR TITLE
chore(deps): 3 outdated/obsolete constraints found. setuptools floor (17.1 from 2013)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytest
 mock
 pytest-mock
 wheel
-setuptools>=17.1
+setuptools>=65.0
 pexpect
 pypandoc
 pytest-benchmark

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ VERSION = '3.32'
 install_requires = ['psutil', 'colorama', 'six']
 extras_require = {':python_version<"3.4"': ['pathlib2'],
                   ':python_version<"3.3"': ['backports.shutil_get_terminal_size'],
-                  ':python_version<="2.7"': ['decorator<5', 'pyte<0.8.1'],
+                  ':python_version<="2.7"': ['decoratorNot applicable', 'pyteNot applicable'],
                   ':python_version>"2.7"': ['decorator', 'pyte'],
                   ":sys_platform=='win32'": ['win_unicode_console']}
 


### PR DESCRIPTION
## 🔧 依赖维护更新 — nvbn/thefuck

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

3 outdated/obsolete constraints found. setuptools floor (17.1 from 2013) should be raised to 65+. The decorator<5 and pyte<0.8.1 constraints are Python 2.7 relics that block modern versions unnecessarily. Note: project 'thefuck' v3.32 appears abandoned (original repo archived), so major upgrades carry elevated risk.

### 📦 变更清单

🔴 **setuptools**: `>=17.1` → `>=65.0`
  _setuptools 17.1 is from 2013; modern versions (65+) fix many security issues and compatibility problems_

🟡 **decorator (Python 2.7 constraint)**: `<5` → `Not applicable`
  _Python 2.7 is EOL and no longer supported; the constraint is obsolete. Consider removing Python 2.7 support entirely for decorator>=5_

🟡 **pyte (Python 2.7 constraint)**: `<0.8.1` → `Not applicable`
  _Same as decorator; Python 2.7 is EOL. Modern pyte (0.8.3+) has bug fixes; the constraint is a remnant from Python 2.7 era_

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `requirements.txt`
- `setup.py`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_