### PR TITLE
chore(deps): 1 clearly outdated dep found. setuptools pinned to >=17.1 (2014) is very

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytest
 mock
 pytest-mock
 wheel
-setuptools>=17.1
+setuptools>=70.0.0
 pexpect
 pypandoc
 pytest-benchmark


### PR DESCRIPTION
## 🔧 依赖维护更新 — nvbn/thefuck

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 clearly outdated dep found. setuptools pinned to >=17.1 (2014) is very far behind current 70.x. All other requirements.txt deps are unpinned (current by default). setup.py runtime deps (psutil, colorama, six, pyte, decorator) are unpinned — no safe upgrade to suggest without risk.

### 📦 变更清单

🔴 **setuptools**: `>=17.1` → `>=70.0.0`
  _>=17.1 is from ~2014; current setuptools is 70.x with security patches, build improvements, and PEP 660 support_

### ⚠️ 风险等级
🟢 **Low**

### 📝 文件变更
- `requirements.txt`
- `setup.py`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_