### PR TITLE
chore(deps): 2 outdated constraints found. setuptools>=17.1 is severely outdated (201

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytest
 mock
 pytest-mock
 wheel
-setuptools>=17.1
+setuptools>=70.0.0
 pexpect
 pypandoc
 pytest-benchmark

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ VERSION = '3.32'
 install_requires = ['psutil', 'colorama', 'six']
 extras_require = {':python_version<"3.4"': ['pathlib2'],
                   ':python_version<"3.3"': ['backports.shutil_get_terminal_size'],
-                  ':python_version<="2.7"': ['decorator<5', 'pyte<0.8.1'],
+                  ':python_version<="2.7"': ['decorator<5', 'pyte>=0.8.1,<1.0'],
                   ':python_version>"2.7"': ['decorator', 'pyte'],
                   ":sys_platform=='win32'": ['win_unicode_console']}
 


### PR DESCRIPTION
## 🔧 依赖维护更新 — nvbn/thefuck

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

2 outdated constraints found. setuptools>=17.1 is severely outdated (2014), should be >=70.0. The pyte<0.8.1 constraint is overly restrictive for Python 2.7. Note: requirements.txt has no version pins for most packages (flake8, pytest, etc.) — cannot determine if outdated without knowing age of lock state. Many deps in setup.py also lack upper bounds.

### 📦 变更清单

🔴 **setuptools**: `>=17.1` → `>=70.0.0`
  _setuptools 17.1 from 2014 is 10+ years behind; current 70.x includes critical security fixes_

🟡 **pyte**: `<0.8.1` → `>=0.8.1,<1.0`
  _Constraint 'pyte<0.8.1' for Python 2.7 is very restrictive; newer 0.8.x/0.9.x releases have bug fixes_

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `requirements.txt`
- `setup.py`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_